### PR TITLE
Revert "Add support for running testing concurrently for different OCP versions"

### DIFF
--- a/config.json
+++ b/config.json
@@ -207,7 +207,5 @@
   "plan_wait_timeout": 3000,
   "clean_target_resources": true,
   "matrix_test": false,
-  "release_test": false,
-  "target_ocp_version": "4.17",
   "mount_root": ""
 }

--- a/tests/test_mtv.py
+++ b/tests/test_mtv.py
@@ -6,9 +6,15 @@ from ocp_resources.mtv import MTV
 from ocp_resources.storage_class import StorageClass
 from ocp_resources.plan import Plan
 from report import create_migration_scale_report
-from utilities.mtv_migration import test_migration, get_vm_suffix
+from utilities.mtv_migration import test_migration
 
-VM_SUFFIX = get_vm_suffix()
+STORAGE_SUFFIX = ""
+if config["matrix_test"]:
+    SC = config["storage_class"]
+    if "ceph-rbd" in SC:
+        STORAGE_SUFFIX = "-ceph-rbd"
+    elif "nfs" in SC:
+        STORAGE_SUFFIX = "-nfs"
 
 
 @pytest.mark.parametrize(
@@ -18,7 +24,7 @@ VM_SUFFIX = get_vm_suffix()
             [
                 {
                     "virtual_machines": [
-                        {"name": f"mtv-rhel8-sanity{VM_SUFFIX}", "guest_agent": True},
+                        {"name": f"mtv-rhel8-sanity{STORAGE_SUFFIX}", "guest_agent": True},
                     ],
                     "warm_migration": False,
                 }
@@ -295,7 +301,12 @@ def test_mtv_migration_non_utc(
         pytest.param(
             [
                 {
-                    "virtual_machines": [{"name": f"mtv-rhel8-79{VM_SUFFIX}"}, {"name": f"mtv-win2019-79{VM_SUFFIX}"}],
+                    "virtual_machines": [
+                        {"name": f"mtv-rhel8-79{STORAGE_SUFFIX}"},
+                        {
+                            "name": f"mtv-win2019-79{STORAGE_SUFFIX}",
+                        },
+                    ],
                     "warm_migration": False,
                 }
             ],
@@ -668,7 +679,7 @@ def test_negative_same_source_vm(
         pytest.param(
             [
                 {
-                    "virtual_machines": [{"name": f"cnv-rhel9-2disks2nics{VM_SUFFIX}", "source_vm_power": "on"}],
+                    "virtual_machines": [{"name": f"cnv-rhel9-2disks2nics{STORAGE_SUFFIX}", "source_vm_power": "on"}],
                     "warm_migration": False,
                 }
             ],

--- a/tests/test_mtv_warm.py
+++ b/tests/test_mtv_warm.py
@@ -1,12 +1,19 @@
 import pytest
 from pytest_testconfig import config
+
 from ocp_resources.mtv import MTV
-from utilities.mtv_migration import test_migration, get_cutover_value, get_vm_suffix
+from utilities.mtv_migration import test_migration, get_cutover_value
 
 if config["source_provider_type"] in ["openstack", "openshift"]:
     pytest.skip("OpenStack/OpenShift warm migration is not supported.", allow_module_level=True)
 
-VM_SUFFIX = get_vm_suffix()
+STORAGE_SUFFIX = ""
+if config["matrix_test"]:
+    SC = config["storage_class"]
+    if "ceph-rbd" in SC:
+        STORAGE_SUFFIX = "-ceph-rbd"
+    elif "nfs" in SC:
+        STORAGE_SUFFIX = "-nfs"
 
 
 @pytest.mark.tier0
@@ -19,7 +26,7 @@ VM_SUFFIX = get_vm_suffix()
                 {
                     "virtual_machines": [
                         {
-                            "name": f"mtv-rhel8-warm-sanity{VM_SUFFIX}",
+                            "name": f"mtv-rhel8-warm-sanity{STORAGE_SUFFIX}",
                             "source_vm_power": "on",
                             "guest_agent": True,
                         },
@@ -62,7 +69,7 @@ def test_sanity_warm_mtv_migration(
                 {
                     "virtual_machines": [
                         {
-                            "name": f"mtv-rhel8-warm-2disks2nics{VM_SUFFIX}",
+                            "name": f"mtv-rhel8-warm-2disks2nics{STORAGE_SUFFIX}",
                             "source_vm_power": "on",
                             "guest_agent": True,
                         },
@@ -398,7 +405,7 @@ def test_warm_negative_source_provider_non_admin(
                 {
                     "virtual_machines": [
                         {
-                            "name": f"mtv-rhel8-warm-394{VM_SUFFIX}",
+                            "name": f"mtv-rhel8-warm-394{STORAGE_SUFFIX}",
                             "source_vm_power": "on",
                             "guest_agent": True,
                         },

--- a/utilities/mtv_migration.py
+++ b/utilities/mtv_migration.py
@@ -16,20 +16,6 @@ from report import create_migration_scale_report
 mtv_namespace = config["mtv_namespace"]
 
 
-def get_vm_suffix() -> str:
-    vm_suffix = ""
-    if config["matrix_test"]:
-        storage_name = config["storage_class"]
-        if "ceph-rbd" in storage_name:
-            vm_suffix = "-ceph-rbd"
-        elif "nfs" in storage_name:
-            vm_suffix = "-nfs"
-    if config["release_test"]:
-        ocp_version = config["target_ocp_version"].replace(".", "-")
-        vm_suffix = f"{vm_suffix}-{ocp_version}"
-    return vm_suffix
-
-
 def get_cutover_value(current_cutover=None):
     datetime_utc = datetime.now(pytz.utc)
     if current_cutover:


### PR DESCRIPTION
Reverts RedHatQE/mtv-api-tests#6

Missed some things.

We do not use config.json anymore.
You edited need_review tests.

