### PR TITLE
Remove vmware 7.0 and 6.7 from config, use new repo for vddk image

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -24,6 +24,7 @@ from ocp_resources.storage_class import StorageClass
 from ocp_resources.storage_map import StorageMap
 from ocp_resources.storage_profile import StorageProfile
 from ocp_resources.virtual_machine import VirtualMachine
+from ocp_utilities.infra import create_update_secret
 from pytest_harvest import get_fixture_store
 from pytest_testconfig import config as py_config
 
@@ -167,9 +168,19 @@ def pytest_exception_interact(node, call, report):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def autouse_fixtures(source_provider_data, nfs_storage_profile):
+def autouse_fixtures(source_provider_data, nfs_storage_profile, updated_cluster_pull_secret):
     # source_provider_data called here to fail fast in provider not found in the providers list from config
     yield
+
+
+@pytest.fixture(scope="session")
+def updated_cluster_pull_secret(ocp_admin_client):
+    create_update_secret(
+        secret_data_dict={"auths": {"quey.io/rh-openshift-mtv": {"auth": py_config["quey_rh_openshift_mtv_secret"]}}},
+        name="pull-secret",  # pragma: allowlist secret
+        namespace="openshift-config",
+        admin_client=ocp_admin_client,
+    )
 
 
 @pytest.fixture(scope="session")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,4 +46,5 @@ dependencies = [
   "pandas>=2.2.3",
   "cloudpickle>=3.1.1",
   "pytest-harvest>=1.10.5",
+  "openshift-python-utilities>=6.0.7",
 ]

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -168,6 +168,7 @@ matrix_test = True
 release_test = False
 target_ocp_version = "4.17"
 mount_root = ""
+quey_rh_openshift_mtv_secret = "cmgtb3BlbnNoaWZ0LW10dityaF9vcGVuc2hpZnRfbXR2Okc2MUk2T0U3RzJVMDkzT1gwOUtPTUNYWlJZSDdSSlk1Rk0yTlFJU0NVMTRQNzM5VzRTMERQSDY1WVg5TldMUzI="
 
 for _dir in dir():
     val = locals()[_dir]

--- a/uv.lock
+++ b/uv.lock
@@ -57,6 +57,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/3c/adaf39ce1fb4afdd21b611e3d530b183bb7759c9b673d60db0e347fd4439/beautifulsoup4-4.13.3.tar.gz", hash = "sha256:1bd32405dacc920b42b83ba01644747ed77456a65760e285fbc47633ceddaf8b", size = 619516 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/49/6abb616eb3cbab6a7cca303dc02fdf3836de2e0b834bf966a7f5271a34d8/beautifulsoup4-4.13.3-py3-none-any.whl", hash = "sha256:99045d7d3f08f91f0d656bc9b7efbae189426cd913d830294a15eefa0ea4df16", size = 186015 },
+]
+
+[[package]]
 name = "cachetools"
 version = "5.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -425,6 +438,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/4b/ce2d3a36f77186d7dbca0f10b33e6a1c0eee390d9434960d2a14e2736b52/deepdiff-8.1.1.tar.gz", hash = "sha256:dd7bc7d5c8b51b5b90f01b0e2fe23c801fd8b4c6a7ee7e31c5a3c3663fcc7ceb", size = 433560 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/66/f7/2df72b55635926872b947203aacbe7e1109a51929aec8ebfef8c4a348eb5/deepdiff-8.1.1-py3-none-any.whl", hash = "sha256:b0231fa3afb0f7184e82535f2b4a36636442ed21e94a0cf3aaa7982157e7ebca", size = 84655 },
+]
+
+[[package]]
+name = "deprecation"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178 },
 ]
 
 [[package]]
@@ -818,6 +843,7 @@ dependencies = [
     { name = "click" },
     { name = "cloudpickle" },
     { name = "humanfriendly" },
+    { name = "openshift-python-utilities" },
     { name = "openshift-python-wrapper" },
     { name = "openstacksdk" },
     { name = "ovirt-python-sdk" },
@@ -847,6 +873,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.7" },
     { name = "cloudpickle", specifier = ">=3.1.1" },
     { name = "humanfriendly", specifier = ">=10.0" },
+    { name = "openshift-python-utilities", specifier = ">=6.0.7" },
     { name = "openshift-python-wrapper", specifier = ">=11.0.12" },
     { name = "openshift-python-wrapper", specifier = ">=11.0.13" },
     { name = "openstacksdk", specifier = ">=4.0.0" },
@@ -943,6 +970,25 @@ wheels = [
 ]
 
 [[package]]
+name = "openshift-python-utilities"
+version = "6.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "colorlog" },
+    { name = "deprecation" },
+    { name = "openshift-python-wrapper" },
+    { name = "openshift-python-wrapper-data-collector" },
+    { name = "pyhelper-utils" },
+    { name = "python-simple-logger" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "semver" },
+    { name = "timeout-sampler" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/cc/34cfb46e9232813139c7958b00ef6a54475d262ca2f6fdd49e0fd5f31e27/openshift_python_utilities-6.0.7.tar.gz", hash = "sha256:49ad7d478784405419f58c5d800852b5883e5a8c6b8fb76d73a1ab957f70b9bb", size = 18169 }
+
+[[package]]
 name = "openshift-python-wrapper"
 version = "11.0.27"
 source = { registry = "https://pypi.org/simple" }
@@ -967,6 +1013,17 @@ dependencies = [
     { name = "xmltodict" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/92/e5/d23f09715f6817e81601aac27e6d6ce7ed425e63a144b8bb764cadcb44f6/openshift_python_wrapper-11.0.27.tar.gz", hash = "sha256:797a0ad1da79f0b3bbb46cd824c3c5878e42c013393eb53698ce1bc1506f2c67", size = 6490733 }
+
+[[package]]
+name = "openshift-python-wrapper-data-collector"
+version = "2.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openshift-python-wrapper" },
+    { name = "pytest-testconfig" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/95/9028d39697f067b90c1315f352daea56f04880831cd0ed115c6d11bafd4b/openshift_python_wrapper_data_collector-2.0.8.tar.gz", hash = "sha256:a681e5c8b4309b484d0d1e552cafc88c195794031b88a409c9b1dfe65576c2a5", size = 8212 }
 
 [[package]]
 name = "openstacksdk"
@@ -1882,6 +1939,15 @@ wheels = [
 ]
 
 [[package]]
+name = "semver"
+version = "3.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602", size = 269730 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746", size = 17912 },
+]
+
+[[package]]
 name = "setuptools"
 version = "75.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1906,6 +1972,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/ce/fbaeed4f9fb8b2daa961f90591662df6a86c1abf25c548329a86920aedfb/soupsieve-2.6.tar.gz", hash = "sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb", size = 101569 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/c2/fe97d779f3ef3b15f05c94a2f1e3d21732574ed441687474db9d342a7315/soupsieve-2.6-py3-none-any.whl", hash = "sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9", size = 36186 },
 ]
 
 [[package]]


### PR DESCRIPTION
Use https://quay.io/repository/rh-openshift-mtv/vddk-init-image?tab=tags for vddk init images
remove unused vmwares (6.7 and 7.0) from config.py