### PR TITLE
feat: cold migrate RHEL VMs with shared disks (MTV-454)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -899,6 +899,14 @@ def prepared_plan(
                 vm_name_suffix=vm_name_suffix,
             )
 
+        # Track original VM names and cloned objects for shared disk relinking (only if needed)
+        # Check for `is not None` because the field can be True (owner VM) or False (consumer VM),
+        # and both need relinking. We only skip VMs without this field at all.
+        has_shared_disk_config = any(vm.get("migrate_shared_disks") is not None for vm in virtual_machines)
+        if has_shared_disk_config:
+            original_source_vm_names: list[str] = [vm["name"] for vm in virtual_machines]
+            cloned_vm_objects: list[Any] = []
+
         for vm in virtual_machines:
             # Get VM object first (without full vm_dict analysis)
             # Add enable_ctk flag for warm migrations
@@ -910,6 +918,8 @@ def prepared_plan(
                 session_uuid=fixture_store["session_uuid"],
                 clone_options=clone_options,
             )
+            if has_shared_disk_config:
+                cloned_vm_objects.append(provider_vm_api)
 
             # Power state control: "on" = start VM, "off" = stop VM, not set = leave unchanged
             source_vm_power = vm.get("source_vm_power")  # Optional - if not set, VM power state unchanged
