### PR TITLE
feat: Add Windows OS detection and multidisk support for OpenStack

### DIFF
--- a/libs/providers/rhv.py
+++ b/libs/providers/rhv.py
@@ -242,7 +242,7 @@ class OvirtProvider(BaseProvider):
 
         # Guest OS - detect Windows from VM OS type
         os_type = (source_vm.os.type if source_vm.os and source_vm.os.type else "").lower()
-        result_vm_info["win_os"] = "windows" in os_type or "win" in os_type
+        result_vm_info["win_os"] = "windows" in os_type
 
         return result_vm_info
 


### PR DESCRIPTION
### **User description**
Add Windows OS detection across OpenStack and RHV providers using OS type metadata. Enhance OpenStack provider to support VMs with multiple attached volumes during cloning by creating volume snapshots for all disks and preserving boot index ordering.


___

### **PR Type**
Enhancement


___

### **Description**
- Add Windows OS detection for OpenStack and RHV providers

- Support multi-disk VM cloning with volume snapshots

- Improve boot volume identification and boot index ordering

- Enhance volume attachment retrieval and metadata handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["VM with Multiple Volumes"] -->|"list_snapshots"| B["Get Volume Attachments"]
  B -->|"create_server_image"| C["Create Volume Snapshots"]
  C -->|"snapshot_by_volume_id"| D["Create New Volumes"]
  D -->|"boot_index ordering"| E["Create Cloned VM"]
  A -->|"get_volume_metadata"| F["Detect Boot Volume"]
  F -->|"_is_windows"| G["Determine OS Type"]
  G -->|"win_os flag"| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openstack.py</strong><dd><code>Multi-disk cloning and Windows OS detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/providers/openstack.py

<ul><li>Add Windows OS detection via <code>_is_windows()</code> method checking volume and <br>image metadata<br> <li> Refactor <code>list_snapshots()</code> to use volume attachments API instead of <br>direct volume query<br> <li> Enhance <code>get_volume_metadata()</code> to identify boot volume by <code>is_bootable</code> <br>flag with error handling<br> <li> Implement multi-disk cloning in <code>clone_vm()</code> with volume snapshot <br>mapping and boot index ordering<br> <li> Add volume snapshot cleanup for multiple snapshots created during <br>multi-disk operations<br> <li> Import <code>openstack.exceptions</code> for SDK exception handling</ul>


</details>


  </td>
  <td><a href="https://github.com/RedHatQE/mtv-api-tests/pull/298/files#diff-c4147b3481ea40863d39f2787b0979624148939729ec166b05450c12b712953b">+130/-34</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rhv.py</strong><dd><code>Add Windows OS detection for RHV</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/providers/rhv.py

<ul><li>Add Windows OS detection in <code>vm_dict()</code> method using VM OS type metadata<br> <li> Set <code>win_os</code> flag based on OS type string containing "windows" or "win"</ul>


</details>


  </td>
  <td><a href="https://github.com/RedHatQE/mtv-api-tests/pull/298/files#diff-c64a567f780ae7aba0158d120315aa59ef1262ef18dd04ccd244a7ff57546708">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows OS detection reliability across OpenStack and RHV providers.
  * Fixed boot-volume identification to ensure correct system disk selection.

* **Improvements**
  * VM cloning now uses snapshot-based provisioning with per-volume snapshot handling and comprehensive snapshot cleanup.
  * Enhanced volume listing, metadata handling, validation, and error logging for more robust snapshot and volume workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->