### PR TITLE
Enable CBT on cloned VMs and add virtctl download from cluster

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -56,6 +56,7 @@ from utilities.resources import create_and_store_resource
 from utilities.utils import (
     create_source_cnv_vms,
     create_source_provider,
+    download_virtctl_from_cluster,
     get_cluster_client,
     get_value_from_py_config,
 )
@@ -274,7 +275,9 @@ def pytest_harvest_xdist_cleanup():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def autouse_fixtures(source_provider_data, nfs_storage_profile, base_resource_name, forklift_pods_state):
+def autouse_fixtures(
+    source_provider_data, nfs_storage_profile, base_resource_name, forklift_pods_state, virtctl_binary
+):
     # source_provider_data called here to fail fast in provider not found in the providers list from config
     yield
 
@@ -387,6 +390,17 @@ def ocp_admin_client():
             raise RemoteClusterAndLocalCluterNamesError("Remote cluster must be the same as local cluster.")
 
     yield _client
+
+
+@pytest.fixture(scope="session")
+def virtctl_binary(ocp_admin_client):
+    """
+    Download and configure virtctl binary from the cluster.
+
+    This fixture ensures virtctl is available in PATH for all tests
+    that need to interact with VMs via virtctl commands.
+    """
+    return download_virtctl_from_cluster(client=ocp_admin_client)
 
 
 @pytest.fixture(scope="session")

--- a/utilities/mtv_migration.py
+++ b/utilities/mtv_migration.py
@@ -9,7 +9,6 @@ from ocp_resources.network_map import NetworkMap
 from ocp_resources.plan import Plan
 from ocp_resources.provider import Provider
 from ocp_resources.storage_map import StorageMap
-
 from pytest import FixtureRequest
 from pytest_testconfig import py_config
 from simple_logger.logger import get_logger
@@ -191,8 +190,12 @@ def run_migration(
         plan.wait_for_condition(condition=Plan.Condition.READY, status=Plan.Condition.Status.TRUE, timeout=360)
     except TimeoutExpiredError:
         LOGGER.error(f"Plan {plan.name} failed to reach status {Plan.Condition.Status.TRUE}\n\t{plan.instance}")
-        source_provider = Provider(name=source_provider_name, namespace=source_provider_namespace)
-        dest_provider = Provider(name=destination_provider_name, namespace=destination_provider_namespace)
+        source_provider = Provider(
+            client=ocp_admin_client, name=source_provider_name, namespace=source_provider_namespace
+        )
+        dest_provider = Provider(
+            client=ocp_admin_client, name=destination_provider_name, namespace=destination_provider_namespace
+        )
         LOGGER.error(f"Source provider: {source_provider.instance}")
         LOGGER.error(f"Destinaion provider: {dest_provider.instance}")
         raise

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import ipaddress
 import tempfile
 from pathlib import Path
-import ipaddress
 from typing import Any
 
 import go_template
@@ -79,7 +79,6 @@ def get_ssh_credentials_from_provider_config(
 def check_ssh_connectivity(
     vm_name: str,
     vm_ssh_connections: SSHConnectionManager,
-    vm_config: dict[str, Any],
     source_provider_data: dict[str, Any],
     source_vm_info: dict[str, Any],
 ) -> None:
@@ -89,7 +88,6 @@ def check_ssh_connectivity(
     Args:
         vm_name: Name of the VM to test
         vm_ssh_connections: SSH connections fixture manager
-        vm_config: VM configuration from the plan
         source_provider_data: Provider configuration from .providers.json
         source_vm_info: VM information including OS type
 
@@ -936,7 +934,6 @@ def check_vms(
                 check_ssh_connectivity(
                     vm_name=vm_name,
                     vm_ssh_connections=vm_ssh_connections,
-                    vm_config=vm,
                     source_provider_data=source_provider_data,
                     source_vm_info=source_vm,
                 )


### PR DESCRIPTION
## Summary

This PR adds support for Change Block Tracking (CBT) on cloned VMware VMs for warm migration and introduces automatic virtctl binary download from the cluster.

## Changes

### VMware CBT Support
- Enable Change Block Tracking via `ctkEnabled = "true"` in extraConfig during VM cloning
- CBT configuration is preserved during MAC address regeneration retry logic
- Required for warm migration incremental snapshot support

### Virtctl Binary Download
- Add `download_virtctl_from_cluster()` function to automatically fetch virtctl binary
- Checks PATH first, downloads from cluster's ConsoleCLIDownload resource if not found
- Handles SSL self-signed certificates for internal clusters
- New `virtctl_binary` session fixture for automatic setup and cleanup

### Bug Fixes
- Fixed missing `client=` parameter in Provider instantiation in utilities

## Test Plan

- [ ] Verify CBT is enabled on cloned VMware VMs
- [ ] Test warm migration with CBT-enabled VMs
- [ ] Verify virtctl binary download from cluster works
- [ ] Test virtctl detection in PATH
- [ ] Verify SSL certificate handling for internal clusters
- [ ] Run existing test suite to ensure no regressions