### PR TITLE
fix: remove target_power_state from independent nonpersistent disk test config

### DIFF
--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -194,7 +194,6 @@ tests_params: dict = {
             {
                 "name": "xcopy-template-test",
                 "source_vm_power": "off",
-                "target_power_state": "on",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thin",


### PR DESCRIPTION
## Summary

Removes `target_power_state: "on"` from the `test_copyoffload_independent_nonpersistent_disk_migration` configuration in `tests/tests_config/config.py`.

This setting is not required for the test and was inconsistent with other similar tests.

## Changes

* `tests/tests_config/config.py`: Removed `target_power_state: "on"` from `test_copyoffload_independent_nonpersistent_disk_migration`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified configuration for virtual machine migration test scenarios by removing redundant power state parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->