### PR TITLE
MTV-3129: Add ClusterRole (forklift-migrator-role) migration tests for local remote cluster

### DIFF
--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -475,6 +475,26 @@ tests_params: dict = {
         "warm_migration": False,
         "copyoffload": True,
     },
+    "test_mtv_clusterrole_warm_migration": {
+        "virtual_machines": [
+            {
+                "name": "mtv-tests-rhel8",
+                "source_vm_power": "on",
+                "guest_agent": True,
+            },
+        ],
+        "warm_migration": True,
+    },
+    "test_mtv_clusterrole_warm_migration_with_scc": {
+        "virtual_machines": [
+            {
+                "name": "mtv-tests-rhel8",
+                "source_vm_power": "on",
+                "guest_agent": True,
+            },
+        ],
+        "warm_migration": True,
+    },
     "test_copyoffload_scale_migration": {
         "virtual_machines": [
             {

--- a/tests/warm/conftest.py
+++ b/tests/warm/conftest.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import base64
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from ocp_resources.cluster_role import ClusterRole
+from ocp_resources.cluster_role_binding import ClusterRoleBinding
+from ocp_resources.provider import Provider
+from ocp_resources.role_binding import RoleBinding
+from ocp_resources.secret import Secret
+from ocp_resources.service_account import ServiceAccount
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+from libs.providers.openshift import OCPProvider
+from utilities.resources import create_and_store_resource
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+FORKLIFT_MIGRATOR_ROLE_NAME = "forklift-migrator-role"
+
+
+@pytest.fixture(scope="session")
+def clusterrole_destination_ocp_provider(
+    fixture_store: dict[str, Any],
+    ocp_admin_client: "DynamicClient",
+    session_uuid: str,
+    target_namespace: str,
+    mtv_namespace: str,
+) -> OCPProvider:
+    """Create a token-based OCP provider using the existing forklift-migrator-role and a fresh SA.
+
+    Verifies the flow:
+      1. Create a fresh ServiceAccount (in MTV operator namespace)
+      2. Bind it ONLY to the existing ClusterRole forklift-migrator-role (from operator/PR)
+      3. Create a token for that SA (equivalent to: oc create token <sa> -n <mtv-namespace>)
+      4. Create Forklift Provider CR using that token (in target namespace)
+
+    Does NOT create the ClusterRole; forklift-migrator-role must already exist in the cluster.
+
+    Args:
+        fixture_store (dict[str, Any]): Fixture store for resource tracking and teardown.
+        ocp_admin_client (DynamicClient): OpenShift DynamicClient for cluster operations.
+        session_uuid (str): Unique session identifier for resource naming.
+        target_namespace (str): Namespace for provider resources (Provider CR, provider secret).
+        mtv_namespace (str): MTV operator namespace for ServiceAccount and token.
+
+    Returns:
+        OCPProvider: Token-based OCP provider bound to forklift-migrator-role.
+
+    Raises:
+        ValueError: If the SA token is not populated within 60s.
+    """
+    sa_name = f"{session_uuid}-forklift-migrator-sa"
+    binding_name = f"{session_uuid}-forklift-migrator-binding"
+    token_secret_name = f"{session_uuid}-clusterrole-token"
+    provider_name = f"{session_uuid}-clusterrole-destination-ocp-provider"
+
+    create_and_store_resource(
+        client=ocp_admin_client,
+        fixture_store=fixture_store,
+        resource=ServiceAccount,
+        name=sa_name,
+        namespace=mtv_namespace,
+    )
+
+    create_and_store_resource(
+        client=ocp_admin_client,
+        fixture_store=fixture_store,
+        resource=ClusterRoleBinding,
+        name=binding_name,
+        cluster_role=FORKLIFT_MIGRATOR_ROLE_NAME,
+        subjects=[{"kind": "ServiceAccount", "name": sa_name, "namespace": mtv_namespace}],
+    )
+
+    create_and_store_resource(
+        client=ocp_admin_client,
+        fixture_store=fixture_store,
+        resource=Secret,
+        name=token_secret_name,
+        namespace=mtv_namespace,
+        type="kubernetes.io/service-account-token",
+        annotations={"kubernetes.io/service-account.name": sa_name},
+    )
+
+    token_secret_ref = Secret(
+        client=ocp_admin_client,
+        name=token_secret_name,
+        namespace=mtv_namespace,
+    )
+
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=60,
+            sleep=2,
+            func=lambda: (token_secret_ref.instance.data or {}).get("token"),
+        ):
+            if sample:
+                token_b64 = sample
+                break
+    except TimeoutExpiredError:
+        raise ValueError(
+            f"Token was not populated in Secret {token_secret_name} for ServiceAccount {sa_name} within 60s"
+        ) from None
+
+    token_value = base64.b64decode(token_b64).decode("utf-8")
+
+    provider_secret = create_and_store_resource(
+        client=ocp_admin_client,
+        fixture_store=fixture_store,
+        resource=Secret,
+        name=f"{provider_name}-secret",
+        namespace=target_namespace,
+        string_data={"token": token_value, "insecureSkipVerify": "true"},
+    )
+
+    provider = create_and_store_resource(
+        client=ocp_admin_client,
+        fixture_store=fixture_store,
+        resource=Provider,
+        name=provider_name,
+        namespace=target_namespace,
+        secret_name=provider_secret.name,
+        secret_namespace=provider_secret.namespace,
+        url=ocp_admin_client.configuration.host,
+        provider_type=Provider.ProviderType.OPENSHIFT,
+    )
+
+    return OCPProvider(ocp_resource=provider, fixture_store=fixture_store)
+
+
+@pytest.fixture(scope="class")
+def forklift_scc_binding(
+    fixture_store: dict[str, Any],
+    ocp_admin_client: "DynamicClient",
+    session_uuid: str,
+    target_namespace: str,
+) -> Generator[RoleBinding, None, None]:
+    """Create ClusterRole and RoleBinding to grant forklift-controller-scc SCC to the default SA.
+
+    Class-scoped so that resources are created per test class and torn down after
+    the class completes. This ensures "without SCC" test classes run against a
+    clean state where neither the ClusterRole nor the RoleBinding exist.
+
+    Equivalent to: oc adm policy add-scc-to-user forklift-controller-scc -z default -n <namespace>
+
+    Args:
+        fixture_store (dict[str, Any]): Fixture store for resource tracking and teardown.
+        ocp_admin_client (DynamicClient): OpenShift DynamicClient for cluster operations.
+        session_uuid (str): Unique session identifier for resource naming.
+        target_namespace (str): Namespace where migration pods run.
+
+    Yields:
+        RoleBinding: The created RoleBinding resource.
+    """
+    scc_cluster_role_name = "system:openshift:scc:forklift-controller-scc"
+
+    scc_cluster_role = create_and_store_resource(
+        client=ocp_admin_client,
+        fixture_store=fixture_store,
+        resource=ClusterRole,
+        name=scc_cluster_role_name,
+        rules=[
+            {
+                "apiGroups": ["security.openshift.io"],
+                "resourceNames": ["forklift-controller-scc"],
+                "resources": ["securitycontextconstraints"],
+                "verbs": ["use"],
+            }
+        ],
+    )
+
+    role_binding = create_and_store_resource(
+        client=ocp_admin_client,
+        fixture_store=fixture_store,
+        resource=RoleBinding,
+        name=f"{session_uuid}-forklift-scc-binding",
+        namespace=target_namespace,
+        role_ref_kind="ClusterRole",
+        role_ref_name=scc_cluster_role_name,
+        subjects_kind="ServiceAccount",
+        subjects_name="default",
+        subjects_namespace=target_namespace,
+    )
+
+    yield role_binding
+
+    role_binding.clean_up()
+    scc_cluster_role.clean_up()

--- a/tests/warm/test_mtv_warm_clusterrole_migration.py
+++ b/tests/warm/test_mtv_warm_clusterrole_migration.py
@@ -1,0 +1,266 @@
+import pytest
+from exceptions.exceptions import MigrationPlanExecError
+from ocp_resources.network_map import NetworkMap
+from ocp_resources.plan import Plan
+from ocp_resources.storage_map import StorageMap
+from pytest_testconfig import config as py_config
+
+from utilities.migration_utils import get_cutover_value
+from utilities.mtv_migration import (
+    create_plan_resource,
+    execute_migration,
+    get_network_migration_map,
+    get_storage_migration_map,
+)
+from utilities.post_migration import check_vms
+from utilities.utils import get_value_from_py_config, populate_vm_ids
+
+
+@pytest.mark.remote
+@pytest.mark.tier0
+@pytest.mark.warm
+@pytest.mark.incremental
+@pytest.mark.skipif(
+    not get_value_from_py_config("remote_ocp_cluster"),
+    reason="No remote OCP cluster provided",
+)
+@pytest.mark.parametrize(
+    "class_plan_config",
+    [pytest.param(py_config["tests_params"]["test_mtv_clusterrole_warm_migration"])],
+    indirect=True,
+    ids=["MTV-3129-clusterrole-warm"],
+)
+@pytest.mark.usefixtures("cleanup_migrated_vms")
+class TestClusterroleWarmMtvMigration:
+    """Verify ClusterRole (forklift-migrator-role) without SCC fails warm migration."""
+
+    storage_map: StorageMap
+    network_map: NetworkMap
+    plan_resource: Plan
+
+    def test_create_storagemap(
+        self,
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        clusterrole_destination_ocp_provider,
+        source_provider_inventory,
+        target_namespace,
+    ):
+        """Create StorageMap resource for migration."""
+        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.storage_map = get_storage_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=clusterrole_destination_ocp_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            vms=vms,
+        )
+        assert self.storage_map, "StorageMap creation failed"
+
+    def test_create_networkmap(
+        self,
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        clusterrole_destination_ocp_provider,
+        source_provider_inventory,
+        target_namespace,
+        multus_network_name,
+    ):
+        """Create NetworkMap resource for migration."""
+        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.network_map = get_network_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=clusterrole_destination_ocp_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            multus_network_name=multus_network_name,
+            vms=vms,
+        )
+        assert self.network_map, "NetworkMap creation failed"
+
+    def test_create_plan(
+        self,
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        clusterrole_destination_ocp_provider,
+        target_namespace,
+        source_provider_inventory,
+    ):
+        """Create MTV Plan CR resource."""
+        populate_vm_ids(prepared_plan, source_provider_inventory)
+
+        self.__class__.plan_resource = create_plan_resource(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=clusterrole_destination_ocp_provider,
+            storage_map=self.storage_map,
+            network_map=self.network_map,
+            virtual_machines_list=prepared_plan["virtual_machines"],
+            target_namespace=target_namespace,
+            warm_migration=prepared_plan.get("warm_migration", False),
+        )
+        assert self.plan_resource, "Plan creation failed"
+
+    def test_migrate_vms(
+        self,
+        fixture_store,
+        ocp_admin_client,
+        target_namespace,
+    ):
+        """Execute warm migration, expecting failure without SCC binding."""
+        with pytest.raises(MigrationPlanExecError):
+            execute_migration(
+                ocp_admin_client=ocp_admin_client,
+                fixture_store=fixture_store,
+                plan=self.plan_resource,
+                target_namespace=target_namespace,
+                cut_over=get_cutover_value(),
+            )
+
+
+@pytest.mark.remote
+@pytest.mark.tier0
+@pytest.mark.warm
+@pytest.mark.incremental
+@pytest.mark.skipif(
+    not get_value_from_py_config("remote_ocp_cluster"),
+    reason="No remote OCP cluster provided",
+)
+@pytest.mark.parametrize(
+    "class_plan_config",
+    [pytest.param(py_config["tests_params"]["test_mtv_clusterrole_warm_migration_with_scc"])],
+    indirect=True,
+    ids=["MTV-3129-clusterrole-warm-with-scc"],
+)
+@pytest.mark.usefixtures("cleanup_migrated_vms")
+class TestClusterroleWarmWithSccMigration:
+    """Verify ClusterRole (forklift-migrator-role) with SCC binding succeeds warm migration."""
+
+    storage_map: StorageMap
+    network_map: NetworkMap
+    plan_resource: Plan
+
+    def test_create_storagemap(
+        self,
+        forklift_scc_binding,
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        clusterrole_destination_ocp_provider,
+        source_provider_inventory,
+        target_namespace,
+    ):
+        """Create StorageMap resource for migration."""
+        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.storage_map = get_storage_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=clusterrole_destination_ocp_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            vms=vms,
+        )
+        assert self.storage_map, "StorageMap creation failed"
+
+    def test_create_networkmap(
+        self,
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        clusterrole_destination_ocp_provider,
+        source_provider_inventory,
+        target_namespace,
+        multus_network_name,
+    ):
+        """Create NetworkMap resource for migration."""
+        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.network_map = get_network_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=clusterrole_destination_ocp_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            multus_network_name=multus_network_name,
+            vms=vms,
+        )
+        assert self.network_map, "NetworkMap creation failed"
+
+    def test_create_plan(
+        self,
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        clusterrole_destination_ocp_provider,
+        target_namespace,
+        source_provider_inventory,
+    ):
+        """Create MTV Plan CR resource."""
+        populate_vm_ids(prepared_plan, source_provider_inventory)
+
+        self.__class__.plan_resource = create_plan_resource(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=clusterrole_destination_ocp_provider,
+            storage_map=self.storage_map,
+            network_map=self.network_map,
+            virtual_machines_list=prepared_plan["virtual_machines"],
+            target_namespace=target_namespace,
+            warm_migration=prepared_plan.get("warm_migration", False),
+        )
+        assert self.plan_resource, "Plan creation failed"
+
+    def test_migrate_vms(
+        self,
+        fixture_store,
+        ocp_admin_client,
+        target_namespace,
+    ):
+        """Execute warm migration."""
+        execute_migration(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            plan=self.plan_resource,
+            target_namespace=target_namespace,
+            cut_over=get_cutover_value(),
+        )
+
+    def test_check_vms(
+        self,
+        prepared_plan,
+        source_provider,
+        clusterrole_destination_ocp_provider,
+        source_provider_data,
+        target_namespace,
+        source_vms_namespace,
+        source_provider_inventory,
+        vm_ssh_connections,
+    ):
+        """Validate migrated VMs."""
+        check_vms(
+            plan=prepared_plan,
+            source_provider=source_provider,
+            destination_provider=clusterrole_destination_ocp_provider,
+            network_map_resource=self.network_map,
+            storage_map_resource=self.storage_map,
+            source_provider_data=source_provider_data,
+            source_vms_namespace=source_vms_namespace,
+            source_provider_inventory=source_provider_inventory,
+            vm_ssh_connections=vm_ssh_connections,
+        )


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Add comprehensive ClusterRole migration tests for forklift-migrator-role
  - Cold migration test with token-based OCP provider
  - Warm migration test with token-based OCP provider
  - ConfigMap and Secret migration verification tests

