### PR TITLE
feat: add Polarion test case IDs to copyoffload test classes

### DIFF
--- a/tests/test_copyoffload_migration.py
+++ b/tests/test_copyoffload_migration.py
@@ -35,7 +35,7 @@ LOGGER = get_logger(__name__)
     "class_plan_config",
     [pytest.param(py_config["tests_params"]["test_copyoffload_thin_migration"])],
     indirect=True,
-    ids=["copyoffload-thin"],
+    ids=["MTV-559:copyoffload-thin"],
 )
 @pytest.mark.usefixtures("multus_network_name", "copyoffload_config", "setup_copyoffload_ssh", "cleanup_migrated_vms")
 class TestCopyoffloadThinMigration:
@@ -373,7 +373,7 @@ class TestCopyoffloadThinSnapshotsMigration(CopyoffloadSnapshotBase):
     "class_plan_config",
     [pytest.param(py_config["tests_params"]["test_copyoffload_2tb_vm_snapshots_migration"])],
     indirect=True,
-    ids=["copyoffload-2tb-vm-snapshots"],
+    ids=["MTV-575:copyoffload-2tb-vm-snapshots"],
 )
 @pytest.mark.skipif(
     py_config.get("source_provider_type") != Provider.ProviderType.VSPHERE,
@@ -390,7 +390,7 @@ class TestCopyoffload2TbVmSnapshotsMigration(CopyoffloadSnapshotBase):
     "class_plan_config",
     [pytest.param(py_config["tests_params"]["test_copyoffload_thick_lazy_migration"])],
     indirect=True,
-    ids=["copyoffload-thick-lazy"],
+    ids=["MTV-580:copyoffload-thick-lazy"],
 )
 @pytest.mark.usefixtures("multus_network_name", "copyoffload_config", "setup_copyoffload_ssh", "cleanup_migrated_vms")
 class TestCopyoffloadThickLazyMigration:
@@ -538,7 +538,7 @@ class TestCopyoffloadThickLazyMigration:
     "class_plan_config",
     [pytest.param(py_config["tests_params"]["test_copyoffload_multi_disk_migration"])],
     indirect=True,
-    ids=["copyoffload-multi-disk"],
+    ids=["MTV-561:copyoffload-multi-disk"],
 )
 @pytest.mark.usefixtures("multus_network_name", "copyoffload_config", "setup_copyoffload_ssh", "cleanup_migrated_vms")
 class TestCopyoffloadMultiDiskMigration:
@@ -689,7 +689,7 @@ class TestCopyoffloadMultiDiskMigration:
     "class_plan_config",
     [pytest.param(py_config["tests_params"]["test_copyoffload_multi_disk_different_path_migration"])],
     indirect=True,
-    ids=["copyoffload-multi-disk-different-path"],
+    ids=["MTV-563:copyoffload-multi-disk-different-path"],
 )
 @pytest.mark.usefixtures("multus_network_name", "copyoffload_config", "setup_copyoffload_ssh", "cleanup_migrated_vms")
 class TestCopyoffloadMultiDiskDifferentPathMigration:
@@ -840,7 +840,7 @@ class TestCopyoffloadMultiDiskDifferentPathMigration:
     "class_plan_config",
     [pytest.param(py_config["tests_params"]["test_copyoffload_rdm_virtual_disk_migration"])],
     indirect=True,
-    ids=["copyoffload-rdm-virtual"],
+    ids=["MTV-562:copyoffload-rdm-virtual"],
 )
 @pytest.mark.usefixtures("multus_network_name", "copyoffload_config", "cleanup_migrated_vms")
 class TestCopyoffloadRdmVirtualDiskMigration:
@@ -995,7 +995,7 @@ class TestCopyoffloadRdmVirtualDiskMigration:
     "class_plan_config",
     [pytest.param(py_config["tests_params"]["test_copyoffload_multi_datastore_migration"])],
     indirect=True,
-    ids=["copyoffload-multi-datastore"],
+    ids=["MTV-564:copyoffload-multi-datastore"],
 )
 @pytest.mark.usefixtures("multus_network_name", "copyoffload_config", "cleanup_migrated_vms")
 class TestCopyoffloadMultiDatastoreMigration:
@@ -1157,7 +1157,7 @@ class TestCopyoffloadMultiDatastoreMigration:
     "class_plan_config",
     [pytest.param(py_config["tests_params"]["test_copyoffload_mixed_datastore_migration"])],
     indirect=True,
-    ids=["copyoffload-mixed-datastore"],
+    ids=["MTV-565:copyoffload-mixed-datastore"],
 )
 @pytest.mark.usefixtures("multus_network_name", "copyoffload_config", "mixed_datastore_config", "cleanup_migrated_vms")
 class TestCopyoffloadMixedDatastoreMigration:
@@ -1322,7 +1322,7 @@ class TestCopyoffloadMixedDatastoreMigration:
     "class_plan_config",
     [pytest.param(py_config["tests_params"]["test_copyoffload_independent_persistent_disk_migration"])],
     indirect=True,
-    ids=["copyoffload-independent-persistent"],
+    ids=["MTV-567:copyoffload-independent-persistent"],
 )
 @pytest.mark.usefixtures("multus_network_name", "copyoffload_config", "cleanup_migrated_vms")
 class TestCopyoffloadIndependentPersistentDiskMigration:
