### PR TITLE
fix: Apply Jira marker only for RHV warm migration

### DIFF
--- a/tests/test_mtv_warm_migration.py
+++ b/tests/test_mtv_warm_migration.py
@@ -13,13 +13,16 @@ SOURCE_PROVIDER_TYPE = py_config.get("source_provider_type")
 
 
 pytestmark = [
-    pytest.mark.jira("MTV-2846", run=py_config.get("source_provider_type") != Provider.ProviderType.RHV),
     pytest.mark.skipif(
         SOURCE_PROVIDER_TYPE
         in (Provider.ProviderType.OPENSTACK, Provider.ProviderType.OPENSHIFT, Provider.ProviderType.OVA),
         reason=f"{SOURCE_PROVIDER_TYPE} warm migration is not supported.",
     ),
 ]
+
+# Only apply Jira marker for RHV - skip if issue unresolved, run normally if resolved
+if SOURCE_PROVIDER_TYPE == Provider.ProviderType.RHV:
+    pytestmark.append(pytest.mark.jira("MTV-2846", run=False))
 
 
 @pytest.mark.tier0


### PR DESCRIPTION
Previously, the MTV-2846 Jira marker was applied to all providers, causing VMware tests to show xfailed/xpassed results (which means If tests fail they are marked as SKIPPED) even when the issue only affects RHV.

Now:
- RHV: Skip if MTV-2846 unresolved, run normally if resolved
- VMware: Always runs normally (pass/fail)
- OpenStack/OpenShift/OVA: Skip (warm migration not supported)