- Implement clusterrole_destination_ocp_provider fixture for token-based authentication
  - Creates fresh ServiceAccount and binds to existing forklift-migrator-role
  - Generates token and creates Forklift Provider CR

- Add utility functions for ConfigMap and Secret migration verification

- Fix virtctl_binary fixture to respect VIRTCTL_PATH environment variable

- Add test configuration parameters for three ClusterRole migration scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Config<br/>test_mtv_clusterrole_*"] -->|defines| B["Test Classes<br/>Cold/Warm/ConfigMap-Secret"]
  C["clusterrole_destination_ocp_provider<br/>fixture"] -->|creates| D["ServiceAccount<br/>+ ClusterRoleBinding"]
  D -->|generates| E["Token Secret"]
  E -->|creates| F["Forklift Provider CR"]
  B -->|uses| F
  B -->|verifies| G["VM Migration<br/>+ ConfigMap/Secret"]
  H["clusterrole_utils<br/>verify functions"] -->|validates| G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Add token-based OCP provider fixture and env var support</code>&nbsp; </dd></summary>
<hr>

conftest.py

<ul><li>Added <code>base64</code> import for token decoding<br> <li> Added imports for <code>ClusterRoleBinding</code> and <code>ServiceAccount</code> resources<br> <li> Fixed <code>virtctl_binary</code> fixture to check <code>VIRTCTL_PATH</code> environment <br>variable first<br> <li> Implemented <code>clusterrole_destination_ocp_provider</code> session-scoped <br>fixture that creates ServiceAccount, binds to forklift-migrator-role, <br>generates token, and creates Forklift Provider CR<br> <li> Added <code>FORKLIFT_MIGRATOR_ROLE_NAME</code> constant for the existing <br>ClusterRole</ul>