@@ -1473,7 +1473,7 @@ class TestCopyoffloadIndependentPersistentDiskMigration:
     "class_plan_config",
     [pytest.param(py_config["tests_params"]["test_copyoffload_independent_nonpersistent_disk_migration"])],
     indirect=True,
-    ids=["copyoffload-independent-nonpersistent"],
+    ids=["MTV-568:copyoffload-independent-nonpersistent"],
 )
 @pytest.mark.usefixtures("multus_network_name", "copyoffload_config", "cleanup_migrated_vms")
 class TestCopyoffloadIndependentNonpersistentDiskMigration:
@@ -1624,7 +1624,7 @@ class TestCopyoffloadIndependentNonpersistentDiskMigration:
     "class_plan_config",
     [pytest.param(py_config["tests_params"]["test_copyoffload_10_mixed_disks_migration"])],
     indirect=True,
-    ids=["copyoffload-10-mixed-disks"],
+    ids=["MTV-573:copyoffload-10-mixed-disks"],
 )
 @pytest.mark.usefixtures("multus_network_name", "copyoffload_config", "cleanup_migrated_vms")
 class TestCopyoffload10MixedDisksMigration:
@@ -1775,7 +1775,7 @@ class TestCopyoffload10MixedDisksMigration:
     "class_plan_config",
     [pytest.param(py_config["tests_params"]["test_copyoffload_large_vm_migration"])],
     indirect=True,
-    ids=["copyoffload-large-vm"],
+    ids=["MTV-600:copyoffload-large-vm"],
 )
 @pytest.mark.usefixtures("multus_network_name", "copyoffload_config", "cleanup_migrated_vms")
 class TestCopyoffloadLargeVmMigration:
@@ -1926,7 +1926,7 @@ class TestCopyoffloadLargeVmMigration:
     "class_plan_config",
     [pytest.param(py_config["tests_params"]["test_copyoffload_nonconforming_name_migration"])],
     indirect=True,
-    ids=["copyoffload-nonconforming-name"],
+    ids=["MTV-579:copyoffload-nonconforming-name"],
 )
 @pytest.mark.usefixtures("multus_network_name", "copyoffload_config", "setup_copyoffload_ssh", "cleanup_migrated_vms")
 class TestCopyoffloadNonconformingNameMigration:
@@ -2142,7 +2142,7 @@ class TestCopyoffloadNonconformingNameMigration:
     "class_plan_config",
     [pytest.param(py_config["tests_params"]["test_copyoffload_warm_migration"])],
     indirect=True,
-    ids=["copyoffload-warm"],
+    ids=["MTV-577:copyoffload-warm"],
 )
 @pytest.mark.usefixtures(
     "multus_network_name", "precopy_interval_forkliftcontroller", "copyoffload_config", "cleanup_migrated_vms"


### PR DESCRIPTION
### **User description**
Add Polarion test case IDs to all copy-offload migration test class parametrize IDs for improved test traceability and reporting integration.

Changes:
- Update parametrize  to include test case ID with colon separator
- Format: MTV-XXX:description for clear separation of ID and test name
- Applied to 15 copyoffload test classes:
  * MTV-559: Thin disk migration
  * MTV-575: 2TB VM with snapshots migration
  * MTV-580: Thick-lazy provisioned disk migration
  * MTV-561: Multi-disk migration
  * MTV-563: Multi-disk different path migration
  * MTV-562: RDM virtual disk migration
  * MTV-564: Multi-datastore migration
  * MTV-565: Mixed datastore migration
  * MTV-567: Independent persistent disk migration
  * MTV-568: Independent non-persistent disk migration
  * MTV-573: 10 mixed disks migration
  * MTV-600: Large VM migration
  * MTV-579: Non-conforming name migration
  * MTV-577: Warm migration

Benefits:
- Test case IDs visible in test output and JUnit XML test names
- Enables correlation between test execution and Polarion test cases
- Improves test result tracking and reporting to external systems
- Colon separator provides clear semantic distinction between ID and description

Related: Implements test case ID tracking for Polarion/ReportPortal integration


___

### **PR Type**
Enhancement


___

### **Description**
- Add Polarion test case IDs to 15 copyoffload test classes

- Format test IDs as MTV-XXX:description for traceability

- Enable correlation between test execution and Polarion cases

- Improve test result tracking and external system reporting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Classes"] -- "Add MTV-XXX IDs" --> B["Parametrize IDs"]
  B -- "Format: MTV-XXX:description" --> C["Test Output & JUnit XML"]
  C -- "Enable Correlation" --> D["Polarion/ReportPortal Integration"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_copyoffload_migration.py</strong><dd><code>Add Polarion test case IDs to parametrize decorators</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_copyoffload_migration.py

<ul><li>Updated parametrize IDs for 15 copyoffload test classes with Polarion <br>test case IDs<br> <li> Changed format from descriptive names to MTV-XXX:description pattern<br> <li> Applied IDs: MTV-559, MTV-575, MTV-580, MTV-561, MTV-563, MTV-562, <br>MTV-564, MTV-565, MTV-567, MTV-568, MTV-573, MTV-600, MTV-579, MTV-577<br> <li> Maintains existing test functionality while adding traceability <br>metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/RedHatQE/mtv-api-tests/pull/286/files#diff-a413c4b67baaed5d01cf9591b5b1c8df4cf59914545c08fa0b512c9f7d6f005a">+14/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test identifiers and enhanced test verification parameters to improve test coverage tracking and validation scope in migration tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->