### PR TITLE
cold migration, remove sanity for tier0, use test with win and rhel vms

### DIFF
--- a/tests/test_mtv_cold_migration.py
+++ b/tests/test_mtv_cold_migration.py
@@ -23,7 +23,6 @@ VM_SUFFIX = get_vm_suffix()
     indirect=True,
     ids=["rhel8"],
 )
-@pytest.mark.tier0
 def test_sanity_cold_mtv_migration(
     request,
     fixture_store,
@@ -67,7 +66,6 @@ def test_sanity_cold_mtv_migration(
                     "warm_migration": False,
                 }
             ],
-            # TODO fix Polarion ID
         )
     ],
     indirect=True,
@@ -95,6 +93,54 @@ def test_cold_remote_ocp(
         plans=plans,
         network_migration_map=remote_network_migration_map,
         storage_migration_map=remote_storage_migration_map,
+        source_provider_data=source_provider_data,
+        target_namespace=target_namespace,
+    )
+
+
+@pytest.mark.parametrize(
+    "plans",
+    [
+        # MTV-79
+        pytest.param(
+            [
+                {
+                    "virtual_machines": [
+                        {"name": f"mtv-rhel8-79{VM_SUFFIX}"},
+                        {
+                            "name": f"mtv-win2019-79{VM_SUFFIX}",
+                        },
+                    ],
+                    "warm_migration": False,
+                }
+            ],
+        )
+    ],
+    indirect=True,
+    ids=["MTV-79"],
+)
+@pytest.mark.tier0
+def test_cold_migration(
+    request,
+    fixture_store,
+    session_uuid,
+    target_namespace,
+    plans,
+    source_provider,
+    source_provider_data,
+    destination_provider,
+    network_migration_map,
+    storage_migration_map,
+):
+    migrate_vms(
+        fixture_store=fixture_store,
+        test_name=request._pyfuncitem.name,
+        session_uuid=session_uuid,
+        source_provider=source_provider,
+        destination_provider=destination_provider,
+        plans=plans,
+        network_migration_map=network_migration_map,
+        storage_migration_map=storage_migration_map,
         source_provider_data=source_provider_data,
         target_namespace=target_namespace,
     )

--- a/tools/dev/build_run_tests_command.py
+++ b/tools/dev/build_run_tests_command.py
@@ -65,6 +65,7 @@ def main() -> str:
 
     if user_data_from_re:
         data = user_data_from_re.groupdict()
+
     elif user_data_from_template:
         data = user_data_from_template
 
@@ -84,6 +85,7 @@ def main() -> str:
 
     if "vmware" in provider:
         source_provider_type = "--tc=source_provider_type:vsphere"
+
     else:
         source_provider_type = f"--tc=source_provider_type:{provider}"
 
@@ -102,9 +104,12 @@ def main() -> str:
 
     elif provider == "openstack":
         base_cmd += f" {source_provider_type} --tc=source_provider_version:psi {target_namespace}"
+
     # Remote
     if remote:
         base_cmd += f" -m remote --tc=remote_ocp_cluster:{os.environ['CLUSTER_NAME']}"
+    else:
+        base_cmd += " -m tier0"
 
     # Storage
     if storage == "ceph":


### PR DESCRIPTION
In tier0 we have cold migration test that test RHEL vm, and remote test that test both win and RHEL.
Delicate the remote test and make it local migration, remove the sanity test from tier0.