### PR TITLE
feat: MTV-4362: add data integrity validation and graceful VM shutdown for copy-offload tests

### DIFF
--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -330,6 +330,46 @@ class VMWareProvider(BaseProvider):
         if vm.runtime.powerState == vm.runtime.powerState.poweredOn:
             self.wait_task(task=vm.PowerOff(), action_name=f"Stopping VM {vm.name}")
 
+    def shutdown_vm_guest(self, vm: vim.VirtualMachine, timeout: int = 120) -> None:
+        """Gracefully shut down a VM's guest OS via VMware Tools.
+
+        Requests a clean OS shutdown (ShutdownGuest) which flushes filesystem
+        buffers and unmounts filesystems before powering off. Falls back to hard
+        PowerOff if VMware Tools is unavailable or the guest doesn't shut down
+        within the timeout.
+
+        Args:
+            vm (vim.VirtualMachine): VMware VM object to stop.
+            timeout (int): Seconds to wait for graceful shutdown before falling back to PowerOff.
+        """
+        if vm.runtime.powerState != vm.runtime.powerState.poweredOn:
+            return
+
+        try:
+            vm.ShutdownGuest()
+            LOGGER.info(f"Requested graceful shutdown for VM {vm.name}, waiting up to {timeout}s")
+            for sample in TimeoutSampler(
+                wait_timeout=timeout,
+                sleep=5,
+                func=lambda: vm.runtime.powerState,
+            ):
+                if sample != vm.runtime.powerState.poweredOn:
+                    LOGGER.info(f"VM {vm.name} gracefully shut down")
+                    return
+        except (vim.fault.ToolsUnavailable, vim.fault.InvalidPowerState):
+            LOGGER.warning(f"VMware Tools unavailable on VM {vm.name}, falling back to hard PowerOff")
+        except TimeoutExpiredError:
+            LOGGER.warning(f"Graceful shutdown timed out for VM {vm.name} after {timeout}s, falling back to PowerOff")
+
+        if vm.runtime.powerState != vm.runtime.powerState.poweredOn:
+            LOGGER.info(f"VM {vm.name} already powered off, skipping hard PowerOff")
+            return
+
+        try:
+            self.wait_task(task=vm.PowerOff(), action_name=f"Stopping VM {vm.name}")
+        except vim.fault.InvalidPowerState:
+            LOGGER.info(f"VM {vm.name} powered off during fallback attempt")
+
     @staticmethod
     def list_snapshots(vm):
         snapshots = []