@@ -944,6 +954,15 @@ def prepared_plan(
             vm["snapshots_before_migration"] = source_vm_details["snapshots_data"]
             # Store complete source VM data separately (keeps virtual_machines clean for Plan CR serialization)
             plan["source_vms_data"][vm["name"]] = source_vm_details
+
+        # Relink shared disks between clones (VMware-specific)
+        # When VMs with shared disks are cloned, each clone gets independent disk copies,
+        # breaking the shared disk relationship. This restores it on the clones.
+        if has_shared_disk_config and hasattr(source_provider, "relink_shared_disks"):
+            source_provider.relink_shared_disks(
+                source_vm_names=original_source_vm_names,
+                cloned_vms=cloned_vm_objects,
+            )
 
     # Create Hooks if configured
     create_hook_if_configured(plan, "pre_hook", "pre", fixture_store, ocp_admin_client, target_namespace)

--- a/conftest.py
+++ b/conftest.py
@@ -958,7 +958,12 @@ def prepared_plan(
         # Relink shared disks between clones (VMware-specific)
         # When VMs with shared disks are cloned, each clone gets independent disk copies,
         # breaking the shared disk relationship. This restores it on the clones.
-        if has_shared_disk_config and hasattr(source_provider, "relink_shared_disks"):
+        if has_shared_disk_config:
+            if not hasattr(source_provider, "relink_shared_disks"):
+                raise ValueError(
+                    f"Shared-disk migration requested, but provider '{source_provider.type}' "
+                    "does not implement relink_shared_disks"
+                )
             source_provider.relink_shared_disks(
                 source_vm_names=original_source_vm_names,
                 cloned_vms=cloned_vm_objects,

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -1320,6 +1320,161 @@ class VMWareProvider(BaseProvider):
 
         return res
 
+    def _find_disk_by_scsi_position(
+        self,
+        vm: vim.VirtualMachine,
+        bus_number: int,
+        unit_number: int,
+    ) -> vim.vm.device.VirtualDisk | None:
+        """Find a VirtualDisk on a VM by its SCSI bus and unit number.
+
+        Args:
+            vm: The VM to search.
+            bus_number: SCSI bus number (e.g., 0, 1).
+            unit_number: SCSI unit number (e.g., 0, 1).
+
+        Returns:
+            The matching disk, or None if not found.
+        """
+        controller_keys_by_bus: dict[int, int] = {}
+        for device in vm.config.hardware.device:
+            if isinstance(device, vim.vm.device.VirtualSCSIController):
+                controller_keys_by_bus[device.busNumber] = device.key
+
+        target_controller_key = controller_keys_by_bus.get(bus_number)
+        if target_controller_key is None:
+            return None
+
+        for device in vm.config.hardware.device:
+            if (
+                isinstance(device, vim.vm.device.VirtualDisk)
+                and device.controllerKey == target_controller_key
+                and device.unitNumber == unit_number
+            ):
+                return device
+
+        return None
+
+    def relink_shared_disks(
+        self,
+        source_vm_names: list[str],
+        cloned_vms: list[vim.VirtualMachine],
+    ) -> None:
+        """Reconfigure cloned VMs to preserve shared disk relationships from source VMs.
+
+        When VMs with shared disks are cloned, VMware creates independent copies of all disks,
+        breaking the shared disk relationship. This method identifies shared disks between source
+        VMs (same backing VMDK file) and reconfigures the clones so they share a single VMDK copy.
+
+        The first clone keeps its independent copy (owner). Subsequent clones are reconfigured
+        to point to the owner clone's VMDK.
+
+        Args:
+            source_vm_names: Original source/template VM names (before cloning).
+            cloned_vms: Cloned VM objects, in the same order as source_vm_names.
+
+        Raises:
+            ValueError: If source_vm_names and cloned_vms have different lengths.
+        """
+        if len(source_vm_names) != len(cloned_vms):
+            raise ValueError(
+                f"source_vm_names ({len(source_vm_names)}) and cloned_vms ({len(cloned_vms)}) must have same length"
+            )
+
+        if len(source_vm_names) < 2:
+            LOGGER.debug("Only one VM, no shared disk relinking needed")
+            return
+
+        # Get source VMs and map their disk backing files to SCSI positions
+        source_vms = [self.get_obj([vim.VirtualMachine], name) for name in source_vm_names]
+
+        # Build: vmdk_path -> [(vm_index, bus_number, unit_number)]
+        vmdk_positions: dict[str, list[tuple[int, int, int]]] = {}
+
+        for vm_idx, source_vm in enumerate(source_vms):
+            for device in source_vm.config.hardware.device:
+                if not isinstance(device, vim.vm.device.VirtualDisk):
+                    continue
+                if not hasattr(device.backing, "fileName"):
+                    continue
+
+                vmdk_path = device.backing.fileName
+
+                # Find SCSI bus number for this disk's controller
+                bus_number = None
+                for ctrl in source_vm.config.hardware.device:
+                    if isinstance(ctrl, vim.vm.device.VirtualSCSIController) and ctrl.key == device.controllerKey:
+                        bus_number = ctrl.busNumber
+                        break
+
+                if bus_number is None:
+                    continue
+
+                vmdk_positions.setdefault(vmdk_path, []).append((vm_idx, bus_number, device.unitNumber))
+
+        # Find VMDKs shared across multiple source VMs (same file used by different VMs)
+        # Use set comprehension {vm_idx...} to count UNIQUE VMs (a disk might appear
+        # multiple times on the same VM, but that's not "shared between VMs")
+        shared_vmdks = {
+            path: positions
+            for path, positions in vmdk_positions.items()
+            if len({vm_idx for vm_idx, _, _ in positions}) > 1
+        }
+
+        if not shared_vmdks:
+            LOGGER.info("No shared disks detected between source VMs, skipping relink")
+            return
+
+        LOGGER.info(f"Found {len(shared_vmdks)} shared disk(s) between source VMs")
+
+        for shared_vmdk_path, positions in shared_vmdks.items():
+            LOGGER.info(f"Processing shared VMDK: {shared_vmdk_path}")
+
+            # First VM's clone is the owner (keeps its independent disk copy)
+            owner_idx, owner_bus, owner_unit = positions[0]
+            owner_clone = cloned_vms[owner_idx]
+
+            owner_disk = self._find_disk_by_scsi_position(owner_clone, owner_bus, owner_unit)
+            if not owner_disk:
+                LOGGER.warning(
+                    f"Could not find shared disk on owner clone '{owner_clone.name}' "
+                    f"at SCSI({owner_bus}:{owner_unit}), skipping"
+                )
+                continue
+
+            owner_vmdk = owner_disk.backing.fileName
+            LOGGER.info(f"Owner clone '{owner_clone.name}' shared disk VMDK: {owner_vmdk}")
+
+            # Reconfigure consumer clones to point to the owner's VMDK
+            for consumer_idx, consumer_bus, consumer_unit in positions[1:]:
+                consumer_clone = cloned_vms[consumer_idx]
+
+                consumer_disk = self._find_disk_by_scsi_position(consumer_clone, consumer_bus, consumer_unit)
+                if not consumer_disk:
+                    LOGGER.warning(
+                        f"Could not find shared disk on consumer clone '{consumer_clone.name}' "
+                        f"at SCSI({consumer_bus}:{consumer_unit}), skipping"
+                    )
+                    continue
+
+                old_vmdk = consumer_disk.backing.fileName
+                LOGGER.info(f"Relinking '{consumer_clone.name}' shared disk: {old_vmdk} -> {owner_vmdk}")
+
+                disk_spec = vim.vm.device.VirtualDeviceSpec()
+                disk_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+                disk_spec.device = consumer_disk
+                disk_spec.device.backing.fileName = owner_vmdk
+
+                config_spec = vim.vm.ConfigSpec()
+                config_spec.deviceChange = [disk_spec]
+
+                task = consumer_clone.ReconfigVM_Task(spec=config_spec)
+                self.wait_task(
+                    task=task,
+                    action_name=f"Relinking shared disk on '{consumer_clone.name}'",
+                )
+                LOGGER.info(f"Successfully relinked shared disk on '{consumer_clone.name}'")
+
     def delete_vm(self, vm_name: str) -> None:
         vm = self.get_obj(vimtype=[vim.VirtualMachine], name=vm_name)
         self.stop_vm(vm=vm)

--- a/tests/test_mtv_cold_migration.py
+++ b/tests/test_mtv_cold_migration.py
@@ -279,3 +279,5 @@ class TestColdRemoteOcp:
             source_provider_inventory=source_provider_inventory,
             vm_ssh_connections=vm_ssh_connections,
         )
+
+

--- a/tests/test_mtv_cold_migration.py
+++ b/tests/test_mtv_cold_migration.py
@@ -279,5 +279,3 @@ class TestColdRemoteOcp:
             source_provider_inventory=source_provider_inventory,
             vm_ssh_connections=vm_ssh_connections,
         )
-
-

--- a/tests/test_shared_disk_migration.py
+++ b/tests/test_shared_disk_migration.py
@@ -1,0 +1,239 @@
+"""Shared disk migration tests (MTV-4548).
+
+Tests for migrating VMs with shared disks using the migrateSharedDisks flag.
+The owner VM (migrateSharedDisks=true) migrates the shared disk PVC, while
+the consumer VM (migrateSharedDisks=false) reuses the existing PVC.
+"""
+
+import pytest
+from ocp_resources.network_map import NetworkMap
+from ocp_resources.plan import Plan
+from ocp_resources.storage_map import StorageMap
+from pytest_testconfig import config as py_config
+
+from utilities.mtv_migration import (
+    create_plan_resource,
+    execute_migration,
+    get_network_migration_map,
+    get_storage_migration_map,
+)
+from utilities.post_migration import check_vms
+from utilities.shared_disk import verify_pvc_count_for_vm, verify_shared_disk_data
+from utilities.utils import populate_vm_ids
+
+
+@pytest.mark.incremental
+@pytest.mark.parametrize(
+    "class_plan_config",
+    [
+        pytest.param(
+            py_config["tests_params"]["test_shared_disk_migration"],
+        )
+    ],
+    indirect=True,
+    ids=["shared-disk"],
+)
+@pytest.mark.usefixtures("cleanup_migrated_vms")
+class TestSharedDiskMigration:
+    """MTV-4548: Verify migration with shared disks (migrateSharedDisks: false)."""
+
+    storage_map: StorageMap
+    network_map: NetworkMap
+    plan_resource_vm1: Plan
+    plan_resource_vm2: Plan
+
+    def test_create_storagemap(
+        self,
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        destination_provider,
+        source_provider_inventory,
+        target_namespace,
+    ):
+        """Create StorageMap resource for both VMs."""
+        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.storage_map = get_storage_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            vms=vms,
+        )
+        assert self.storage_map, "StorageMap creation failed"
+
+    def test_create_networkmap(
+        self,
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        destination_provider,
+        source_provider_inventory,
+        target_namespace,
+        multus_network_name,
+    ):
+        """Create NetworkMap resource for both VMs."""
+        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.network_map = get_network_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            multus_network_name=multus_network_name,
+            vms=vms,
+        )
+        assert self.network_map, "NetworkMap creation failed"
+
+    def test_create_plan_vm1(
+        self,
+        prepared_plan_1,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        destination_provider,
+        target_namespace,
+        source_provider_inventory,
+    ):
+        """Create MTV Plan CR resource for VM1 (migrateSharedDisks=true)."""
+        populate_vm_ids(prepared_plan_1, source_provider_inventory)
+        migrate_shared_disks = prepared_plan_1["virtual_machines"][0].get("migrate_shared_disks")
+
+        self.__class__.plan_resource_vm1 = create_plan_resource(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            storage_map=self.storage_map,
+            network_map=self.network_map,
+            virtual_machines_list=prepared_plan_1["virtual_machines"],
+            target_namespace=target_namespace,
+            warm_migration=prepared_plan_1.get("warm_migration", False),
+            migrate_shared_disks=migrate_shared_disks,
+            target_power_state=prepared_plan_1.get("target_power_state"),
+        )
+        assert self.plan_resource_vm1, "Plan creation for VM1 failed"
+
+    def test_migrate_vm1(
+        self,
+        fixture_store,
+        ocp_admin_client,
+        target_namespace,
+    ):
+        """Execute migration for VM1."""
+        execute_migration(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            plan=self.plan_resource_vm1,
+            target_namespace=target_namespace,
+        )
+
+    def test_create_plan_vm2(
+        self,
+        prepared_plan_2,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        destination_provider,
+        target_namespace,
+        source_provider_inventory,
+    ):
+        """Create MTV Plan CR resource for VM2 (migrateSharedDisks=false)."""
+        populate_vm_ids(prepared_plan_2, source_provider_inventory)
+        migrate_shared_disks = prepared_plan_2["virtual_machines"][0].get("migrate_shared_disks")
+
+        self.__class__.plan_resource_vm2 = create_plan_resource(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            storage_map=self.storage_map,
+            network_map=self.network_map,
+            virtual_machines_list=prepared_plan_2["virtual_machines"],
+            target_namespace=target_namespace,
+            warm_migration=prepared_plan_2.get("warm_migration", False),
+            migrate_shared_disks=migrate_shared_disks,
+            target_power_state=prepared_plan_2.get("target_power_state"),
+        )
+        assert self.plan_resource_vm2, "Plan creation for VM2 failed"
+
+    def test_migrate_vm2(
+        self,
+        fixture_store,
+        ocp_admin_client,
+        target_namespace,
+    ):
+        """Execute migration for VM2."""
+        execute_migration(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            plan=self.plan_resource_vm2,
+            target_namespace=target_namespace,
+        )
+
+    def test_verify_pvc_count(
+        self,
+        prepared_plan,
+        ocp_admin_client,
+        target_namespace,
+    ):
+        """Verify VM2 has only 2 PVCs (no duplicate shared disk PVC)."""
+        expected_pvc_count = prepared_plan["expected_pvc_count_vm2"]
+        verify_pvc_count_for_vm(
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            plan_name=self.plan_resource_vm2.name,
+            expected_pvc_count=expected_pvc_count,
+        )
+
+    def test_verify_shared_disk_data(
+        self,
+        prepared_plan,
+        vm_ssh_connections,
+        source_provider_data,
+    ):
+        """Verify shared disk read/write access from both VMs."""
+        vm1_name = prepared_plan["virtual_machines"][0]["name"]
+        vm2_name = prepared_plan["virtual_machines"][1]["name"]
+        shared_disk_device = prepared_plan["shared_disk_device"]
+        vm1_info = prepared_plan["source_vms_data"][vm1_name]
+        vm2_info = prepared_plan["source_vms_data"][vm2_name]
+
+        verify_shared_disk_data(
+            vm1_name=vm1_name,
+            vm2_name=vm2_name,
+            vm_ssh_connections=vm_ssh_connections,
+            source_provider_data=source_provider_data,
+            vm1_info=vm1_info,
+            vm2_info=vm2_info,
+            shared_disk_device=shared_disk_device,
+        )
+
+    def test_check_vms(
+        self,
+        prepared_plan,
+        source_provider,
+        destination_provider,
+        source_provider_data,
+        target_namespace,
+        source_vms_namespace,
+        source_provider_inventory,
+        vm_ssh_connections,
+    ):
+        """Validate both migrated VMs."""
+        check_vms(
+            plan=prepared_plan,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            network_map_resource=self.network_map,
+            storage_map_resource=self.storage_map,
+            source_provider_data=source_provider_data,
+            source_vms_namespace=source_vms_namespace,
+            source_provider_inventory=source_provider_inventory,
+            vm_ssh_connections=vm_ssh_connections,
+        )

