### PR TITLE
Add independent persistent disk migration test

### DIFF
--- a/tests/test_copyoffload_migration.py
+++ b/tests/test_copyoffload_migration.py
@@ -878,3 +878,113 @@ def test_copyoffload_multi_datastore_migration(
 
     # Verify that the correct number of disks were migrated (1 base + 1 added = 2 total)
     verify_vm_disk_count(destination_provider=destination_provider, plan=plan, target_namespace=target_namespace)
+
+
+@pytest.mark.copyoffload
+@pytest.mark.parametrize(
+    "plan,multus_network_name",
+    [
+        pytest.param(
+            py_config["tests_params"]["test_copyoffload_independent_persistent_disk_migration"],
+            py_config["tests_params"]["test_copyoffload_independent_persistent_disk_migration"],
+        )
+    ],
+    indirect=True,
+    ids=["copyoffload-independent-persistent"],
+)
+def test_copyoffload_independent_persistent_disk_migration(
+    request,
+    fixture_store,
+    ocp_admin_client,
+    target_namespace,
+    destination_provider,
+    plan,
+    source_provider,
+    source_provider_data,
+    multus_network_name,
+    source_provider_inventory,
+    source_vms_namespace,
+    copyoffload_config,
+    copyoffload_storage_secret,
+    vm_ssh_connections,
+):
+    """
+    Test copy-offload migration of a VM with an independent persistent disk.
+
+    This test validates that a VM with an Independent-Persistent disk can be
+    successfully migrated using storage array XCOPY capabilities. Independent
+    persistent disks are excluded from snapshots, so this test confirms that
+    MTV correctly handles this disk type during cold migration.
+
+    Test Workflow:
+    1.  Clones a VM from a template and adds an independent persistent disk
+        as defined in the test configuration (via the 'plan' fixture).
+    2.  Validates the copy-offload configuration (via copyoffload_config fixture).
+    3.  Creates a storage secret for storage array authentication.
+    4.  Creates network and storage migration maps with copy-offload parameters.
+    5.  Executes the migration using copy-offload (cold migration).
+    6.  Verifies that the migrated VM in OpenShift has the correct total number of disks.
+    """
+    # Get copy-offload configuration
+    copyoffload_config_data = source_provider_data["copyoffload"]
+    storage_vendor_product = copyoffload_config_data["storage_vendor_product"]
+    datastore_id = copyoffload_config_data["datastore_id"]
+    storage_class = py_config["storage_class"]
+
+    # Create network migration map
+    vms_names = [vm["name"] for vm in plan["virtual_machines"]]
+    network_migration_map = get_network_migration_map(
+        fixture_store=fixture_store,
+        source_provider=source_provider,
+        destination_provider=destination_provider,
+        source_provider_inventory=source_provider_inventory,
+        ocp_admin_client=ocp_admin_client,
+        multus_network_name=multus_network_name,
+        target_namespace=target_namespace,
+        vms=vms_names,
+    )
+
+    # Build offload plugin configuration
+    offload_plugin_config = {
+        "vsphereXcopyConfig": {
+            "secretRef": copyoffload_storage_secret.name,
+            "storageVendorProduct": storage_vendor_product,
+        }
+    }
+
+    # Create storage migration map with copy-offload configuration
+    storage_migration_map = get_storage_migration_map(
+        fixture_store=fixture_store,
+        target_namespace=target_namespace,
+        source_provider=source_provider,
+        destination_provider=destination_provider,
+        ocp_admin_client=ocp_admin_client,
+        source_provider_inventory=source_provider_inventory,
+        vms=vms_names,
+        storage_class=storage_class,
+        # Copy-offload specific parameters
+        datastore_id=datastore_id,
+        offload_plugin_config=offload_plugin_config,
+        access_mode="ReadWriteOnce",
+        volume_mode="Block",
+    )
+
+    # Execute copy-offload migration
+    migrate_vms(
+        ocp_admin_client=ocp_admin_client,
+        request=request,
+        fixture_store=fixture_store,
+        source_provider=source_provider,
+        destination_provider=destination_provider,
+        plan=plan,
+        network_migration_map=network_migration_map,
+        storage_migration_map=storage_migration_map,
+        source_provider_data=source_provider_data,
+        target_namespace=target_namespace,
+        source_vms_namespace=source_vms_namespace,
+        source_provider_inventory=source_provider_inventory,
+        vm_ssh_connections=vm_ssh_connections,
+    )
+
+    # Verify that the correct number of disks were migrated
+    verify_vm_disk_count(destination_provider=destination_provider, plan=plan, target_namespace=target_namespace)

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -155,6 +155,26 @@ tests_params: dict = {
         "warm_migration": False,
         "copyoffload": True,
     },
+    "test_copyoffload_independent_persistent_disk_migration": {
+        "virtual_machines": [
+            {
+                "name": "xcopy-template-test",
+                "source_vm_power": "off",
+                "guest_agent": True,
+                "clone": True,
+                "disk_type": "thin",
+                "add_disks": [
+                    {
+                        "size_gb": 30,
+                        "disk_mode": "independent_persistent",
+                        "provision_type": "thin",
+                    },
+                ],
+            },
+        ],
+        "warm_migration": False,
+        "copyoffload": True,
+    },
 }
 
 for _dir in dir():


### PR DESCRIPTION
# Add Independent Persistent Disk Migration Test

## Summary
Adds a new test `test_copyoffload_independent_persistent_disk_migration` to verify copy-offload migration of a VM with an independent persistent disk.

This test validates that MTV (Migration Toolkit for Virtualization) can successfully handle VMs with "Independent - Persistent" disks, which are excluded from snapshots and require specific handling during migration (especially cold migration).

### Configuration
```json
"test_copyoffload_independent_persistent_disk_migration": {
    "virtual_machines": [
        {
            "name": "xcopy-template-test",
            "source_vm_power": "off",
            "guest_agent": True,
            "clone": True,
            "disk_type": "thin",
            "add_disks": [
                {
                    "size_gb": 10,
                    "disk_mode": "independent_persistent",
                    "provision_type": "thin",
                },
            ],
        },
    ],
    "warm_migration": False,
    "copyoffload": True,
}
```

## Changes

### Implementation
*   **`tests/test_copyoffload_migration.py`**: Added `test_copyoffload_independent_persistent_disk_migration`.
*   **`tests/tests_config/config.py`**: Added configuration for the new test scenario.

## Technical Details
*   **Workflow**:
    1.  Clones a source VM and attaches a 10GB independent persistent disk.
    2.  Validates copy-offload configuration and secrets.
    3.  Performs a **Cold Migration** (Warm migration relies on snapshots, which independent disks do not support).
    4.  Verifies the integrity of the migration by checking the disk count on the destination OpenShift VM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for VM migration using copy-offload with an independent persistent disk and a matching test configuration for a cloned VM using thin provisioning.
  * Note: the PR unintentionally introduced a duplicate, identical test definition.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->