</details>


  </td>
  <td><a href="https://github.com/RedHatQE/mtv-api-tests/pull/293/files#diff-a31c7ed5d35f5ed8233994868c54d625b18e6bacb6794344c4531e62bd9dde59">+109/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>clusterrole_utils.py</strong><dd><code>Add ConfigMap and Secret migration verification utilities</code></dd></summary>
<hr>

utilities/clusterrole_utils.py

<ul><li>Implemented <code>verify_configmap_migrated</code> function to assert ConfigMap <br>exists in target namespace and data matches source<br> <li> Implemented <code>verify_secret_migrated</code> function to assert Secret exists in <br>target namespace and data matches source<br> <li> Both functions include comprehensive logging and detailed assertion <br>error messages<br> <li> Functions handle missing resources and data mismatches gracefully</ul>


</details>


  </td>
  <td><a href="https://github.com/RedHatQE/mtv-api-tests/pull/293/files#diff-267fc6a0dd90f275a90ae71c64550d71f2bcce873078b9da3f44ce8913ccc582">+116/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_mtv_clusterrole_migration.py</strong><dd><code>Add ClusterRole migration test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_mtv_clusterrole_migration.py

<ul><li>Created three test classes for ClusterRole migration scenarios<br> <li> <code>TestClusterroleColdMtvMigration</code>: verifies cold migration with <br>token-based provider<br> <li> <code>TestClusterroleWarmMtvMigration</code>: verifies warm migration with <br>token-based provider<br> <li> <code>TestClusterroleConfigmapSecretMigration</code>: verifies ConfigMap and Secret <br>migration alongside VM migration<br> <li> All tests use <code>clusterrole_destination_ocp_provider</code> fixture and verify <br>VM running status post-migration</ul>