--- a/tests/test_shared_disk_migration.py
+++ b/tests/test_shared_disk_migration.py
@@ -1,4 +1,4 @@
-"""Shared disk migration tests (MTV-4548).
+"""Shared disk migration tests (MTV-454).
 
 Tests for migrating VMs with shared disks using the migrateSharedDisks flag.
 The owner VM (migrateSharedDisks=true) migrates the shared disk PVC, while
@@ -35,7 +35,7 @@ from utilities.utils import populate_vm_ids
 )
 @pytest.mark.usefixtures("cleanup_migrated_vms")
 class TestSharedDiskMigration:
-    """MTV-4548: Verify migration with shared disks (migrateSharedDisks: false)."""
+    """MTV-454: Verify migration with shared disks (owner and consumer VMs)."""
 
     storage_map: StorageMap
     network_map: NetworkMap
@@ -220,7 +220,6 @@ class TestSharedDiskMigration:
         source_provider,
         destination_provider,
         source_provider_data,
-        target_namespace,
         source_vms_namespace,
         source_provider_inventory,
         vm_ssh_connections,

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -514,6 +514,28 @@ tests_params: dict = {
         "post_hook": {"expected_result": "fail"},
         "expected_migration_result": "fail",
     },
+    "test_shared_disk_migration": {
+        "virtual_machines": [
+            {
+                "name": "mtv-feature-shared-rhel1",
+                "source_vm_power": "off",
+                "guest_agent": True,
+                "migrate_shared_disks": True,
+                "target_power_state": "on",
+            },
+            {
+                "name": "mtv-feature-shared-rhel2",
+                "source_vm_power": "off",
+                "guest_agent": True,
+                "migrate_shared_disks": False,
+                "target_power_state": "on",
+            },
+        ],
+        "warm_migration": False,
+        "shared_disk_device": "/dev/vdc",
+        "expected_pvc_count_vm2": 2,
+        "target_power_state": "on",
+    },
 }
 
 for _dir in dir():

