### PR TITLE
chore(deps): bump pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-docstring-first
@@ -23,7 +23,7 @@ repos:
       - id: check-toml
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.2.0
+    rev: 7.3.0
     hooks:
       - id: flake8
         args: [--config=.flake8]
@@ -35,18 +35,18 @@ repos:
       - id: detect-secrets
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.10
+    rev: v0.14.11
     hooks:
       - id: ruff
       - id: ruff-format
 
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.20.1
+    rev: v8.30.0
     hooks:
       - id: gitleaks
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.19.1
     hooks:
       - id: mypy
         additional_dependencies:
@@ -60,7 +60,7 @@ repos:
           ]
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.18.1
+    rev: v0.20.0
     hooks:
       - id: markdownlint-cli2
         args: ["--fix"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,16 +134,16 @@ client = DynamicClient(...)  # Never do this - use get_client() instead
 
 The following resource classes are available from `ocp_resources` and should be used directly:
 
-| Symbol | Import Path |
-|--------|-------------|
-| `Resource` | `from ocp_resources.resource import Resource` |
-| `Namespace` | `from ocp_resources.namespace import Namespace` |
-| `Secret` | `from ocp_resources.secret import Secret` |
-| `Pod` | `from ocp_resources.pod import Pod` |
+| Symbol           | Import Path                                                |
+| ---------------- | ---------------------------------------------------------- |
+| `Resource`       | `from ocp_resources.resource import Resource`              |
+| `Namespace`      | `from ocp_resources.namespace import Namespace`            |
+| `Secret`         | `from ocp_resources.secret import Secret`                  |
+| `Pod`            | `from ocp_resources.pod import Pod`                        |
 | `VirtualMachine` | `from ocp_resources.virtual_machine import VirtualMachine` |
-| `StorageClass` | `from ocp_resources.storage_class import StorageClass` |
-| `ConfigMap` | `from ocp_resources.configmap import ConfigMap` |
-| `Service` | `from ocp_resources.service import Service` |
+| `StorageClass`   | `from ocp_resources.storage_class import StorageClass`     |
+| `ConfigMap`      | `from ocp_resources.configmap import ConfigMap`            |
+| `Service`        | `from ocp_resources.service import Service`                |
 
 **Verifying re-exports:**
 
@@ -166,7 +166,8 @@ Each resource module typically exports a single class with the resource name.
 
 - `ocp_utilities.infra.get_client()` returns a `kubernetes.dynamic.DynamicClient` instance
 - This does NOT mean `DynamicClient` is re-exported by `openshift-python-wrapper`
-- The fact that `get_client()` returns `DynamicClient` only permits importing `DynamicClient` for type annotations (see below)
+- The fact that `get_client()` returns `DynamicClient` only permits importing `DynamicClient`
+  for type annotations (see below)
 - You must NEVER instantiate `DynamicClient` directly - always use `get_client()`
 
 **Type annotations exception for DynamicClient:**
@@ -228,14 +229,14 @@ isinstance(obj, DynamicClient)  # Runtime usage is forbidden
 
 **Summary of DynamicClient rules:**
 
-| Usage | Allowed? |
-|-------|----------|
-| Import inside `TYPE_CHECKING` block | Yes |
-| String annotation `"DynamicClient"` | Yes |
-| Top-level import used only in annotations | Yes (but prefer TYPE_CHECKING) |
-| Instantiate `DynamicClient(...)` directly | No - use `get_client()` |
-| Use in `isinstance()` or runtime checks | No |
-| Import other `kubernetes.*` modules | No |
+| Usage                                        | Allowed?                         |
+| -------------------------------------------- | -------------------------------- |
+| Import inside `TYPE_CHECKING` block          | Yes                              |
+| String annotation `"DynamicClient"`          | Yes                              |
+| Top-level import used only in annotations    | Yes (but prefer TYPE_CHECKING)   |
+| Instantiate `DynamicClient(...)` directly    | No - use `get_client()`          |
+| Use in `isinstance()` or runtime checks      | No                               |
+| Import other `kubernetes.*` modules          | No                               |
 
 #### Function Size - Keep Functions Small
 
@@ -849,13 +850,13 @@ MAX_RETRIES = 3  # Constant - move to config
 
 **Where to put helper functions:**
 
-| Function Type | Location |
-|---------------|----------|
-| Migration utilities | `utilities/mtv_migration.py` |
-| Resource utilities | `utilities/resources.py` |
-| Provider utilities | `utilities/providers.py` |
-| General utilities | `utilities/utils.py` |
-| Provider classes | `libs/<provider>.py` |
+| Function Type       | Location                      |
+| ------------------- | ----------------------------- |
+| Migration utilities | `utilities/mtv_migration.py`  |
+| Resource utilities  | `utilities/resources.py`      |
+| Provider utilities  | `utilities/providers.py`      |
+| General utilities   | `utilities/utils.py`          |
+| Provider classes    | `libs/<provider>.py`          |
 
 **Why this rule exists:**
 


### PR DESCRIPTION
## Summary
- Bump pre-commit hook versions to latest releases
- Fix markdown table formatting in CLAUDE.md

## Changes

### Pre-commit hooks updated:
| Hook | Old Version | New Version |
|------|-------------|-------------|
| pre-commit-hooks | v5.0.0 | v6.0.0 |
| flake8 | 7.2.0 | 7.3.0 |
| ruff-pre-commit | v0.11.10 | v0.14.11 |
| gitleaks | v8.20.1 | v8.30.0 |
| mirrors-mypy | v1.15.0 | v1.19.1 |
| markdownlint-cli2 | v0.18.1 | v0.20.0 |

### Documentation:
- Fix markdown table alignment in CLAUDE.md to pass markdownlint

## Test plan
- [x] Pre-commit hooks pass locally
- [ ] CI checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tool dependencies to latest versions.

* **Documentation**
  * Enhanced documentation with improved formatting and content clarity for better readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->