### PR TITLE
feat(tools): add macOS support to bm-dns-setup script

### DIFF
--- a/tools/bm-dns-setup.sh
+++ b/tools/bm-dns-setup.sh
@@ -150,6 +150,17 @@ run_disable() {
 
 # --- Main ---
 
+parse_options() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --domain)
+                [[ -n "${2:-}" ]] || die "--domain requires a value"
+                DOMAIN="$2"; shift 2 ;;
+            *) die "Unknown option: $1" ;;
+        esac
+    done
+}
+
 [[ $# -ge 1 ]] || { echo "$USAGE" >&2; exit 1; }
 
 ACTION="$1"
@@ -162,27 +173,13 @@ case "$ACTION" in
         [[ $# -ge 1 ]] || { echo "$USAGE" >&2; exit 1; }
         IP="$1"
         shift
-        while [[ $# -gt 0 ]]; do
-            case "$1" in
-                --domain)
-                    [[ -n "${2:-}" ]] || die "--domain requires a value"
-                    DOMAIN="$2"; shift 2 ;;
-                *) die "Unknown option: $1" ;;
-            esac
-        done
+        parse_options "$@"
         validate_ip "$IP"
         validate_domain "$DOMAIN"
         run_enable "$IP" "$DOMAIN"
         ;;
     disable)
-        while [[ $# -gt 0 ]]; do
-            case "$1" in
-                --domain)
-                    [[ -n "${2:-}" ]] || die "--domain requires a value"
-                    DOMAIN="$2"; shift 2 ;;
-                *) die "Unknown option: $1" ;;
-            esac
-        done
+        parse_options "$@"
         validate_domain "$DOMAIN"
         run_disable "$DOMAIN"
         ;;


### PR DESCRIPTION
Add macOS support to the bare-metal DNS setup script.
The script auto-detects the OS (`uname -s`) and uses `/etc/resolver` on macOS. 
Linux behavior is unchanged.
Tested on macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional domain parameter for customizable DNS enable/disable flows
  * Input validation for IPs and domains to prevent misconfiguration
  * Platform-specific handling for Linux and macOS with OS-aware dispatch and clear unsupported-OS messaging
  * Improved interface detection by domain for accurate network targeting
  * Centralized command flow for consistent enable/disable handling

* **Documentation**
  * Updated help/usage to include the new domain option and related error guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->