--- a/utilities/mtv_migration.py
+++ b/utilities/mtv_migration.py
@@ -151,6 +151,7 @@ def create_plan_resource(
     target_labels: dict[str, str] | None = None,
     target_affinity: dict[str, Any] | None = None,
     vm_target_namespace: str | None = None,
+    migrate_shared_disks: bool | None = None,
     target_power_state: str | None = None,
 ) -> Plan:
     """Create MTV Plan CR resource.
@@ -182,6 +183,7 @@ def create_plan_resource(
         target_labels (dict[str, str] | None): Optional custom labels to apply to migrated VM metadata. Defaults to None.
         target_affinity (dict[str, Any] | None): Optional Kubernetes pod affinity/anti-affinity configuration. Defaults to None.
         vm_target_namespace (str | None): Custom target namespace for VMs. Defaults to None.
+        migrate_shared_disks (bool | None): Whether to migrate shared disks. True for owner VM (creates PVC), False for consumer VM (reuses PVC). Defaults to None (omits field).
         target_power_state (str | None): Target power state for VMs after migration (e.g., 'on', 'off'). Defaults to None.
 
     Returns:
@@ -234,6 +236,9 @@ def create_plan_resource(
 
     if target_affinity:
         plan_kwargs["target_affinity"] = target_affinity
+
+    if migrate_shared_disks is not None:
+        plan_kwargs["migrate_shared_disks"] = migrate_shared_disks
 
     # Add copy-offload specific parameters if enabled
     if copyoffload:

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -146,7 +146,7 @@ def verify_pvc_count_for_vm(
     """
     LOGGER.info(f"Verifying PVC count for plan '{plan_name}' in namespace '{target_namespace}'.")
 
