### PR TITLE
fix: parallel execution safety and test reliability improvements

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -606,9 +606,16 @@ def virtctl_binary(ocp_admin_client: "DynamicClient") -> Path:
 
 
 @pytest.fixture(scope="session")
-def precopy_interval_forkliftcontroller(ocp_admin_client, mtv_namespace):
-    """
-    Set the snapshots interval in the forklift-controller ForkliftController
+def precopy_interval_forkliftcontroller(
+    ocp_admin_client: "DynamicClient",
+    mtv_namespace: str,
+) -> Generator[None, None, None]:
+    """Set the precopy interval in ForkliftController if not already configured.
+
+    Uses check-and-set without ResourceEditor context manager to avoid
+    restoring the original value on session teardown. This prevents race
+    conditions during parallel execution where one worker's teardown would
+    clobber the precopy interval for other workers still running warm migrations.
     """
     forklift_controller = ForkliftController(
         client=ocp_admin_client,
@@ -617,33 +624,37 @@ def precopy_interval_forkliftcontroller(ocp_admin_client, mtv_namespace):
         ensure_exists=True,
     )
 
-    snapshots_interval = py_config["snapshots_interval"]
+    snapshots_interval = str(py_config["snapshots_interval"])
+
     forklift_controller.wait_for_condition(
         status=forklift_controller.Condition.Status.TRUE,
         condition=forklift_controller.Condition.Type.RUNNING,
         timeout=300,
     )
 
+    current_interval = getattr(forklift_controller.instance.spec, "controller_precopy_interval", None)
+
+    if str(current_interval) == snapshots_interval:
+        LOGGER.info(
+            f"ForkliftController controller_precopy_interval already set to {snapshots_interval}, skipping update"
+        )
+        yield
+        return
+
     LOGGER.info(
-        f"Updating forklift-controller ForkliftController CR with snapshots interval={snapshots_interval} seconds"
+        f"Setting ForkliftController controller_precopy_interval from {current_interval!r} to {snapshots_interval}"
+    )
+    ResourceEditor(patches={forklift_controller: {"spec": {"controller_precopy_interval": snapshots_interval}}}).update(
+        backup_resources=False
     )
 
-    with ResourceEditor(
-        patches={
-            forklift_controller: {
-                "spec": {
-                    "controller_precopy_interval": str(snapshots_interval),
-                }
-            }
-        }
-    ):
-        forklift_controller.wait_for_condition(
-            status=forklift_controller.Condition.Status.TRUE,
-            condition=forklift_controller.Condition.Type.SUCCESSFUL,
-            timeout=300,
-        )
+    forklift_controller.wait_for_condition(
+        status=forklift_controller.Condition.Status.TRUE,
+        condition=forklift_controller.Condition.Type.SUCCESSFUL,
+        timeout=300,
+    )
 
-        yield
+    yield
 
 
 @pytest.fixture(scope="session")

--- a/conftest.py
+++ b/conftest.py
@@ -1069,7 +1069,9 @@ def prepared_plan(
                 source_provider.start_vm(provider_vm_api)
                 # Wait for guest info to become available (VMware only)
                 if source_provider.type == Provider.ProviderType.VSPHERE:
-                    source_provider.wait_for_vmware_guest_info(provider_vm_api, timeout=120)
+                    source_provider.wait_for_vmware_guest_info(
+                        provider_vm_api, timeout=class_plan_config.get("guest_agent_timeout", 120)
+                    )
             elif source_vm_power == "off":
                 source_provider.stop_vm(provider_vm_api)
 

--- a/conftest.py
+++ b/conftest.py
@@ -816,7 +816,7 @@ def multus_network_name(
     Returns:
         dict[str, str]: Dictionary with "name" (base name) and "namespace" (NAD namespace)
     """
-    hash_prefix = generate_class_hash_prefix(request.node.nodeid)
+    hash_prefix = generate_class_hash_prefix(request.node.nodeid, session_uuid=fixture_store["session_uuid"])
     base_name = f"cb-{hash_prefix}"
 
     class_name = request.node.cls.__name__ if request.node.cls else request.node.name
@@ -1028,7 +1028,7 @@ def prepared_plan(
 
         if openshift_source_provider:
             # Generate unique network name for class-based tests
-            hash_prefix = generate_class_hash_prefix(request.node.nodeid)
+            hash_prefix = generate_class_hash_prefix(request.node.nodeid, session_uuid=fixture_store["session_uuid"])
             multus_network_name = f"cb-{hash_prefix}"
 
             # Create NAD for OpenShift source provider

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -465,6 +465,7 @@ tests_params: dict = {
                 ]
             }
         },
