### PR TITLE
Raise if resource name do not start with session uuid

### DIFF
--- a/utilities/data_collector.py
+++ b/utilities/data_collector.py
@@ -3,18 +3,16 @@ import os
 import shutil
 import zipfile
 from pathlib import Path
-from typing import Any
 
 import yaml
 from kubernetes.dynamic import DynamicClient, ResourceInstance
-from ocp_resources.datavolume import DataVolume
 from ocp_resources.network_map import NetworkMap
 from ocp_resources.persistent_volume import PersistentVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.plan import Plan
 from ocp_resources.pod import Pod
 from ocp_resources.provider import Provider
-from ocp_resources.resource import NamespacedResource, Resource
+from ocp_resources.resource import NamespacedResource, Resource, get_client
 from ocp_resources.storage_map import StorageMap
 from simple_logger.logger import get_logger
 
@@ -30,16 +28,15 @@ def prepare_base_path(base_path: Path) -> None:
     base_path.mkdir(parents=True, exist_ok=True)
 
 
-def collect_pods_logs(logs_path: Path, namespace: str, client: DynamicClient, session_uuid: str) -> None:
+def collect_pods_logs(logs_path: Path, namespace: str, client: DynamicClient) -> None:
     for _pod in Pod.get(namespace=namespace, dyn_client=client):