-    all_pvcs = list(PersistentVolumeClaim.get(dyn_client=ocp_admin_client, namespace=target_namespace))
+    all_pvcs = list(PersistentVolumeClaim.get(client=ocp_admin_client, namespace=target_namespace))
     plan_pvcs = [pvc for pvc in all_pvcs if plan_name in pvc.name]
 
     actual_count = len(plan_pvcs)

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -1,0 +1,159 @@
+"""Shared disk migration utilities.
+
+This module provides utilities for testing and validating shared disk migrations (MTV-4548).
+Includes functions for verifying shared disk accessibility between VMs and PVC count validation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
+from pyhelper_utils.shell import run_ssh_commands
+from simple_logger.logger import get_logger
+
+from utilities.post_migration import get_ssh_credentials_from_provider_config
+from utilities.ssh_utils import SSHConnectionManager
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+LOGGER = get_logger(name=__name__)
+
+
+def verify_shared_disk_data(
+    vm1_name: str,
+    vm2_name: str,
+    vm_ssh_connections: SSHConnectionManager,
+    source_provider_data: dict[str, Any],
+    vm1_info: dict[str, Any],
+    vm2_info: dict[str, Any],
+    shared_disk_device: str = "/dev/vdc",
+) -> None:
+    """Verify shared disk is accessible from both VMs by writing/reading data.
+
+    NOTE: This test assumes the shared disk is already formatted with a filesystem
+    and is unmounted (due to MTV-2200 limitation - virt-v2v cannot update fstab for
+    shared disks, causing boot failure if mounted).
+
+    Args:
+        vm1_name (str): Name of the first VM (owner).
+        vm2_name (str): Name of the second VM (consumer).
+        vm_ssh_connections (SSHConnectionManager): SSH connection manager.
+        source_provider_data (dict[str, Any]): Provider configuration from .providers.json.
+        vm1_info (dict[str, Any]): VM1 information including OS type.
+        vm2_info (dict[str, Any]): VM2 information including OS type.
+        shared_disk_device (str): Shared disk device path. Defaults to "/dev/vdc".
+
+    Raises:
+        AssertionError: If shared disk data verification fails.
+    """
+    LOGGER.info(f"Verifying shared disk between {vm1_name} and {vm2_name}")
+
+    vm1_user, vm1_pass = get_ssh_credentials_from_provider_config(source_provider_data, vm1_info)
+    vm2_user, vm2_pass = get_ssh_credentials_from_provider_config(source_provider_data, vm2_info)
+
+    ssh_vm1 = vm_ssh_connections.create(vm_name=vm1_name, username=vm1_user, password=vm1_pass)
+    ssh_vm2 = vm_ssh_connections.create(vm_name=vm2_name, username=vm2_user, password=vm2_pass)
+
+    mount_point = "/mnt/shared_disk"
+    partition = f"{shared_disk_device}1"
+    test_file_vm1 = f"{mount_point}/test-vm1.txt"
+    test_file_vm2 = f"{mount_point}/test-vm2.txt"
+
+    # VM1: Mount shared disk and write test data
+    LOGGER.info(f"VM1: Mounting shared disk {partition}")
+    with ssh_vm1:
+        run_ssh_commands(ssh_vm1.rrmngmnt_host, ["sudo", "mkdir", "-p", mount_point])
+        run_ssh_commands(ssh_vm1.rrmngmnt_host, ["sudo", "mount", partition, mount_point])
+
+        # Write test data from VM1
+        # Note: Using 'tee' instead of shell redirect (>) to avoid quoting issues over SSH.
+        # Shell redirect can fail silently due to permission and escaping problems.
+        LOGGER.info("VM1: Writing test data")
+        run_ssh_commands(ssh_vm1.rrmngmnt_host, ["sh", "-c", f"echo 'Data from VM1' | sudo tee {test_file_vm1} > /dev/null"])
+        run_ssh_commands(ssh_vm1.rrmngmnt_host, ["sudo", "sync"])
+
+    # VM2: Mount shared disk and verify VM1's data
+    LOGGER.info(f"VM2: Mounting shared disk {partition}")
+    with ssh_vm2:
+        run_ssh_commands(ssh_vm2.rrmngmnt_host, ["sudo", "mkdir", "-p", mount_point])
+        run_ssh_commands(ssh_vm2.rrmngmnt_host, ["sudo", "mount", partition, mount_point])
+
+        # Verify VM2 can read VM1's data
+        LOGGER.info("VM2: Reading VM1's test data")
+        results = run_ssh_commands(ssh_vm2.rrmngmnt_host, ["sudo", "cat", test_file_vm1])
+        vm2_read_data = results[0].strip()
+        assert "Data from VM1" in vm2_read_data, f"VM2 cannot read VM1's data: {vm2_read_data}"
+        LOGGER.info("VM2: Successfully read VM1's data")
+
+        # Write test data from VM2
+        LOGGER.info("VM2: Writing test data")
+        run_ssh_commands(ssh_vm2.rrmngmnt_host, ["sh", "-c", f"echo 'Data from VM2' | sudo tee {test_file_vm2} > /dev/null"])
+        run_ssh_commands(ssh_vm2.rrmngmnt_host, ["sudo", "sync"])
+
+        # Unmount to prevent concurrent access when VM1 remounts
+        run_ssh_commands(ssh_vm2.rrmngmnt_host, ["sudo", "umount", mount_point])
+
+    # VM1: Verify can read VM2's data (bidirectional access)
+    LOGGER.info("VM1: Verifying bidirectional access")
+    with ssh_vm1:
+        # Unmount stale mount from first session
+        run_ssh_commands(ssh_vm1.rrmngmnt_host, ["sudo", "umount", mount_point])
+
+        # Flush block device buffers to clear stale kernel cache
+        # XFS (non-cluster filesystem) retains metadata in kernel buffer cache.
+        # Without this, VM1 won't see VM2's newly written files even after remount.
+        run_ssh_commands(ssh_vm1.rrmngmnt_host, ["sudo", "blockdev", "--flushbufs", shared_disk_device])
+
+        # Remount fresh to see VM2's changes
+        run_ssh_commands(ssh_vm1.rrmngmnt_host, ["sudo", "mount", partition, mount_point])
+
+        results = run_ssh_commands(ssh_vm1.rrmngmnt_host, ["sudo", "cat", test_file_vm2])
+        vm1_read_data = results[0].strip()
+        assert "Data from VM2" in vm1_read_data, f"VM1 cannot read VM2's data: {vm1_read_data}"
+        LOGGER.info("VM1: Successfully read VM2's data")
+
+        # Cleanup: Unmount from VM1
+        run_ssh_commands(ssh_vm1.rrmngmnt_host, ["sudo", "umount", mount_point])
+
+    LOGGER.info("Shared disk verification successful - bidirectional access confirmed")
+
+
+def verify_pvc_count_for_vm(
+    ocp_admin_client: DynamicClient,
+    target_namespace: str,
+    plan_name: str,
+    expected_pvc_count: int,
+) -> None:
+    """Verify the number of PVCs created for a migration plan.
+
+    Used for shared disk testing: the consumer VM plan should create fewer PVCs
+    because it reuses the shared disk PVC from the owner VM plan.
+
+    Args:
+        ocp_admin_client (DynamicClient): OpenShift admin client.
+        target_namespace (str): Namespace where PVCs were created.
+        plan_name (str): Plan name to filter PVCs by (matched as substring of PVC name).
+        expected_pvc_count (int): Expected number of PVCs.
+
+    Raises:
+        AssertionError: If actual PVC count doesn't match expected count.
+    """
+    LOGGER.info(f"Verifying PVC count for plan '{plan_name}' in namespace '{target_namespace}'.")
+
+    all_pvcs = list(PersistentVolumeClaim.get(dyn_client=ocp_admin_client, namespace=target_namespace))
+    plan_pvcs = [pvc for pvc in all_pvcs if plan_name in pvc.name]
+
+    actual_count = len(plan_pvcs)
+    LOGGER.info(f"Found {actual_count} PVCs for plan '{plan_name}'. Expected: {expected_pvc_count}")
+
+    if actual_count != expected_pvc_count:
+        pvc_names = [pvc.name for pvc in plan_pvcs]
+        LOGGER.error(f"PVC count mismatch. Found PVCs: {pvc_names}")
+
+    assert actual_count == expected_pvc_count, (
+        f"Expected {expected_pvc_count} PVCs for plan '{plan_name}', but found {actual_count}"
+    )
+
+    LOGGER.info(f"Successfully verified {expected_pvc_count} PVCs for plan '{plan_name}'.")

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -71,7 +71,9 @@ def verify_shared_disk_data(
         # Note: Using 'tee' instead of shell redirect (>) to avoid quoting issues over SSH.
         # Shell redirect can fail silently due to permission and escaping problems.
         LOGGER.info("VM1: Writing test data")
-        run_ssh_commands(ssh_vm1.rrmngmnt_host, ["sh", "-c", f"echo 'Data from VM1' | sudo tee {test_file_vm1} > /dev/null"])
+        run_ssh_commands(
+            ssh_vm1.rrmngmnt_host, ["sh", "-c", f"echo 'Data from VM1' | sudo tee {test_file_vm1} > /dev/null"]
+        )
         run_ssh_commands(ssh_vm1.rrmngmnt_host, ["sudo", "sync"])
 
     # VM2: Mount shared disk and verify VM1's data
@@ -89,7 +91,9 @@ def verify_shared_disk_data(
 
         # Write test data from VM2
         LOGGER.info("VM2: Writing test data")
-        run_ssh_commands(ssh_vm2.rrmngmnt_host, ["sh", "-c", f"echo 'Data from VM2' | sudo tee {test_file_vm2} > /dev/null"])
+        run_ssh_commands(
+            ssh_vm2.rrmngmnt_host, ["sh", "-c", f"echo 'Data from VM2' | sudo tee {test_file_vm2} > /dev/null"]
+        )
         run_ssh_commands(ssh_vm2.rrmngmnt_host, ["sudo", "sync"])
 
         # Unmount to prevent concurrent access when VM1 remounts

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -1,6 +1,6 @@
 """Shared disk migration utilities.
 
