### PR TITLE
feat: Ensure unique names for cloned VMs by appending a UUID

### DIFF
--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -12,6 +12,7 @@ from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from exceptions.exceptions import VmBadDatastoreError, VmCloneError, VmMissingVmxError, VmNotFoundError
 from libs.base_provider import BaseProvider
+from utilities.naming import generate_name_with_uuid
 
 LOGGER = get_logger(__name__)
 
@@ -366,7 +367,9 @@ class VMWareProvider(BaseProvider):
             regenerate_mac: Whether to regenerate MAC addresses for network interfaces.
                           Prevents MAC address conflicts between cloned VMs. Default: True.
         """
-        clone_vm_name = f"{session_uuid}-{clone_vm_name}"
+
+        # generate new uuid for uniqueness of a test
+        clone_vm_name = generate_name_with_uuid(f"{session_uuid}-{clone_vm_name}")
         LOGGER.info(f"Starting clone process for '{clone_vm_name}' from '{source_vm_name}'")
 
         source_vm = self.get_obj([vim.VirtualMachine], source_vm_name)


### PR DESCRIPTION
This commit enhances the naming convention for cloned virtual machines to prevent naming collisions during test execution.
Previously, cloned VM names could conflict if tests were run in quick succession or if resource cleanup from a prior run was incomplete. This could lead to failures in the test, such as errors related to the populator pod.
To resolve this, an additional UUID is now generated and appended to each cloned VM's name, ensuring that every instance is unique. This improves the stability and reliability of the tests. This change also includes a fix for a missing import of the generate_name_with_uuid function.

<img width="717" height="107" alt="image" src="https://github.com/user-attachments/assets/0f8fd430-07ae-4e91-8da1-1286bc9c4d7c" />
