### PR TITLE
docs: add test method vs fixture guidance and fixture location rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -532,8 +532,8 @@ tests_params: dict = {
 
 ### conftest.py Structure
 
-Fixtures and hooks must be defined in `conftest.py` files, not in test files. Helper functions go to `utilities/`.
-Place fixtures in the `conftest.py` closest to the tests that use them.
+Only pytest fixtures and hooks belong in conftest.py. Helper functions go to `utilities/`.
+Place fixtures in the `conftest.py` closest to the tests that use them, never in test files.
 
 ### Fixture Scopes
 


### PR DESCRIPTION
## Summary

Add two CLAUDE.md rules to improve test organization guidance:

### Test Methods Must Be Tests (SHOULD)

Before adding a `test_` prefixed method, consider whether it belongs as a test or as a fixture/helper. If the method's sole purpose is a precondition for other tests and has no value as a standalone test step, it likely belongs in a fixture.

### Fixture Location

Fixtures must be defined in `conftest.py` files, not in test files. Place fixtures in the `conftest.py` closest to the tests that use them.

## Related

- #324 — refactor: organize tests into subdirectories for better structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Test Methods Must Be Tests (SHOULD)" guidance clarifying when test-prefixed methods belong in tests versus fixtures/helpers.
  * Repeated that guidance within the Distinction/Fixture Rules section for emphasis.
  * Clarified placement guidance: fixtures and hooks belong in conftest files (not test files) and should be placed in the conftest closest to the tests that use them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->