-This module provides utilities for testing and validating shared disk migrations (MTV-4548).
+This module provides utilities for testing and validating shared disk migrations (MTV-454).
 Includes functions for verifying shared disk accessibility between VMs and PVC count validation.
 """
 

--- a/utilities/ssh_utils.py
+++ b/utilities/ssh_utils.py
@@ -246,6 +246,9 @@ class VMSSHConnection:
         self.rrmngmnt_host.users.append(user)
         self.rrmngmnt_user = user
 
+        # CRITICAL: Set port on the executor factory so ALL executors use the port-forward port
+        self.rrmngmnt_host.executor_factory.port = self.local_port
+
         connected = False
         try:
             executor = self.rrmngmnt_host.executor(user=user)

--- a/utilities/ssh_utils.py
+++ b/utilities/ssh_utils.py
@@ -246,7 +246,9 @@ class VMSSHConnection:
         self.rrmngmnt_host.users.append(user)
         self.rrmngmnt_user = user
 
-        # CRITICAL: Set port on the executor factory so ALL executors use the port-forward port
+        # CRITICAL: Set port on the executor factory so ALL executors use the port-forward port.
+        # Without this, run_ssh_commands() creates new executors that try to connect to port 22
+        # instead of the port-forward port, causing connection failures.
         self.rrmngmnt_host.executor_factory.port = self.local_port
 
         connected = False

--- a/utilities/virtctl.py
+++ b/utilities/virtctl.py
@@ -46,7 +46,9 @@ def _check_existing_virtctl(download_dir: Path) -> Path | None:
                 LOGGER.info(f"Symlink already exists at {virtctl_binary}")
                 return virtctl_binary
             # File exists but is not executable (corrupted/partial download)
-            LOGGER.warning(f"virtctl binary exists at {virtctl_binary} but is not executable. Will download from cluster instead.")
+            LOGGER.warning(
+                f"virtctl binary exists at {virtctl_binary} but is not executable. Will download from cluster instead."
+            )
             return None
         except Exception as e:
             LOGGER.warning(f"Failed to create symlink for virtctl: {e}. Will download from cluster instead.")

--- a/utilities/virtctl.py
+++ b/utilities/virtctl.py
@@ -35,7 +35,8 @@ def _check_existing_virtctl(download_dir: Path) -> Path | None:
     if existing_virtctl:
         LOGGER.info(f"virtctl found in PATH at {existing_virtctl}, creating symlink in {download_dir}")
         try:
-            # Create symlink in download_dir for pytest-xdist workers to share
+            # Create symlink in download_dir so pytest-xdist workers can find it.
+            # Workers don't share PATH but do share the download_dir via pytest-shared temp directory.
             virtctl_binary.symlink_to(existing_virtctl)
             LOGGER.info(f"Created symlink: {virtctl_binary} -> {existing_virtctl}")
             return virtctl_binary

--- a/utilities/virtctl.py
+++ b/utilities/virtctl.py
@@ -45,7 +45,9 @@ def _check_existing_virtctl(download_dir: Path) -> Path | None:
             if virtctl_binary.exists() and os.access(virtctl_binary, os.X_OK):
                 LOGGER.info(f"Symlink already exists at {virtctl_binary}")
                 return virtctl_binary
-            raise
+            # File exists but is not executable (corrupted/partial download)
+            LOGGER.warning(f"virtctl binary exists at {virtctl_binary} but is not executable. Will download from cluster instead.")
+            return None
         except Exception as e:
             LOGGER.warning(f"Failed to create symlink for virtctl: {e}. Will download from cluster instead.")
             return None

--- a/utilities/virtctl.py
+++ b/utilities/virtctl.py
@@ -21,19 +21,33 @@ def _check_existing_virtctl(download_dir: Path) -> Path | None:
         download_dir: Directory where virtctl might be downloaded
 
     Returns:
-        Path to existing virtctl binary, or None if not found
+        Path to virtctl in download_dir (may be symlink), or None if not found
     """