--- a/tests/copyoffload/conftest.py
+++ b/tests/copyoffload/conftest.py
@@ -369,13 +369,15 @@ def nonpersistent_disk_ready(
     to independent_nonpersistent after the VM is powered off.
 
     Args:
-        vmware_cloud_init_ready (None): Ensures cloud-init has finished and VM is off.
+        vmware_cloud_init_ready (None): Ensures cloud-init has finished (VM may still be on).
         prepared_plan (dict[str, Any]): Processed test plan with VM data.
         source_provider (VMWareProvider): The VMware source provider instance.
     """
     for vm_data in prepared_plan["virtual_machines"]:
         vm_name = vm_data["name"]
         provider_vm_api = prepared_plan["source_vms_data"][vm_name]["provider_vm_api"]
+        if provider_vm_api.runtime.powerState == provider_vm_api.runtime.powerState.poweredOn:
+            source_provider.shutdown_vm_guest(vm=provider_vm_api)
         source_provider.change_disk_mode(
             vm=provider_vm_api,
             disk_mode="independent_nonpersistent",

--- a/tests/copyoffload/test_copyoffload_migration.py
+++ b/tests/copyoffload/test_copyoffload_migration.py
@@ -20,6 +20,7 @@ from ocp_resources.network_map import NetworkMap
 from ocp_resources.plan import Plan
 from ocp_resources.secret import Secret
 from ocp_resources.storage_map import StorageMap
+from ocp_resources.virtual_machine import VirtualMachine
 from pytest_testconfig import config as py_config
 from simple_logger.logger import get_logger
 
@@ -38,7 +39,8 @@ from utilities.mtv_migration import (
     wait_for_migration_complate,
 )
 from utilities.naming import sanitize_kubernetes_name
-from utilities.post_migration import check_vms
+from utilities.post_migration import check_vms, verify_data_integrity
+from utilities.vmware_guest_operations import create_data_integrity_marker
 from utilities.resources import create_and_store_resource
 from utilities.ssh_utils import SSHConnectionManager
 
@@ -220,11 +222,12 @@ class TestCopyoffloadThinMigration:
 
 
 class CopyoffloadSnapshotBase:
-    """Base class for copy-offload migration tests with snapshots."""
+    """Base class for copy-offload snapshot migration tests with data integrity validation."""
 
     storage_map: StorageMap
     network_map: NetworkMap
     plan_resource: Plan
+    data_integrity_marker: str
 
     def test_create_storagemap(
         self,
@@ -267,8 +270,14 @@ class CopyoffloadSnapshotBase:
             f"Expected at least {snapshots_to_create} snapshots, got {len(vm_cfg['snapshots_before_migration'])}"
         )
 
-        # Cold migration expects VM powered off
-        source_provider.stop_vm(provider_vm_api)
+        marker_content = f"mtv-data-integrity-{fixture_store['session_uuid']}"
+        create_data_integrity_marker(
+            source_provider=source_provider,
+            vm=provider_vm_api,
+            source_provider_data=source_provider_data,
+            marker_content=marker_content,
+        )
+        self.__class__.data_integrity_marker = marker_content
 
         copyoffload_config_data = source_provider_data["copyoffload"]
         storage_vendor_product = copyoffload_config_data["storage_vendor_product"]
@@ -405,6 +414,55 @@ class CopyoffloadSnapshotBase:
             destination_provider=destination_provider, plan=prepared_plan, target_namespace=target_namespace
         )
 
+    def test_check_data_integrity(
+        self,
+        prepared_plan: dict[str, Any],
+        ocp_admin_client: DynamicClient,
+        source_provider_data: dict[str, Any],
+        source_provider: BaseProvider,
+        vm_ssh_connections: SSHConnectionManager,
+    ) -> None:
+        """Verify data written before migration survived on the migrated VM.
+
+        Starts the migrated VM, reads the marker file via SSH, and confirms
+        the content matches what was written pre-migration.
+
+        Args:
+            prepared_plan (dict[str, Any]): Processed test plan configuration.
+            ocp_admin_client (DynamicClient): OpenShift admin client.
+            source_provider_data (dict[str, Any]): Provider configuration data.
+            source_provider (BaseProvider): Source provider for VM metadata.
+            vm_ssh_connections (SSHConnectionManager): SSH connection manager.
+        """
+        vm_cfg = prepared_plan["virtual_machines"][0]
+        vm_name = vm_cfg["name"]
+        vm_namespace = prepared_plan["_vm_target_namespace"]
+
+        vm = VirtualMachine(
+            client=ocp_admin_client,
+            name=vm_name,
+            namespace=vm_namespace,
+        )
+
+        source_vm = source_provider.vm_dict(name=vm_name)
+
+        try:
+            if not vm.ready:
+                LOGGER.info(f"Starting migrated VM {vm_name} for data integrity check")
+                vm.start(wait=True, timeout=300)
+            else:
+                LOGGER.info(f"Migrated VM {vm_name} is already running, skipping start")
+            verify_data_integrity(
+                vm_name=vm_name,
+                vm_ssh_connections=vm_ssh_connections,
+                source_provider_data=source_provider_data,
+                source_vm_info=source_vm,
+                expected_marker_content=self.data_integrity_marker,
+            )
+        finally:
+            LOGGER.info(f"Stopping VM {vm_name} after data integrity check")
+            vm.stop(wait=True, timeout=300)
+
 
 @pytest.mark.copyoffload
 @pytest.mark.incremental
@@ -412,7 +470,7 @@ class CopyoffloadSnapshotBase:
     "class_plan_config",
     [pytest.param(py_config["tests_params"]["test_copyoffload_thin_snapshots_migration"])],
     indirect=True,
-    ids=["copyoffload-thin-snapshots"],
+    ids=["MTV-560:copyoffload-thin-snapshots"],
 )
 @pytest.mark.copyoffload_snapshots
 @pytest.mark.usefixtures(

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -65,7 +65,6 @@ tests_params: dict = {
         "virtual_machines": [
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thin",
@@ -78,7 +77,6 @@ tests_params: dict = {
         "virtual_machines": [
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thick-lazy",
@@ -91,7 +89,6 @@ tests_params: dict = {
         "virtual_machines": [
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "add_disks": [
@@ -106,7 +103,6 @@ tests_params: dict = {
         "virtual_machines": [
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "add_disks": [
@@ -126,7 +122,6 @@ tests_params: dict = {
         "virtual_machines": [
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "add_disks": [
@@ -141,7 +136,6 @@ tests_params: dict = {
         "virtual_machines": [
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thin",
@@ -155,7 +149,6 @@ tests_params: dict = {
         "virtual_machines": [
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thin",
@@ -176,7 +169,6 @@ tests_params: dict = {
         "virtual_machines": [
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thin",
@@ -196,7 +188,6 @@ tests_params: dict = {
         "virtual_machines": [
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thin",
@@ -215,7 +206,6 @@ tests_params: dict = {
         "virtual_machines": [
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thin",
@@ -240,7 +230,6 @@ tests_params: dict = {
         "virtual_machines": [
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thin",
@@ -273,7 +262,6 @@ tests_params: dict = {
         "virtual_machines": [
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thin",
@@ -294,7 +282,6 @@ tests_params: dict = {
         "virtual_machines": [
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thin",
@@ -314,14 +301,12 @@ tests_params: dict = {
         "virtual_machines": [
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thin",
             },
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thin",
@@ -336,7 +321,6 @@ tests_params: dict = {
                 "name": "xcopy-template-test",
                 "clone_name": "XCopy_Test_VM_CAPS",  # Non-conforming name for cloned VM
                 "preserve_name_format": True,  # Don't sanitize the name (keep capitals and underscores)
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thin",
@@ -349,7 +333,6 @@ tests_params: dict = {
         "virtual_machines": [
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "target_datastore_id": "non_xcopy_datastore_id",
@@ -370,7 +353,6 @@ tests_params: dict = {
         "virtual_machines": [
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thick-lazy",
@@ -378,7 +360,6 @@ tests_params: dict = {
             },
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thick-lazy",
@@ -386,7 +367,6 @@ tests_params: dict = {
             },
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thick-lazy",
@@ -394,7 +374,6 @@ tests_params: dict = {
             },
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thick-lazy",
@@ -402,7 +381,6 @@ tests_params: dict = {
             },
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thick-lazy",
@@ -417,14 +395,12 @@ tests_params: dict = {
         "virtual_machines": [
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thick-lazy",
             },
             {
                 "name": "xcopy-template-test",
-                "source_vm_power": "off",
                 "guest_agent": True,
                 "clone": True,
                 "disk_type": "thick-lazy",

--- a/utilities/copyoffload_migration.py
+++ b/utilities/copyoffload_migration.py
@@ -140,7 +140,8 @@ def wait_for_cloud_init(
         provider_vm_api: Provider VM object
         file_name: Full path to the file to check for (e.g., "/cloud-init.finish")
         timeout: Timeout in seconds (default: 2000)
-        target_power_state: Desired power state after check ("on" or "off", default: "off")
+        target_power_state: Expected source VM power state for downstream validation ("on" or "off",
+            default: "off"). When "off", logs that MTV will handle shutdown. Does not change VM power.
 
     Raises:
         TimeoutExpiredError: If cloud-init does not finish within timeout
@@ -205,11 +206,7 @@ def wait_for_cloud_init(
 
     finally:
         if target_power_state == "off":
-            LOGGER.info(f"Powering off VM - {vm_name}")
-            try:
-                source_provider.stop_vm(provider_vm_api)
-            except Exception as e:
-                LOGGER.warning(f"Failed to power off VM '{vm_name}': {type(e).__name__}: {e}")
+            LOGGER.info(f"VM {vm_name} left powered on — MTV will handle shutdown for cold migration")
         else:
             LOGGER.info(f"Leaving VM {vm_name} powered on")
 

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -25,6 +25,7 @@ from libs.forklift_inventory import ForkliftInventory
 from libs.providers.rhv import OvirtProvider
 from utilities.ssh_utils import SSHConnectionManager
 from utilities.utils import get_cluster_version, get_value_from_py_config, rhv_provider
+from utilities.vmware_guest_operations import DATA_INTEGRITY_FILE
 
 LOGGER = get_logger(name=__name__)
 
@@ -134,6 +135,82 @@ def check_ssh_connectivity(
                 return
     except TimeoutExpiredError as e:
         raise TimeoutExpiredError(f"SSH connectivity to VM {vm_name} could not be established after {timeout}s") from e
+
+
+def verify_data_integrity(
+    vm_name: str,
+    vm_ssh_connections: SSHConnectionManager,
+    source_provider_data: dict[str, Any],
+    source_vm_info: dict[str, Any],
+    expected_marker_content: str,
+    timeout: int = 300,
+    retry_delay: int = 15,
+) -> None:
+    """Verify that data written before migration survived on the migrated VM.
+
+    Reads a marker file created pre-migration and asserts its content matches
+    the expected value, confirming disk data integrity through the migration process.
+
+    Args:
+        vm_name (str): Name of the migrated VM.
+        vm_ssh_connections (SSHConnectionManager): SSH connection manager.
+        source_provider_data (dict[str, Any]): Provider configuration with guest credentials.
+        source_vm_info (dict[str, Any]): VM information including OS type.
+        expected_marker_content (str): The exact string expected in the marker file.
+        timeout (int): Maximum seconds to wait for SSH connectivity.
+        retry_delay (int): Seconds between SSH retry attempts.
+
+    Raises:
+        AssertionError: If marker file content does not match expected value.
+        TimeoutExpiredError: If SSH connectivity cannot be established.
+        ValueError: If the guest is a Windows VM (Linux-only feature).
+    """
+    if source_vm_info.get("win_os", False):
+        raise ValueError(
+            f"Data integrity verification is only supported on Linux guests. "
+            f"VM '{vm_name}' is a Windows guest and {DATA_INTEGRITY_FILE!r} is a Linux path."
+        )
+
+    LOGGER.info(f"Verifying data integrity on migrated VM {vm_name}")
+
+    ssh_username, ssh_password = get_ssh_credentials_from_provider_config(source_provider_data, source_vm_info)
+    ssh_conn = vm_ssh_connections.create(vm_name=vm_name, username=ssh_username, password=ssh_password)
+
+    def _read_marker() -> str | None:
+        try:
+            with ssh_conn:
+                if not ssh_conn.rrmngmnt_host:
+                    LOGGER.warning(f"SSH connection not established for VM {vm_name} - retrying...")
+                    return None
+                executor = ssh_conn.rrmngmnt_host.executor(user=ssh_conn.rrmngmnt_user)
+                executor.port = ssh_conn.local_port
+
+                rc, stdout, err = executor.run_cmd(["cat", DATA_INTEGRITY_FILE])
+                if rc != 0:
+                    LOGGER.warning(f"Failed to read marker file on VM {vm_name}: {err} - retrying...")
+                    return None
+                return stdout.strip()
+        except (SSHException, AuthenticationException, NoValidConnectionsError, ChannelException) as e:
+            LOGGER.warning(f"SSH failed for VM {vm_name}: {type(e).__name__}: {e} - retrying...")
+            return None
+
+    marker_content: str | None = None
+    try:
+        for sample in TimeoutSampler(wait_timeout=timeout, sleep=retry_delay, func=_read_marker):
+            if sample is not None:
+                marker_content = sample
+                break
+    except TimeoutExpiredError as e:
+        raise TimeoutExpiredError(f"Could not read data integrity marker from VM {vm_name} after {timeout}s") from e
+
+    assert marker_content == expected_marker_content, (
+        f"Data integrity check failed on VM {vm_name}: expected {expected_marker_content!r}, got {marker_content!r}"
+    )
+    LOGGER.info(
+        f"Data integrity verified on VM {vm_name}: "
+        f"marker file {DATA_INTEGRITY_FILE} exists with expected content {marker_content!r}. "
+        f"Pre-migration data survived the migration process."
+    )
 
 
 def _parse_windows_network_config(ipconfig_output: str) -> dict[str, dict[str, Any]]:

--- a/utilities/vmware_guest_operations.py
+++ b/utilities/vmware_guest_operations.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
 LOGGER = get_logger(__name__)
 
 _FILE_TRANSFER_TIMEOUT: int = 30
+DATA_INTEGRITY_DIR: str = "/opt/mtv_data_integrity"
+DATA_INTEGRITY_FILE: str = f"{DATA_INTEGRITY_DIR}/marker.txt"
 
 
 def run_command_in_vmware_guest(
@@ -247,3 +249,80 @@ def detect_vmware_ip_origins_via_guest_ops(
         return
 
     _apply_ip_origins_to_vm_details(vm_details=vm_details, origins=origins, vm_name=vm.name)
+
+
+def create_data_integrity_marker(
+    source_provider: VMWareProvider,
+    vm: vim.VirtualMachine,
+    source_provider_data: dict[str, Any],
+    marker_content: str,
+) -> None:
+    """Create a test directory and marker file inside a VMware guest for post-migration data integrity validation.
+
+    Writes a known marker string to a file on the guest filesystem so that
+    after migration the same file can be read back to confirm disk data was preserved.
+
+    Uses echo piped to tee so that run_command_in_vmware_guest()'s outer stdout
+    redirect (> output 2>&1) does not clobber the marker file. The marker content
+    must contain only shell-safe characters (alphanumeric, hyphens, underscores).
+
+    Args:
+        source_provider (VMWareProvider): VMware provider instance.
+        vm (vim.VirtualMachine): VMware VM object (must be powered on with VMware Tools running).
+        source_provider_data (dict[str, Any]): Provider config containing guest credentials.
+        marker_content (str): String to write into the marker file.
+
+    Raises:
+        ValueError: If guest credentials are not found or marker content has unsafe characters.
+        GuestCommandError: If the guest command exits with a non-zero exit code.
+    """
+    if not all(c.isalnum() or c in "-_." for c in marker_content):
+        raise ValueError(f"Marker content contains shell-unsafe characters: {marker_content!r}")
+
+    try:
+        guest_username = source_provider_data["guest_vm_linux_user"]
+        guest_password = source_provider_data["guest_vm_linux_password"]
+    except KeyError as e:
+        raise ValueError(
+            f"Linux VM credentials not found in provider config: {e}. "
+            "Required: guest_vm_linux_user, guest_vm_linux_password"
+        ) from e
+
+    guest_family = getattr(vm.guest, "guestFamily", None)
+    if guest_family != "linuxGuest":
+        raise ValueError(
+            f"Data integrity marker requires a Linux guest, but VM {vm.name} has guestFamily={guest_family!r}"
+        )
+
+    auth = vim.vm.guest.NamePasswordAuthentication(
+        username=guest_username, password=guest_password, interactiveSession=False
+    )
+
+    vcenter_host = source_provider.host
+    if vcenter_host is None:
+        raise ValueError(f"vCenter host not available for provider used by VM {vm.name}")
+
+    command = f"mkdir -p {DATA_INTEGRITY_DIR} && echo {marker_content} | tee {DATA_INTEGRITY_FILE}"
+
+    LOGGER.info(f"Creating data integrity marker on VM {vm.name} at {DATA_INTEGRITY_FILE}")
+    run_command_in_vmware_guest(
+        content=source_provider.content,
+        vm=vm,
+        auth=auth,
+        command=command,
+        vcenter_host=vcenter_host,
+    )
+
+    readback = run_command_in_vmware_guest(
+        content=source_provider.content,
+        vm=vm,
+        auth=auth,
+        command=f"cat {DATA_INTEGRITY_FILE}",
+        vcenter_host=vcenter_host,
+    )
+    LOGGER.info(f"Marker read-back on source VM {vm.name}: {readback.strip()!r}")
+
+    if readback.strip() != marker_content:
+        raise GuestCommandError(
+            f"Marker verification failed on source VM {vm.name}: expected {marker_content!r}, got {readback.strip()!r}"
+        )


### PR DESCRIPTION
## Summary

- **Data integrity validation for snapshot tests**: Creates a marker file on the source VM before migration and verifies it exists with the correct content on the migrated destination VM. This validates that data survives the migration process and that migration takes the latest VM state (not an older snapshot).
- **Graceful VM shutdown (`shutdown_vm_guest`)**: Added `shutdown_vm_guest()` to `VMWareProvider` that performs a clean OS shutdown via `ShutdownGuest` (flushes filesystem buffers, unmounts cleanly) with fallback to hard `PowerOff`. Used in the `nonpersistent_disk_ready` fixture where the VM must be off before changing disk mode.
- **Remove `source_vm_power` from cold copyoffload tests**: MTV handles VM shutdown via `ShutdownGuest` during cold migration, so we no longer need to manage it ourselves. This removes the `source_vm_power` config entry and skips `check_vms_power_state` for all cold copyoffload tests. Warm migration test (`test_copyoffload_warm_migration`) retains `source_vm_power: "on"`.
- **Fix test ID**: Corrected test ID for `TestCopyoffloadThinSnapshotsMigration` to `MTV-560:copyoffload-thin-snapshots`.

## Changed Files

| File | Change |
|------|--------|
| `libs/providers/vmware.py` | Add `shutdown_vm_guest()` method |
| `tests/copyoffload/conftest.py` | Use graceful shutdown in `nonpersistent_disk_ready` fixture |
| `tests/copyoffload/test_copyoffload_migration.py` | Add `test_check_data_integrity` to snapshot base class, fix test ID |
| `tests/tests_config/config.py` | Remove `source_vm_power` from all cold copyoffload configs |
| `utilities/copyoffload_migration.py` | Remove explicit VM shutdown from `wait_for_cloud_init` (MTV handles it) |
| `utilities/post_migration.py` | Add `verify_data_integrity()` function |
| `utilities/vmware_guest_operations.py` | Add `create_data_integrity_marker()` function |

## Note for maintainers

The `shutdown_vm_guest()` function can also replace the hard `PowerOff` (`stop_vm`) in the root `conftest.py` `prepared_plan` fixture (line ~1004) for all cold migration tests — not just copyoffload. This is left as a follow-up.

## Test plan

- [x] Pre-commit passes (ruff, mypy, flake8)
- [x] Jenkins: snapshot tests pass with data integrity validation
- [x] Jenkins: nonpersistent disk test passes with graceful shutdown
- [x] Jenkins: all other cold copyoffload tests pass without `source_vm_power`
- [x] Jenkins: warm copyoffload test still passes with `source_vm_power: "on"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attempt graceful guest OS shutdown with automatic fallback to forced power-off when needed.
  * Create and verify in-guest data-integrity markers to confirm post-migration data correctness.

* **Tests**
  * Migration tests generate and validate data-integrity markers and updated flows to start/stop migrated VMs for verification.
  * Tests only attempt shutdown for source VMs that are actually powered on.

* **Behavior**
  * Migration utilities defer source-VM shutdown when models indicate the VM should remain powered on.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->