</details>


  </td>
  <td><a href="https://github.com/RedHatQE/mtv-api-tests/pull/293/files#diff-dc9461cf55ba29b91e55799324f2fe567c16335ecbb7d5ba183d53318244fd65">+298/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Add test parameters for ClusterRole migration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/tests_config/config.py

<ul><li>Added <code>test_mtv_clusterrole_cold_migration</code> configuration with single <br>RHEL8 VM and cold migration<br> <li> Added <code>test_mtv_clusterrole_warm_migration</code> configuration with single <br>RHEL8 VM powered on and warm migration enabled<br> <li> Added <code>test_mtv_clusterrole_configmap_secret_migration</code> configuration <br>with single RHEL8 VM and cold migration</ul>


</details>


  </td>
  <td><a href="https://github.com/RedHatQE/mtv-api-tests/pull/293/files#diff-bd44158c04d40b13a776c6a4f4fc5245a958147cff61e65765b8be7f518f40fe">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ClusterRole-based destination provider using a service-account token.
  * Environment variable override to select the virtctl binary.

* **Utilities**
  * Helpers to run ClusterRole-based migrations and verify VM status, ConfigMap, and Secret migration results.

* **Tests**
  * End-to-end tests covering cold, warm, and ConfigMap/Secret ClusterRole migration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->