-    # Check if virtctl is in PATH
-    existing_virtctl = shutil.which("virtctl")
-    if existing_virtctl:
-        LOGGER.info(f"virtctl already available in PATH at {existing_virtctl}")
-        return Path(existing_virtctl)
-
-    # Check if previously downloaded
     virtctl_binary = download_dir / "virtctl"
+
+    # Check if already in download_dir
     if virtctl_binary.exists() and os.access(virtctl_binary, os.X_OK):
         LOGGER.info(f"virtctl already exists at {virtctl_binary}")
         return virtctl_binary
+
+    # Check if virtctl is in PATH (from system installation)
+    existing_virtctl = shutil.which("virtctl")
+    if existing_virtctl:
+        LOGGER.info(f"virtctl found in PATH at {existing_virtctl}, creating symlink in {download_dir}")
+        try:
+            # Create symlink in download_dir for pytest-xdist workers to share
+            virtctl_binary.symlink_to(existing_virtctl)
+            LOGGER.info(f"Created symlink: {virtctl_binary} -> {existing_virtctl}")
+            return virtctl_binary
+        except FileExistsError:
+            # Race condition: another worker just created the symlink
+            if virtctl_binary.exists() and os.access(virtctl_binary, os.X_OK):
+                LOGGER.info(f"Symlink already exists at {virtctl_binary}")
+                return virtctl_binary
+            raise
+        except Exception as e:
+            LOGGER.warning(f"Failed to create symlink for virtctl: {e}. Will download from cluster instead.")
+            return None
 
     return None
 


