### PR TITLE
feat: Add html_report_url support to AI analysis JUnit XML output

### DIFF
--- a/utilities/pytest_utils.py
+++ b/utilities/pytest_utils.py
@@ -462,7 +462,7 @@ def enrich_junit_xml(session: pytest.Session) -> None:
     }
 
     analysis_map, html_report_url = _fetch_analysis_from_server(server_url=server_url, payload=payload)
-    if not analysis_map:
+    if not analysis_map and not html_report_url:
         return
 
     _apply_analysis_to_xml(xml_path=xml_path, analysis_map=analysis_map, html_report_url=html_report_url)
@@ -516,11 +516,11 @@ def _fetch_analysis_from_server(
         payload (dict[str, Any]): Request payload containing failures and AI config.
 
     Returns:
-     Tuple of (analysis_map, html_report_url).
-        analysis_map: Mapping of (classname, test_name) to analysis results.
-        html_report_url: The HTML report URL, extracted from the server response
-            or constructed from job_id and server_url when the response omits it.
-            Empty string if neither is available.
+        tuple[dict[tuple[str, str], dict[str, Any]], str]: Two-element tuple of:
+            analysis_map: Mapping of (classname, test_name) to analysis results.
+            html_report_url: URL from server response, or constructed from
+                job_id and server_url, or empty string if neither is available.
+
         Returns ({}, "") on request failure.
     """
     try:
@@ -551,6 +551,9 @@ def _fetch_analysis_from_server(
     html_report_url = result.get("html_report_url") or (
         f"{server_url.rstrip('/')}/results/{job_id}.html" if job_id else ""
     )
+    if html_report_url and not html_report_url.startswith(("http://", "https://")):
+        LOGGER.warning(f"jenkins-job-insight: Invalid html_report_url scheme, ignoring: {html_report_url}")
+        html_report_url = ""
 
     analysis_map: dict[tuple[str, str], dict[str, Any]] = {}
     for failure in result.get("failures", []):
@@ -582,7 +585,7 @@ def _apply_analysis_to_xml(
         xml_path (Path): Path to the JUnit XML report file.
         analysis_map (dict[tuple[str, str], dict[str, Any]]): Mapping of
             (classname, test_name) to analysis results.
-        html_report_url: URL to the HTML report, added as a testsuite-level property.
+        html_report_url (str): URL to the HTML report, added as a testsuite-level property.
 
     Raises:
         Exception: Re-raises any exception from XML parsing/writing after
@@ -607,13 +610,14 @@ def _apply_analysis_to_xml(
                 f"jenkins-job-insight: {len(unmatched)} analysis results did not match any testcase: {unmatched}"
             )
 
-        # Add html_report_url as a testsuite-level property
+        # Add html_report_url to the first testsuite only (pytest JUnit XML does not use namespaces)
         if html_report_url:
-            for testsuite in tree.iter("testsuite"):
-                ts_props = testsuite.find("properties")
+            first_testsuite = next(tree.iter("testsuite"), None)
+            if first_testsuite is not None:
+                ts_props = first_testsuite.find("properties")
                 if ts_props is None:
                     ts_props = ET.Element("properties")
-                    testsuite.insert(0, ts_props)
+                    first_testsuite.insert(0, ts_props)
                 _add_property(ts_props, "html_report_url", html_report_url)
 
         tree.write(str(xml_path), encoding="unicode", xml_declaration=True)


### PR DESCRIPTION
### **User description**
- Extract html_report_url from server response, falling back to constructing it from job_id and server_url
- Propagate html_report_url through the analysis pipeline
- Add html_report_url as a testsuite-level property in JUnit XML


___

### **PR Type**
Enhancement


___

### **Description**
- Extract html_report_url from server response with fallback construction

- Propagate html_report_url through analysis pipeline to XML output

- Add html_report_url as testsuite-level property in JUnit XML

- Update function signatures and return types to handle URL propagation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Server Response"] -->|"Extract html_report_url"| B["_fetch_analysis_from_server"]
  B -->|"Return tuple with URL"| C["enrich_junit_xml"]
  C -->|"Pass html_report_url"| D["_apply_analysis_to_xml"]
  D -->|"Add as testsuite property"| E["JUnit XML Report"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pytest_utils.py</strong><dd><code>Add html_report_url extraction and XML property insertion</code></dd></summary>
<hr>

utilities/pytest_utils.py

<ul><li>Modified <code>_fetch_analysis_from_server</code> to return tuple of analysis_map <br>and html_report_url<br> <li> Extract html_report_url from server response with fallback to <br>constructed URL from job_id<br> <li> Updated <code>_apply_analysis_to_xml</code> to accept html_report_url parameter and <br>add it as testsuite-level property<br> <li> Updated <code>enrich_junit_xml</code> to unpack and propagate html_report_url <br>through the pipeline</ul>


</details>


  </td>
  <td><a href="https://github.com/RedHatQE/mtv-api-tests/pull/300/files#diff-e4de8579cd915e154ef154623ac1b483d3229e69c33b961fb972676349b64109">+33/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * JUnit XML test reports now include a testsuite-level link to the HTML report when available, making it easier to open full test results.
  * If the HTML report URL cannot be obtained or is invalid, reports omit the link rather than embedding a bad URL, improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->