### PR TITLE
Add test for copy-offload with multiple datastores

### DIFF
--- a/.providers.json.example
+++ b/.providers.json.example
@@ -26,7 +26,7 @@
     "guest_vm_win_password": "WINDOWS VMS PASSWORD",
     "copyoffload": {
       "storage_vendor_product": "ontap",  # or "vantara"
-      "datastore_id": "datastore-12345",
+      "datastore_ids": ["datastore-12345", "datastore-67890"],  # List of datastore IDs (first is default)
       "template_name": "rhel9-template",
       "storage_hostname": "storage.example.com",
       "storage_username": "admin",

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Add the `copyoffload` section under your vSphere provider configuration (see `.p
 ```json
 "copyoffload": {
   "storage_vendor_product": "ontap",
-  "datastore_id": "datastore-123",
+  "datastore_ids": ["datastore-123", "datastore-456"],
   "template_name": "rhel9-template",
   "storage_hostname": "storage.example.com",
   "storage_username": "admin",
@@ -251,6 +251,10 @@ Add the `copyoffload` section under your vSphere provider configuration (see `.p
   "ontap_svm": "vserver-name"
 }
 ```
+
+**Note:** `datastore_ids` is a list of datastore IDs that support copy-offload.
+The first datastore in the list serves as the default for VMs without explicit datastore assignments.
+Multiple datastores enable migration of VMs with disks distributed across different datastores on the same storage system.
 
 **Vendor-specific fields:**
 

--- a/tests/test_copyoffload_migration.py
+++ b/tests/test_copyoffload_migration.py
@@ -67,12 +67,12 @@ def test_copyoffload_thin_migration(
     - Shared storage between vSphere and OpenShift (NetApp ONTAP, Hitachi Vantara)
     - Storage credentials via environment variables or .providers.json config
     - ForkliftController with feature_copy_offload: "true" (must be pre-configured)
-    - Proper datastore_id configuration matching the VM's datastore
+    - Proper datastore_ids configuration matching the VM's datastores
 
     Configuration in .providers.json:
     "copyoffload": {
         "storage_vendor_product": "ontap",  # or "vantara"
-        "datastore_id": "datastore-123",    # vSphere datastore ID
+        "datastore_ids": ["datastore-123", "datastore-456"],    # List of vSphere datastore IDs that support copyoffload (first is default)
         "template_name": "<copyoffload-template-name>",
         "storage_hostname": "storage.example.com",
         "storage_username": "admin",
@@ -105,8 +105,11 @@ def test_copyoffload_thin_migration(
     # Get copy-offload configuration
     copyoffload_config_data = source_provider_data["copyoffload"]
     storage_vendor_product = copyoffload_config_data.get("storage_vendor_product")
-    datastore_id = copyoffload_config_data.get("datastore_id")
+    datastore_ids = copyoffload_config_data.get("datastore_ids", [])
     storage_class = py_config["storage_class"]
+
+    # Use only the first (default) datastore for single-datastore tests
+    datastore_id = datastore_ids[0] if datastore_ids else None
 
     # Create network migration map
     vms_names = [vm["name"] for vm in plan["virtual_machines"]]
@@ -140,7 +143,7 @@ def test_copyoffload_thin_migration(
         vms=vms_names,
         storage_class=storage_class,
         # Copy-offload specific parameters
-        datastore_id=datastore_id,
+        datastore_ids=[datastore_id],
         offload_plugin_config=offload_plugin_config,
         access_mode="ReadWriteOnce",
         volume_mode="Block",
@@ -208,13 +211,13 @@ def test_copyoffload_thick_lazy_migration(
     - Storage class in OpenShift that supports the same storage type as source
     - Storage credentials via environment variables or .providers.json config
     - ForkliftController with feature_copy_offload: "true" (must be pre-configured)
-    - Proper datastore_id configuration matching the VM's datastore
+    - Proper datastore_ids configuration matching the VM's datastores
     - VM must be on a datastore that supports xcopyoff functionality
 
     Configuration in .providers.json:
     "copyoffload": {
         "storage_vendor_product": "ontap",  # or "vantara"
-        "datastore_id": "datastore-123",    # vSphere datastore ID (must support xcopyoff)
+        "datastore_ids": ["datastore-123", "datastore-456"],    # List of vSphere datastore IDs that support copyoffload (first is default)
         "template_name": "<copyoffload-template-name>",
         "storage_hostname": "storage.example.com",
         "storage_username": "admin",
@@ -247,14 +250,17 @@ def test_copyoffload_thick_lazy_migration(
     # Get copy-offload configuration
     copyoffload_config_data = source_provider_data["copyoffload"]
     storage_vendor_product = copyoffload_config_data.get("storage_vendor_product")
-    datastore_id = copyoffload_config_data.get("datastore_id")
+    datastore_ids = copyoffload_config_data.get("datastore_ids", [])
     storage_class = py_config["storage_class"]
+
+    # Use only the first (default) datastore for single-datastore tests
+    datastore_id = datastore_ids[0] if datastore_ids else None
 
     # Validate required copy-offload parameters
     if not all([storage_vendor_product, datastore_id]):
         pytest.fail(
             "Missing required copy-offload parameters in config: "
-            "'storage_vendor_product' and 'datastore_id' must be set."
+            "'storage_vendor_product' and 'datastore_ids' must be set."
         )
 
     # Create network migration map
@@ -289,7 +295,7 @@ def test_copyoffload_thick_lazy_migration(
         vms=vms_names,
         storage_class=storage_class,
         # Copy-offload specific parameters
-        datastore_id=datastore_id,
+        datastore_ids=[datastore_id],
         offload_plugin_config=offload_plugin_config,
         access_mode="ReadWriteOnce",
         volume_mode="Block",
@@ -357,12 +363,12 @@ def test_copyoffload_multi_disk_migration(
     -   Storage class in OpenShift that supports the same storage type as the source.
     -   Storage credentials via environment variables or .providers.json config.
     -   ForkliftController with feature_copy_offload: "true" (must be pre-configured).
-    -   Proper datastore_id configuration matching the VM's datastore.
+    -   Proper datastore_ids configuration matching the VM's datastores.
 
     Configuration in .providers.json:
     "copyoffload": {
         "storage_vendor_product": "ontap",  # or "vantara"
-        "datastore_id": "datastore-123",    # vSphere datastore ID (must support xcopyoff)
+        "datastore_ids": ["datastore-123", "datastore-456"],    # List of vSphere datastore IDs that support copyoffload (first is default)
         "template_name": "<copyoffload-template-name>",
         "storage_hostname": "storage.example.com",
         "storage_username": "admin",
@@ -398,8 +404,11 @@ def test_copyoffload_multi_disk_migration(
     # Get copy-offload configuration
     copyoffload_config_data = source_provider_data["copyoffload"]
     storage_vendor_product = copyoffload_config_data.get("storage_vendor_product")
-    datastore_id = copyoffload_config_data.get("datastore_id")
+    datastore_ids = copyoffload_config_data.get("datastore_ids", [])
     storage_class = py_config["storage_class"]
+
+    # Use only the first (default) datastore for single-datastore tests
+    datastore_id = datastore_ids[0] if datastore_ids else None
 
     # Create network migration map
     vms = [vm["name"] for vm in plan["virtual_machines"]]
@@ -433,7 +442,7 @@ def test_copyoffload_multi_disk_migration(
         vms=vms,
         storage_class=storage_class,
         # Copy-offload specific parameters
-        datastore_id=datastore_id,
+        datastore_ids=[datastore_id],
         offload_plugin_config=offload_plugin_config,
         access_mode="ReadWriteOnce",
         volume_mode="Block",
@@ -456,4 +465,198 @@ def test_copyoffload_multi_disk_migration(
     )
 
     # Verify that the correct number of disks were migrated
+    verify_vm_disk_count(destination_provider=destination_provider, plan=plan, target_namespace=target_namespace)
+
+
+@pytest.mark.copyoffload
+@pytest.mark.parametrize(
+    "plan",
+    [pytest.param(py_config["tests_params"]["test_copyoffload_multi_datastore_migration"])],
+    indirect=True,
+    ids=["copyoffload-multi-datastore"],
+)
+def test_copyoffload_multi_datastore_migration(
+    request,
+    fixture_store,
+    ocp_admin_client,
+    target_namespace,
+    destination_provider,
+    plan,
+    source_provider,
+    source_provider_data,
+    multus_network_name,
+    source_provider_inventory,
+    source_vms_namespace,
+    copyoffload_config,
+    copyoffload_storage_secret,
+):
+    """
+    Test copy-offload migration of a VM with disks on multiple datastores using
+    the same storage system.
+
+    This test validates copy-offload functionality when a VM has:
+    - One disk on the primary/default datastore (from the template)
+    - One additional disk on a secondary datastore on the same storage system.
+
+    This ensures that copy-offload can handle VMs with disks distributed across
+    multiple datastores.
+
+    Test Workflow:
+    1. Validates copy-offload configuration (via copyoffload_config fixture)
+    2. Creates storage secret for storage array authentication (via copyoffload_storage_secret fixture)
+    3. Clones VM from template with an additional disk on the secondary datastore
+    4. Creates network migration map
+    5. Builds copy-offload plugin configuration
+    6. Creates storage map with multiple datastores (primary and secondary)
+    7. Executes migration using copy-offload technology
+    8. Verifies successful migration and VM operation in OpenShift
+    9. Verifies that all disks were migrated correctly
+
+    Requirements:
+    -   vSphere provider with VMs on XCOPY-capable storage (e.g., NetApp iSCSI).
+    -   Shared storage between vSphere and OpenShift (NetApp ONTAP, Hitachi Vantara).
+    -   Storage class in OpenShift that supports the same storage type as the source.
+    -   Storage credentials via environment variables or .providers.json config.
+    -   ForkliftController with feature_copy_offload: "true" (must be pre-configured).
+    -   Two datastores configured using the same storage system.
+    -   Proper datastore_ids configuration matching the VM's datastores.
+
+    Configuration in .providers.json:
+    "copyoffload": {
+        "storage_vendor_product": "ontap",  # or "vantara"
+        "datastore_ids": ["datastore-123", "datastore-456"],    # List of vSphere datastore IDs that support copyoffload (first is default/primary)
+        "template_name": "<copyoffload-template-name>",
+        "storage_hostname": "storage.example.com",
+        "storage_username": "admin",
+        "storage_password": "password",  # pragma: allowlist secret
+        "ontap_svm": "vserver-name"  # For NetApp ONTAP only
+    }
+
+    Optional Environment Variables (override .providers.json values):
+    - COPYOFFLOAD_STORAGE_HOSTNAME
+    - COPYOFFLOAD_STORAGE_USERNAME
+    - COPYOFFLOAD_STORAGE_PASSWORD
+    - COPYOFFLOAD_ONTAP_SVM
+
+    Args:
+        request: Pytest request object
+        fixture_store: Pytest fixture store for resource tracking
+        ocp_admin_client: OpenShift admin client
+        target_namespace: Target namespace for migration
+        destination_provider: Destination provider (OpenShift)
+        plan: Migration plan configuration from test parameters
+        source_provider: Source provider (vSphere)
+        source_provider_data: Source provider configuration data
+        multus_network_name: Multus network configuration name
+        source_provider_inventory: Source provider inventory
+        source_vms_namespace: Source VMs namespace
+        copyoffload_config: Copy-offload configuration validation fixture
+        copyoffload_storage_secret: Storage secret for copy-offload authentication
+    """
+    # Get copy-offload configuration
+    copyoffload_config_data = source_provider_data["copyoffload"]
+    storage_vendor_product = copyoffload_config_data.get("storage_vendor_product")
+    datastore_ids = copyoffload_config_data.get("datastore_ids", [])
+    storage_class = py_config["storage_class"]
+
+    # Use the first datastore as default (for the template disk)
+    default_datastore_id = datastore_ids[0] if datastore_ids else None
+
+    # Validate required copy-offload parameters
+    if not all([storage_vendor_product, default_datastore_id]):
+        pytest.fail(
+            "Missing required copy-offload parameters in config: "
+            "'storage_vendor_product' and 'datastore_ids' must be set."
+        )
+
+    # For multi-datastore test, ensure we have at least 2 datastores configured
+    if len(datastore_ids) < 2:
+        pytest.fail(
+            f"Multi-datastore test requires at least 2 datastores in 'datastore_ids' list. Found {len(datastore_ids)}."
+        )
+
+    # Collect all datastore IDs from the VM configuration
+    # Resolve any markers (like "SECONDARY_DATASTORE") to actual datastore IDs
+    datastores_to_use = [default_datastore_id]  # Start with default datastore
+
+    vm_config = plan["virtual_machines"][0] if plan["virtual_machines"] else {}
+    add_disks = vm_config.get("add_disks", [])
+
+    # Gather unique datastore IDs from the disk configurations, resolving markers
+    for disk in add_disks:
+        disk_datastore_id = disk.get("datastore_id")
+
+        # Resolve SECONDARY_DATASTORE marker
+        if disk_datastore_id == "SECONDARY_DATASTORE":
+            if len(datastore_ids) >= 2:
+                disk_datastore_id = datastore_ids[1]
+                LOGGER.info(f"Resolved SECONDARY_DATASTORE marker to: {disk_datastore_id}")
+            else:
+                LOGGER.warning(
+                    f"SECONDARY_DATASTORE marker found but only {len(datastore_ids)} datastore(s) configured"
+                )
+                disk_datastore_id = None
+
+        if disk_datastore_id and disk_datastore_id not in datastores_to_use:
+            datastores_to_use.append(disk_datastore_id)
+            LOGGER.info(f"Additional disk configured with datastore ID: {disk_datastore_id}")
+
+    LOGGER.info(f"Multi-datastore migration will use {len(datastores_to_use)} datastore(s): {datastores_to_use}")
+
+    # Create network migration map
+    vms_names = [vm["name"] for vm in plan["virtual_machines"]]
+    network_migration_map = get_network_migration_map(
+        fixture_store=fixture_store,
+        source_provider=source_provider,
+        destination_provider=destination_provider,
+        source_provider_inventory=source_provider_inventory,
+        ocp_admin_client=ocp_admin_client,
+        multus_network_name=multus_network_name,
+        target_namespace=target_namespace,
+        vms=vms_names,
+    )
+
+    # Build offload plugin configuration
+    offload_plugin_config = {
+        "vsphereXcopyConfig": {
+            "secretRef": copyoffload_storage_secret.name,
+            "storageVendorProduct": storage_vendor_product,
+        }
+    }
+
+    # Create storage migration map with datastores needed for this VM
+    # If VM has only one disk (no add_disks or all disks on primary), use only primary datastore
+    # If VM has disks on multiple datastores, include all relevant datastores
+    storage_migration_map = get_storage_migration_map(
+        fixture_store=fixture_store,
+        target_namespace=target_namespace,
+        source_provider=source_provider,
+        destination_provider=destination_provider,
+        ocp_admin_client=ocp_admin_client,
+        source_provider_inventory=source_provider_inventory,
+        vms=vms_names,
+        storage_class=storage_class,
+        datastore_ids=datastores_to_use,
+        offload_plugin_config=offload_plugin_config,
+        access_mode="ReadWriteOnce",
+        volume_mode="Block",
+    )
+
+    # Execute copy-offload migration
+    migrate_vms(
+        ocp_admin_client=ocp_admin_client,
+        request=request,
+        fixture_store=fixture_store,
+        source_provider=source_provider,
+        destination_provider=destination_provider,
+        plan=plan,
+        network_migration_map=network_migration_map,
+        storage_migration_map=storage_migration_map,
+        source_provider_data=source_provider_data,
+        target_namespace=target_namespace,
+        source_vms_namespace=source_vms_namespace,
+        source_provider_inventory=source_provider_inventory,
+    )
+
+    # Verify that the correct number of disks were migrated (1 base + 1 added = 2 total)
     verify_vm_disk_count(destination_provider=destination_provider, plan=plan, target_namespace=target_namespace)

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -100,6 +100,27 @@ tests_params: dict = {
         "warm_migration": False,
         "copyoffload": True,
     },
+    "test_copyoffload_multi_datastore_migration": {
+        "virtual_machines": [
+            {
+                "name": "xcopy-template-test",
+                "source_vm_power": "off",
+                "guest_agent": True,
+                "clone": True,
+                "disk_type": "thin",
+                "add_disks": [
+                    {
+                        "size_gb": 30,
+                        "disk_mode": "persistent",
+                        "provision_type": "thin",
+                        "datastore_id": "SECONDARY_DATASTORE",
+                    },
+                ],
+            },
+        ],
+        "warm_migration": False,
+        "copyoffload": True,
+    },
 }
 
 for _dir in dir():


### PR DESCRIPTION
# Add multi-datastore support for copy-offload migrations

## Summary

This PR enables copy-offload migrations for VMs with disks distributed across two datastores on the same storage system. Previously, copy-offload only supported a single datastore configuration.

## Key Changes

### 1. Configuration Format Update
- **Changed**: `datastore_id` (single value) → `datastore_ids` (array)
- **Format**: `"datastore_ids": ["datastore-123", "datastore-456"]`
- First datastore serves as the default/primary datastore
- Additional datastores can be specified for individual disks

### 2. VMware Provider Enhancements (`libs/providers/vmware.py`)
- Added `SECONDARY_DATASTORE` marker support for test configurations
- Implemented per-disk datastore resolution logic
- Added `backing_info.fileName` setting to force disk placement on specified datastores
- Automatic primary datastore assignment for disks without explicit datastore specification

### 3. New Test Case (`tests/test_copyoffload_migration.py`)
- Added `test_copyoffload_multi_datastore_migration` test
- Validates VM migration with disks on two different datastores
- Verifies correct disk placement and migration completion

### 4. Test Configuration (`tests/tests_config/config.py`)
- Added test configuration for multi-datastore scenario
- Uses `SECONDARY_DATASTORE` marker for easy configuration

### 5. Documentation Updates
- **README.md**: Updated copy-offload configuration section with new format and usage notes
- **.providers.json.example**: Updated example configuration with multi-datastore array

## Technical Details

### Marker Resolution
Test configurations can use `"datastore_id": "SECONDARY_DATASTORE"` marker, which is automatically resolved to `datastore_ids[1]` from the provider configuration during VM cloning.

### Per-Disk Datastore Placement
- Disks without explicit `datastore_id` → primary datastore (`datastore_ids[0]`)
- Disks with `SECONDARY_DATASTORE` marker → secondary datastore (`datastore_ids[1]`)
- Disks with explicit datastore ID → specified datastore

### Key Implementation Detail
Setting `backing_info.fileName = f"[{datastore_name}]"` is crucial for vSphere to respect the per-disk datastore specification during VM operations.

## Backward Compatibility

✅ **Fully backward compatible** - existing configurations with single datastore will continue to work. The code automatically uses `datastore_ids[0]` as the default.

## Files Changed

- `libs/providers/vmware.py` - Core multi-datastore logic
- `tests/test_copyoffload_migration.py` - New test + updated existing tests
- `tests/tests_config/config.py` - New test configuration
- `utilities/mtv_migration.py` - Storage map handling for multiple datastores
- `README.md` - Documentation updates
- `.providers.json.example` - Configuration example update
