### PR TITLE
feat: Pvc name template

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ tests_params: dict = {
         ],
         "warm_migration": True,  # True for warm, False for cold
         "preserve_static_ips": True, # True for preserving source Vm's Static IP
+        # pvc_name_template to set Forklift PVC Name template, supports Go template syntax: {{.FileName}},
+        # {{.DiskIndex}}, {{.VmName}} and  Sprig functions, i.e.:
+        "pvc_name_template": '{{ .FileName | trimSuffix \".vmdk\" | replace \"_\" \"-\" }}-{{.DiskIndex}}',
+        "pvc_name_template_use_generate_name": False,  # Boolean to control template usage  
     },
 }
 ```

--- a/libs/providers/openshift.py
+++ b/libs/providers/openshift.py
@@ -124,6 +124,7 @@ class OCPProvider(BaseProvider):
         )
 
         result_vm_info["provider_vm_api"] = cnv_vm
+        result_vm_info["id"] = cnv_vm.instance.metadata.uid
 
         # Power state
         result_vm_info["power_state"] = (
@@ -156,6 +157,7 @@ class OCPProvider(BaseProvider):
                 "network": "pod" if network.get("pod", False) else network["multus"]["networkName"].split("/")[1],
             })
 
+        disk_idx = 0
         for pvc in cnv_vm.vmi.instance.spec.volumes:
             if not _source:
                 name = pvc.persistentVolumeClaim.claimName
@@ -179,7 +181,10 @@ class OCPProvider(BaseProvider):
                     "name": _pvc.instance.spec.storageClassName,
                     "access_mode": _pvc.instance.spec.accessModes,
                 },
+                "device_key": _pvc.name,  # PVC name as unique identifier
+                "unit_number": disk_idx,  # Order in volumes list (excluding cloud-init)
             })
+            disk_idx += 1
 
         result_vm_info["cpu"]["num_cores"] = cnv_vm.vmi.instance.spec.domain.cpu.cores
         result_vm_info["cpu"]["num_sockets"] = cnv_vm.vmi.instance.spec.domain.cpu.sockets

--- a/libs/providers/openstack.py
+++ b/libs/providers/openstack.py
@@ -155,6 +155,7 @@ class OpenStackProvider(BaseProvider):
         result_vm_info["provider_type"] = "openstack"
         result_vm_info["provider_vm_api"] = source_vm
         result_vm_info["name"] = source_vm.name
+        result_vm_info["id"] = source_vm.id  # OpenStack VM/Instance ID (UUID)
 
         # Snapshots details
         for volume_snapshots in self.list_snapshots(vm_name):
@@ -181,6 +182,7 @@ class OpenStackProvider(BaseProvider):
                 "name": disk.name,
                 "size_in_kb": disk.size,
                 "storage": dict(name=disk.availability_zone, id=disk.id),
+                "device_key": disk.id,  # OpenStack volume ID
             })
 
         # CPUs

--- a/libs/providers/rhv.py
+++ b/libs/providers/rhv.py
@@ -169,6 +169,7 @@ class OvirtProvider(BaseProvider):
         result_vm_info["provider_type"] = Resource.ProviderType.RHV
         result_vm_info["provider_vm_api"] = source_vm
         result_vm_info["name"] = source_vm.name
+        result_vm_info["id"] = source_vm.id
 
         # Network Interfaces
         for nic in self.vm_nics(vm=source_vm):
@@ -186,7 +187,9 @@ class OvirtProvider(BaseProvider):
                 "name": disk.name,
                 "size_in_kb": disk.total_size,
                 "storage": dict(name=storage_domain.name, id=storage_domain.id),
+                "device_key": disk.id,  # RHV disk ID
             })
+
         # CPUs
         result_vm_info["cpu"]["num_cores"] = source_vm.cpu.topology.cores
         result_vm_info["cpu"]["num_threads"] = source_vm.cpu.topology.threads

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -438,6 +438,7 @@ class VMWareProvider(BaseProvider):
         result_vm_info["provider_type"] = Resource.ProviderType.VSPHERE
         result_vm_info["provider_vm_api"] = _vm
         result_vm_info["name"] = _vm.name
+        result_vm_info["id"] = _vm._moId  # VMware Managed Object ID
 
         # Devices
         for device in vm_config.hardware.device:
@@ -465,6 +466,9 @@ class VMWareProvider(BaseProvider):
                     "storage": dict(
                         name=device.backing.datastore.name if device.backing and device.backing.datastore else "Unknown"
                     ),
+                    "device_key": device.key,
+                    "unit_number": device.unitNumber,
+                    "controller_key": device.controllerKey,
                 })
 
         # CPUs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,4 +56,5 @@ dependencies = [
   "rich>=14.0.0",
   "python-rrmngmnt>=0.2.0",
   "jc>=1.25.0",
+  "py-go-template>=0.2.0",
 ]

--- a/utilities/migration_utils.py
+++ b/utilities/migration_utils.py
@@ -253,6 +253,8 @@ def prepare_migration_for_tests(
         "test_name": test_name,
         "copyoffload": plan.get("copyoffload", False),
         "preserve_static_ips": plan.get("preserve_static_ips", False),
+        "pvc_name_template": plan.get("pvc_name_template"),
+        "pvc_name_template_use_generate_name": plan.get("pvc_name_template_use_generate_name"),
     }
 
 

--- a/utilities/mtv_migration.py
+++ b/utilities/mtv_migration.py
@@ -121,6 +121,8 @@ def run_migration(
     test_name: str,
     copyoffload: bool = False,
     preserve_static_ips: bool = False,
+    pvc_name_template: str | None = None,
+    pvc_name_template_use_generate_name: bool | None = None,
 ) -> Plan:
     """
     Creates and Runs a Migration ToolKit for Virtualization (MTV) Migration Plan.
@@ -172,6 +174,8 @@ def run_migration(
         "after_hook_name": after_hook_name,
         "after_hook_namespace": after_hook_namespace,
         "preserve_static_ips": preserve_static_ips,
+        "pvc_name_template": pvc_name_template,
+        "pvc_name_template_use_generate_name": pvc_name_template_use_generate_name,
     }
 
     # Add copy-offload specific parameters if enabled

--- a/uv.lock
+++ b/uv.lock
@@ -961,6 +961,7 @@ dependencies = [
     { name = "openstacksdk" },
     { name = "ovirt-python-sdk" },
     { name = "pandas" },
+    { name = "py-go-template" },
     { name = "pyhelper-utils" },
     { name = "pytest" },
     { name = "pytest-harvest" },
@@ -999,6 +1000,7 @@ requires-dist = [
     { name = "openstacksdk", specifier = ">=4.0.0" },
     { name = "ovirt-python-sdk", specifier = ">=1.2.0" },
     { name = "pandas", specifier = ">=2.2.3" },
+    { name = "py-go-template", specifier = ">=0.2.0" },
     { name = "pyhelper-utils", specifier = ">=1.0.9" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-harvest", specifier = ">=1.10.5" },
@@ -1486,6 +1488,16 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "py-go-template"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/33/5d3486f2ace7fa8a411ce6416dc4e40f279fb00d0feb9885f633be4061b5/py_go_template-1.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:43f44dc79e7480d4c144b23c77fc6fd9ba451913a570334f9a46147a04fd6334", size = 2264809, upload-time = "2023-07-13T06:05:52.126Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/b6/2d985ba1480ebae3fa81009c37a41b8a925d2f558676da7c2d8d768246e6/py_go_template-1.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c681d3b94118276438ea2473aa8ac174a5b74d8db42c632fad92b17e0a4244ac", size = 2441973, upload-time = "2023-07-13T06:05:56.473Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/5d/7e83ec3b808c8faa824f96852817815c5877e8ce7f8fd600db5b13f0c6cd/py_go_template-1.0.0-py3-none-win_amd64.whl", hash = "sha256:4991aba8d26e6ec4cddec2a99dd5e1a37c114a480934f7dd66b5f7134c61e2cb", size = 2419036, upload-time = "2023-07-13T06:05:59.189Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a possibility to set and test the PVC names based on PVC name templates MTV feature. It supports a few wildcards (FileName, VmName, DiskIndex for VMware) and Go sprig functions for PVC name templating. The verification part of test checks the order of the disks.

Depends on #176 