### PR TITLE
WIP: Add test for copy-offload with thin-provisioned disks and snapshots

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+tenacity
+timeout-sampler
+-e .
+--extra-index-url=https://pypi.org/simple
+types-paramiko

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -136,6 +136,20 @@ tests_params: dict = {
         "warm_migration": False,
         "copyoffload": True,
     },
+    "test_copyoffload_thin_snapshots_migration": {
+        "virtual_machines": [
+            {
+                "name": "xcopy-template-test",
+                "source_vm_power": "off",
+                "guest_agent": True,
+                "clone": True,
+                "disk_type": "thin",
+                "snapshots": 2,
+            },
+        ],
+        "warm_migration": False,
+        "copyoffload": True,
+    },
 }
 
 for _dir in dir():


### PR DESCRIPTION
### Description

This pull request introduces a new test case to validate the copy-offload migration feature for thin-provisioned virtual machines that have snapshots. The test ensures that the migration correctly transfers the latest state of the VM, including filesystem changes made after the snapshots were taken.

### Changes

- **`tests/test_copyoffload_migration.py`**: Added a new test `test_copyoffload_thin_snapshots_migration` to perform a cold migration of a thin-provisioned VM with snapshots using the copy-offload feature. The test includes steps to create snapshots, create a folder on the source VM post-snapshot, and then migrate.
- **`tests/tests_config/config.py`**: Added a new test configuration `test_copyoffload_thin_snapshots_migration` that defines a VM with `disk_type: "thin"` and `snapshots: 2` for the new test case.
- **`libs/providers/vmware.py`**: Added `create_snapshot` and `get_vm_ip` methods to the `VMWareProvider` class to support snapshot creation and reliable IP address retrieval.
- **`utilities/utils.py`**: Added `run_ssh_command` and `get_guest_credential` helper functions to facilitate remote command execution on guest VMs.
- **`requirements.txt`**: Added `types-paramiko` as a new dependency for static type analysis.