-        if session_uuid in _pod.name:
-            try:
-                for _container in _pod.instance.spec.containers:
-                    _container_name = _container["name"]
-                    with open(logs_path / f"{_pod.name}-{_container_name}.log", "w") as fd:
-                        fd.write(_pod.log(container=_container_name))
-            except Exception:
-                LOGGER.warning(f"Failed to collect logs for pod {_pod.name}")
+        try:
+            for _container in _pod.instance.spec.containers:
+                _container_name = _container["name"]
+                with open(logs_path / f"{_pod.name}-{_container_name}.log", "w") as fd:
+                    fd.write(_pod.log(container=_container_name))
+        except Exception:
+            LOGGER.warning(f"Failed to collect logs for pod {_pod.name}")
 
 
 def collect_namespaced_resource_yaml(
@@ -47,44 +44,30 @@ def collect_namespaced_resource_yaml(
     resource: type[NamespacedResource],
     resource_instance: ResourceInstance,
     client: DynamicClient,
-    session_uuid: str,
 ) -> None:
     _resource_obj = resource(name=resource_instance.name, namespace=resource_instance.namespace, client=client)
-    if _resource_obj.exists and session_uuid in _resource_obj.name:
+    if _resource_obj.exists:
         with open(yaml_path / f"{_resource_obj.name}.yaml", "w") as fd:
             yaml.dump(_resource_obj.instance.to_dict(), fd)
 
 
 def collect_all_namespaced_resources_yaml(
-    yaml_path: Path,
-    resource: type[NamespacedResource],
-    namespace: str,
-    client: DynamicClient,
-    session_uuid: str,
+    yaml_path: Path, resource: type[NamespacedResource], namespace: str, client: DynamicClient
 ) -> None:
     for _resource in resource.get(namespace=namespace, dyn_client=client):
-        if session_uuid in _resource.name:
-            with open(yaml_path / f"{_resource.name}.yaml", "w") as fd:
-                yaml.dump(_resource.instance.to_dict(), fd)
+        with open(yaml_path / f"{_resource.name}.yaml", "w") as fd:
+            yaml.dump(_resource.instance.to_dict(), fd)
 
 
-def collect_all_resources_yaml(
-    yaml_path: Path, resource: type[Resource], client: DynamicClient, session_uuid: str
-) -> None:
+def collect_all_resources_yaml(yaml_path: Path, resource: type[Resource], client: DynamicClient) -> None:
     for _resource in resource.get(dyn_client=client):
-        if session_uuid in _resource.name:
-            with open(yaml_path / f"{_resource.name}.yaml", "w") as fd:
-                yaml.dump(_resource.instance.to_dict(), fd)
+        with open(yaml_path / f"{_resource.name}.yaml", "w") as fd:
+            yaml.dump(_resource.instance.to_dict(), fd)
 
 
-def data_collector(client: DynamicClient, base_path: Path, mtv_namespace: str, session_store: dict[str, Any]) -> None:
+def data_collector(client: DynamicClient, base_path: Path, mtv_namespace: str, plan: Plan | None = None) -> None:
     LOGGER.info(f"Collecting logs in {base_path}")
-    plans: list[Plan] = []
-    session_uuid = session_store["session_uuid"]
-
-    for plan in Plan.get(dyn_client=client, namespace=mtv_namespace):
-        if session_uuid in plan.name:
-            plans.append(plan)
+    plans = [plan] if plan else Plan.get(dyn_client=client, namespace=mtv_namespace)
 
     for _plan in plans:
         _instance = _plan.instance
@@ -104,7 +87,6 @@ def data_collector(client: DynamicClient, base_path: Path, mtv_namespace: str, s
         _mtv_pods_path = Path(_mtv_namespace_path / "pods")
 
         _target_ns_pods_path = Path(_target_namespace_path / "pods")
-        _target_ns_dv_path = Path(_target_namespace_path / "dv")
         _target_ns_pvc_path = Path(_target_namespace_path / "pvc")
 
         _pv_path = Path(base_path / "pv")
@@ -116,7 +98,6 @@ def data_collector(client: DynamicClient, base_path: Path, mtv_namespace: str, s
             _dst_provider_path,
             _mtv_pods_path,
             _target_ns_pods_path,
-            _target_ns_dv_path,
             _target_ns_pvc_path,
             _pv_path,
         ):
@@ -128,16 +109,7 @@ def data_collector(client: DynamicClient, base_path: Path, mtv_namespace: str, s
 
         # Collect pods logs in mtv namespace and target namespace
         for ns, logs_path in zip([mtv_namespace, _target_namespace], [_mtv_pods_path, _target_ns_pods_path]):
-            collect_pods_logs(logs_path=logs_path, namespace=ns, client=client, session_uuid=session_uuid)
-
-        # Collect DVs in target namespace
-        collect_all_namespaced_resources_yaml(
-            yaml_path=_target_ns_dv_path,
-            resource=DataVolume,
-            namespace=_target_namespace,
-            client=client,
-            session_uuid=session_uuid,
-        )
+            collect_pods_logs(logs_path=logs_path, namespace=ns, client=client)
 
         # Collect PVCs in target namespace
         collect_all_namespaced_resources_yaml(
@@ -145,13 +117,10 @@ def data_collector(client: DynamicClient, base_path: Path, mtv_namespace: str, s
             resource=PersistentVolumeClaim,
             namespace=_target_namespace,
             client=client,
-            session_uuid=session_uuid,
         )
 
         # Collect PVs
-        collect_all_resources_yaml(
-            yaml_path=_pv_path, resource=PersistentVolume, client=client, session_uuid=session_uuid
-        )
+        collect_all_resources_yaml(yaml_path=_pv_path, resource=PersistentVolume, client=client)
 
         # Collect network map in mtv namespace
         collect_namespaced_resource_yaml(
@@ -159,7 +128,6 @@ def data_collector(client: DynamicClient, base_path: Path, mtv_namespace: str, s
             resource=NetworkMap,
             resource_instance=_network_map,
             client=client,
-            session_uuid=session_uuid,
         )
 
         # Collect storage map in mtv namespace
@@ -168,7 +136,6 @@ def data_collector(client: DynamicClient, base_path: Path, mtv_namespace: str, s
             resource=StorageMap,
             resource_instance=_storage_map,
             client=client,
-            session_uuid=session_uuid,
         )
 
         # Collect source provider in mtv namespace
@@ -177,7 +144,6 @@ def data_collector(client: DynamicClient, base_path: Path, mtv_namespace: str, s
             resource=Provider,
             resource_instance=_src_provider,
             client=client,
-            session_uuid=session_uuid,
         )
 
         # Collect destination provider in mtv namespace
@@ -186,7 +152,6 @@ def data_collector(client: DynamicClient, base_path: Path, mtv_namespace: str, s
             resource=Provider,
             resource_instance=_dst_provider,
             client=client,
-            session_uuid=session_uuid,
         )
 
 
@@ -202,3 +167,25 @@ def zip_folder(folder_path, output_zip_path):
                 file_path = os.path.join(root, file)
                 # Add the file to the ZIP file
                 zipf.write(file_path, arcname=os.path.relpath(file_path, start=folder_path))
+
+
+if __name__ == "__main__":
+    import sys
+
+    try:
+        plan_name = sys.argv[1]
+    except IndexError:
+        print("Usage: python data_collector.py <plan_name>")
+        sys.exit(1)
+
+    mtv_namespace = "openshift-mtv"
+    logs_path = Path(f".local/plan-debug/{plan_name}")
+    plan = Plan(name=plan_name, namespace=mtv_namespace)
+
+    if not plan.exists:
+        print(f"{plan.name} does not exist in {mtv_namespace} namespace")
+        sys.exit(1)
+
+    prepare_base_path(base_path=logs_path)
+    data_collector(client=get_client(), base_path=logs_path, mtv_namespace=mtv_namespace, plan=plan)
+    zip_folder(folder_path=logs_path, output_zip_path=logs_path / f"{plan_name}.zip")


### PR DESCRIPTION
All resources that we create in the test must start with `session_uuid`.
This is needed to cancel migration, archive plans and run all resources teardown at the end of the test session.