+        "guest_agent_timeout": 600,
     },
     "test_cold_migration_comprehensive": {
         "virtual_machines": [
@@ -501,6 +502,7 @@ tests_params: dict = {
         },
         "vm_target_namespace": f"mtv-vms-cold-comprehensive-{uuid.uuid4().hex[:4]}",
         "multus_namespace": "default",  # Cross-namespace NAD access
+        "guest_agent_timeout": 600,
     },
     "test_post_hook_retain_failed_vm": {
         "virtual_machines": [

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -1,3 +1,5 @@
+import uuid
+
 global config
 
 insecure_verify_skip: str = "true"  # SSL verification for OCP API connections
@@ -442,7 +444,7 @@ tests_params: dict = {
         "warm_migration": True,
         "target_power_state": "on",
         "preserve_static_ips": True,
-        "vm_target_namespace": "custom-vm-namespace",
+        "vm_target_namespace": f"mtv-vms-warm-comprehensive-{uuid.uuid4().hex[:4]}",
         "multus_namespace": "default",  # Cross-namespace NAD access
         "pvc_name_template": '{{ .FileName | trimSuffix ".vmdk" | replace "_" "-" }}-{{.DiskIndex}}',
         "pvc_name_template_use_generate_name": True,
@@ -497,7 +499,7 @@ tests_params: dict = {
                 ]
             }
         },
-        "vm_target_namespace": "mtv-comprehensive-vms",
+        "vm_target_namespace": f"mtv-vms-cold-comprehensive-{uuid.uuid4().hex[:4]}",
         "multus_namespace": "default",  # Cross-namespace NAD access
     },
     "test_post_hook_retain_failed_vm": {

--- a/utilities/mtv_migration.py
+++ b/utilities/mtv_migration.py
@@ -14,7 +14,6 @@ from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 from exceptions.exceptions import (
     MigrationNotFoundError,
     MigrationPlanExecError,
-    MigrationStatusError,
     VmNotFoundError,
     VmPipelineError,
 )
@@ -55,30 +54,22 @@ def _find_migration_for_plan(plan: Plan) -> Migration:
 def _get_failed_migration_step(plan: Plan, vm_name: str) -> str:
     """Get step where VM migration failed.
 
-    Examines the Migration status (not Plan) to find which pipeline step failed.
-    The Migration CR contains the detailed VM pipeline execution status.
+    Reads pipeline data from the Plan CR status, which is the authoritative source.
+    The Plan CR is updated by the forklift controller before the Migration CR syncs,
+    avoiding race conditions where the Migration CR has not yet reflected pipeline errors.
 
     Args:
-        plan (Plan): The Plan resource (used to find the associated Migration)
+        plan (Plan): The Plan resource with migration status
         vm_name (str): Name of the VM to check (matches against status.vms[].name or id)
 
     Returns:
         str: Name of the failed step (e.g., "PreHook", "PostHook", "DiskTransfer")
 
     Raises:
-        MigrationNotFoundError: If Migration CR cannot be found for the Plan
-        MigrationStatusError: If Migration has no status or no vms in status
         VmPipelineError: If VM has no pipeline or no failed step in pipeline
-        VmNotFoundError: If VM not found in Migration status
+        VmNotFoundError: If VM not found in Plan migration status
     """
-    migration = _find_migration_for_plan(plan)
-
-    if not hasattr(migration.instance, "status") or not migration.instance.status:
-        raise MigrationStatusError(migration_name=migration.name)
-
-    vms_status = getattr(migration.instance.status, "vms", None)
-    if not vms_status:
-        raise MigrationStatusError(migration_name=migration.name)
+    vms_status = plan.instance.status.migration.vms
 
     for vm_status in vms_status:
         vm_id = getattr(vm_status, "id", "")
@@ -100,7 +91,7 @@ def _get_failed_migration_step(plan: Plan, vm_name: str) -> str:
 
         raise VmPipelineError(vm_name=vm_name)
 
-    raise VmNotFoundError(f"VM {vm_name} not found in Migration {migration.name} status")
+    raise VmNotFoundError(f"VM '{vm_name}' not found in Plan '{plan.name}' migration status")
 
 
 def _get_all_vms_failed_steps(plan_resource: Plan, vm_names: list[str]) -> dict[str, str]:
@@ -117,10 +108,8 @@ def _get_all_vms_failed_steps(plan_resource: Plan, vm_names: list[str]) -> dict[
         dict[str, str]: Mapping of VM name to failed step name
 
     Raises:
-        MigrationNotFoundError: If migration not found for the plan
-        MigrationStatusError: If migration status is missing or invalid
         VmPipelineError: If VM pipeline is missing or has no failed step
-        VmNotFoundError: If VM not found in migration status
+        VmNotFoundError: If VM not found in Plan migration status
     """
     failed_steps: dict[str, str] = {}
 

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -381,7 +381,7 @@ def check_static_ip_preservation(
         # Get current network configuration via SSH with retry logic It takes time for secondary IPs to appear
         ssh_conn = vm_ssh_connections.create(vm_name=vm_name, username=ssh_username, password=ssh_password)
 
-        def get_matching_interface_with_ip():
+        def get_matching_interface_with_ip(expected_ip: str = expected_ip) -> dict[str, Any] | None:
             """
             Combined function that:
             1. Gets network configuration
@@ -400,7 +400,7 @@ def check_static_ip_preservation(
 
                     # Execute command using executor with the correct user
                     # We need to use the executor with our specific user instead
-                    executor = ssh_conn.rrmngmnt_host.executor(user=ssh_conn.rrmngmnt_user)
+                    executor = ssh_conn.rrmngmnt_host.executor(user=ssh_conn.rrmngmnt_user)  # type: ignore[union-attr]
                     executor.port = ssh_conn.local_port
 
                     # Run the command directly

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -269,7 +269,10 @@ def _verify_subnet_mask(interface_name: str, expected_subnet: str, matching_inte
     """
     subnet_mask = matching_interface.get("subnet_mask")
     if not subnet_mask:
-        return
+        raise AssertionError(
+            f"Subnet mask not found for interface {interface_name} — "
+            f"expected {expected_subnet} but no subnet mask was reported by the guest OS"
+        )
 
     try:
         # Create network objects to compare subnet masks
@@ -445,8 +448,7 @@ def check_static_ip_preservation(
                     for ip_info in interface_ips:
                         if ip_info.get("ip_address") == expected_ip:
                             LOGGER.info(f"SUCCESS: Expected IP {expected_ip} found")
-                            if ip_info.get("subnet_mask"):
-                                matching_interface["subnet_mask"] = ip_info["subnet_mask"]
+                            matching_interface["subnet_mask"] = ip_info.get("subnet_mask", "")
                             return matching_interface
 
                     all_ips = [ip_info.get("ip_address") for ip_info in interface_ips]

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -156,21 +156,17 @@ def _parse_windows_network_config(ipconfig_output: str) -> dict[str, dict[str, A
         interface_name = adapter.get("name", "unknown")
 
         ip_addresses: list[dict[str, Any]] = []
-        subnet_mask = ""
 
         for ipv4 in adapter.get("ipv4_addresses", []):
             ip_addresses.append({
                 "ip_address": ipv4.get("address", ""),
+                "subnet_mask": ipv4.get("subnet_mask", ""),
                 "status": ipv4.get("status", ""),
             })
-            # Use first subnet mask found
-            if not subnet_mask and ipv4.get("subnet_mask"):
-                subnet_mask = ipv4.get("subnet_mask", "")
 
         interface_config: dict[str, Any] = {
             "name": interface_name,
             "ip_addresses": ip_addresses,
-            "subnet_mask": subnet_mask,
         }
 
         # Add MAC address if available
@@ -213,8 +209,14 @@ def _parse_linux_network_config(nmcli_output: str) -> dict[str, dict[str, Any]]:
 
         interfaces[device["device"]] = {
             "name": device["device"],
-            "ip_addresses": [{"ip_address": str(ipaddress.ip_interface(c).ip), "status": ""} for c in cidrs],
-            "subnet_mask": str(ipaddress.ip_interface(cidrs[0]).netmask),
+            "ip_addresses": [
+                {
+                    "ip_address": str(ipaddress.ip_interface(c).ip),
+                    "subnet_mask": str(ipaddress.ip_interface(c).netmask),
+                    "status": "",
+                }
+                for c in cidrs
+            ],
             **({"macAddress": device["hwaddr"]} if device.get("hwaddr") else {}),
             **({"gateway": device["ip4_gateway"]} if device.get("ip4_gateway") else {}),
         }
@@ -437,18 +439,19 @@ def check_static_ip_preservation(
                         LOGGER.warning(f"Interface {interface_name} not found yet")
                         return None  # Retry
 
-                    # Check if expected IP is found
+                    # Check if expected IP is found and extract its subnet mask
                     interface_ips = matching_interface.get("ip_addresses", [])
+
+                    for ip_info in interface_ips:
+                        if ip_info.get("ip_address") == expected_ip:
+                            LOGGER.info(f"SUCCESS: Expected IP {expected_ip} found")
+                            if ip_info.get("subnet_mask"):
+                                matching_interface["subnet_mask"] = ip_info["subnet_mask"]
+                            return matching_interface
+
                     all_ips = [ip_info.get("ip_address") for ip_info in interface_ips]
-
-                    found_expected_ip = any(ip_info.get("ip_address") == expected_ip for ip_info in interface_ips)
-
-                    if found_expected_ip:
-                        LOGGER.info(f"SUCCESS: Expected IP {expected_ip} found")
-                        return matching_interface
-                    else:
-                        LOGGER.warning(f"Expected IP {expected_ip} not found yet. Found IPs: {all_ips}")
-                        return None
+                    LOGGER.warning(f"Expected IP {expected_ip} not found yet. Found IPs: {all_ips}")
+                    return None
 
             except CommandExecFailed as e:
                 # Permanent failure - don't retry

--- a/utilities/utils.py
+++ b/utilities/utils.py
@@ -102,17 +102,18 @@ def load_source_providers(providers_json_path: str | None = None) -> dict[str, d
         return providers
 
 
-def generate_class_hash_prefix(nodeid: str, length: int = 6) -> str:
+def generate_class_hash_prefix(nodeid: str, session_uuid: str, length: int = 6) -> str:
     """Generate a FIPS-compliant hash prefix for class-based resource naming.
 
     Args:
         nodeid (str): The pytest node ID (e.g., request.node.nodeid).
+        session_uuid (str): Unique session identifier for parallel execution safety.
         length (int): Length of the hash prefix (default: 6).
 
     Returns:
         str: A hex prefix of the specified length (e.g., "a1b2c3").
     """
-    return hashlib.sha256(nodeid.encode()).hexdigest()[:length]
+    return hashlib.sha256(f"{nodeid}\x00{session_uuid}".encode()).hexdigest()[:length]
 
 
 def vmware_provider(provider_data: dict[str, Any]) -> bool:


### PR DESCRIPTION
Summary

  Six targeted fixes addressing race conditions in pytest-xdist parallel execution and test reliability issues discovered during CI runs. Each fix is an independent, focused commit.

  Changes

1.  Dynamic vm_target_namespace for parallel execution safety

tests/tests_config/config.py:
Comprehensive test configs used hardcoded vm_target_namespace values ("custom-vm-namespace", "mtv-comprehensive-vms"), causing namespace collisions when multiple xdist workers ran simultaneously. Now generates unique namespace names with a uuid4 hex suffix at config level, preserving the flexibility for tests to specify either dynamic or static namespace names.

2.  Configurable guest_agent_timeout for Windows VM tests

conftest.py, tests/tests_config/config.py:
Windows VMs require significantly longer guest agent startup times than the hardcoded 120s timeout in wait_for_vmware_guest_info (especially after updating the VMware guest tools to the latest version). Added guest_agent_timeout: 600 to comprehensive test configs and made the VMware guest info wait use this configurable value, falling back to 120s for tests that don't specify it.

3. Session-unique NAD hash prefix for parallel safety

conftest.py, utilities/utils.py:
generate_class_hash_prefix() computed hash prefixes from nodeid alone. Two xdist workers running the same test class would produce identical hash prefixes, causing NAD name collisions in shared namespaces. Now  includes session_uuid in the hash input, ensuring unique NAD names per worker session.

4. Read pipeline data from Plan CR instead of Migration CR

utilities/mtv_migration.py:
 _get_failed_migration_step() read pipeline error data from the Migration CR, which syncs asynchronously via reflectPlan(). When checked immediately after wait_for_migration_complete() detected Plan failure, the Migration CR often hadn't synced yet, causing VmPipelineError. Now reads directly from the Plan CR (plan.instance.status.migration.vms), which is the authoritative source updated by the forklift controller before the Migration CR syncs.

5. Store subnet mask per-IP in network config parsers

utilities/post_migration.py:
Windows and Linux network config parsers stored one subnet mask per interface. When an adapter had both an APIPA address (169.254.x.x/16) and a static IP, the parser could grab the APIPA mask (255.255.0.0) instead of the static IP's mask, causing false check_static_ip_preservation failures. Now stores subnet mask per-IP and get_matching_interface_with_ip() promotes the matched IP's mask for verification.

6. Parallel-safe precopy interval (no teardown restore)

conftest.py:
precopy_interval_forkliftcontroller used ResourceEditor as a context manager, which restores the original controller_precopy_interval on session teardown. With multiple xdist workers sharing the same cluster-wide ForkliftController CR, one worker's teardown would clobber the value for workers still running warm migrations, and trigger an unnecessary controller pod rollout. Replaced with check-and-set pattern: reads current value first (skips if already correct), uses ResourceEditor.update(backup_resources=False) for permanent patching without restore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Per-run unique namespaces and session-aware identifiers for better isolation.
  * Increased and configurable guest-agent timeout for comprehensive migration tests.
  * Test fixture now skips unnecessary updates when settings already match.

* **Bug Fixes**
  * More reliable migration step detection by reading consolidated plan status.
  * Stricter network validation with per-IP subnet masks and earlier detection of expected IPs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->