### PR TITLE
fix: make labeled_worker_node fixture parallel-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ Schedule VMs to specific labeled nodes.
 
 ```python
 "target_node_selector": {
-    "migration-workload": None,  # Auto-generated with session_uuid
+    "migration-workload": None,  # Exactly one label; None = auto-generated key & value with session_uuid
 }
 ```
 

--- a/conftest.py
+++ b/conftest.py
@@ -1140,7 +1140,7 @@ def labeled_worker_node(
         dict with keys: node_name, label_key, label_value
 
     Raises:
-        ValueError: If target_node_selector not in test config, contains more than one label,
+        ValueError: If target_node_selector not in test config, does not contain exactly one label,
             or no worker nodes found
     """
     try:


### PR DESCRIPTION
Append session UUID suffix to the label key when in auto-generated mode (config_value is None), so two parallel workers that select the same node no longer overwrite each other's label. Truncation now preserves the UUID suffix (the unique part) by shortening the base key instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Worker node labeling now auto-generates consistent, session-based labels when unset; qualified keys preserve their prefix while ensuring name length limits.
* **Bug Fixes**
  * Added validation to require exactly one target label, preventing ambiguous node selection and raising clear errors for multiple/missing labels.
* **Documentation**
  * Updated guidance: default label values may be auto-generated and are trimmed as needed to fit constraints; test-id removal noted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->