### PR DESCRIPTION
Add support for Cold migrate RHEL VMs with shared disks ([MTV-454](https://polarion.engineering.redhat.com/polarion/#/project/MigrationToolkitVirt/workitem?id=MTV-454)).

  When multiple VMs share a disk in VMware, they need special handling during migration:
  - **Owner VM** (migrateSharedDisks=true): Migrates the shared disk and creates the PVC
  - **Consumer VM** (migrateSharedDisks=false): Reuses the existing PVC created by the owner

  ## Changes

  ### Core Features
  - Add VM cloning with shared disk relinking for VMware provider
  - Add `migrateSharedDisks` parameter to plan creation
  - Add shared disk verification utilities
  - Add comprehensive test suite for shared disk migration
  - Support `prepared_plan_1` and `prepared_plan_2` fixtures for multi-VM tests

  ### Bug Fixes
  - Fix SSH port-forward connection issue by setting port on executor factory
    - Without this fix, `run_ssh_commands()` creates executors that connect to port 22 instead of the port-forward port
  - Fix virtctl binary discovery to create symlinks for pytest-xdist workers
    - Workers don't share PATH but do share the download_dir

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VMware shared-disk relinking for cloned VMs (restores shared-disk relationships post-clone)
  * Plan parameter to enable/disable shared-disk migration per VM
  * Utilities to verify shared-disk data integrity and expected PVC counts after migration

* **Bug Fixes**
  * SSH port-forward propagation to avoid connection failures
  * Improved virtctl discovery to prefer local download directory and safely fall back to PATH

* **Tests**
  * End-to-end tests covering shared-disk migration, PVC counts, and data verification
<!-- end of auto-generated comment: release notes by coderabbit.ai -->