### PR TITLE
feat: add copyoffload_sanity marker for quick copy-offload validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -618,6 +618,7 @@ Class-scoped teardown fixture that cleans up migrated VMs after each test class 
 | `warm`                  | Warm migration tests                  |
 | `remote`                | Remote cluster tests                  |
 | `copyoffload`           | Copy-offload (XCOPY) tests            |
+| `copyoffload_sanity`    | Copy-offload sanity subset            |
 | `copyoffload_snapshots` | Copy-offload snapshot tests (vSphere) |
 
 **Marker requirements for collection-time skipping (MUST):**

--- a/README.md
+++ b/README.md
@@ -257,7 +257,32 @@ The Quick Start runs **tier0** tests (smoke tests). You can run other test categ
 | ------ | ------------- | ----------- |
 | `tier0` | Smoke tests - critical paths | First run, quick validation |
 | `copyoffload` | Fast migrations via shared storage | Testing storage arrays |
+| `copyoffload_sanity` | Copy-offload sanity subset (see below) | Quick copy-offload validation |
 | `warm` | Warm migrations (VMs stay running) | Specific scenario testing |
+
+### Copy-Offload Sanity Tests
+
+The `copyoffload_sanity` marker selects a curated subset of copy-offload tests that cover the core
+migration scenarios. Use this marker for quick validation of copy-offload functionality without
+running the full suite. The sanity set covers:
+
+| Test ID | Test Class | What It Covers |
+| ------- | ---------- | -------------- |
+| MTV-562 | `TestCopyoffloadRdmVirtualDiskMigration` | RDM (Raw Device Mapping) virtual disk migration |
+| MTV-564 | `TestCopyoffloadMultiDatastoreMigration` | VMs with disks spread across multiple datastores |
+| MTV-565 | `TestCopyoffloadMixedDatastoreMigration` | Mixed environment - XCOPY-capable and non-XCOPY datastores with fallback |
+| MTV-572 | `TestCopyoffloadScaleMigration` | Scale migration (5 VMs concurrently) |
+| MTV-573 | `TestCopyoffload10MixedDisksMigration` | VM with 10 mixed disks (thin and thick provisioned) |
+| MTV-577 | `TestCopyoffloadWarmMigration` | Warm (live) migration with copy-offload |
+
+Together these tests validate: different disk types (thin, thick, RDM), multi-disk and multi-datastore
+layouts, mixed XCOPY/non-XCOPY fallback behavior, concurrent scale migration, and warm migration --
+providing broad coverage of copy-offload functionality in a single run.
+
+```bash
+# Run only the sanity subset
+podman run ... uv run pytest -m copyoffload_sanity -v --tc=source_provider:vsphere-8.0.1 ...
+```
 
 **Examples** - Change `-m tier0` to run different tests:
 
@@ -268,8 +293,11 @@ The Quick Start runs **tier0** tests (smoke tests). You can run other test categ
 # Warm migration tests
 podman run ... uv run pytest -m warm -v --tc=source_provider:vsphere-8.0.1 ...
 
-# Copy-offload tests
+# Copy-offload tests (full suite)
 podman run ... uv run pytest -m copyoffload -v --tc=source_provider:vsphere-8.0.1 ...
+
+# Copy-offload sanity tests (quick validation)
+podman run ... uv run pytest -m copyoffload_sanity -v --tc=source_provider:vsphere-8.0.1 ...
 
 # Combine markers
 podman run ... uv run pytest -m "tier0 or warm" -v --tc=source_provider:vsphere-8.0.1 ...
@@ -478,7 +506,7 @@ The wizard will:
 2. Connect to vSphere and let you select datastores, a test VM, and an ESXi host
 3. Prompt for storage vendor and credentials
 4. Connect to OpenShift and let you select a storage class
-5. Ask which test category to run (`all`, `copyoffload`, `tier0`, `warm`, `remote`)
+5. Ask which test category to run (`all`, `copyoffload`, `copyoffload_sanity`, `tier0`, `warm`, `remote`)
 6. Write `.providers.json` and `mtv-api-tests-manifests.yaml`
 
 > **Security Note:** The generated `mtv-api-tests-manifests.yaml` contains embedded credentials

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,6 +18,7 @@ markers =
     remote: Remote cluster migration tests
     warm: Warm migration tests
     copyoffload: Copy-offload (XCOPY) tests
+    copyoffload_sanity: Copy-offload sanity tests - core scenarios for quick validation
     copyoffload_snapshots: Copy-offload snapshot tests (vSphere only)
     incremental: marks tests as incremental (xfail on previous failure)
     min_mtv_version: mark test to require minimum MTV version (e.g., @pytest.mark.min_mtv_version("2.6.0"))

--- a/tests/copyoffload/test_copyoffload_migration.py
+++ b/tests/copyoffload/test_copyoffload_migration.py
@@ -957,6 +957,7 @@ class TestCopyoffloadMultiDiskDifferentPathMigration:
 
 
 @pytest.mark.copyoffload
+@pytest.mark.copyoffload_sanity
 @pytest.mark.incremental
 @pytest.mark.parametrize(
     "class_plan_config",
@@ -1126,6 +1127,7 @@ class TestCopyoffloadRdmVirtualDiskMigration:
 
 
 @pytest.mark.copyoffload
+@pytest.mark.copyoffload_sanity
 @pytest.mark.incremental
 @pytest.mark.parametrize(
     "class_plan_config",
@@ -1302,6 +1304,7 @@ class TestCopyoffloadMultiDatastoreMigration:
 
 
 @pytest.mark.copyoffload
+@pytest.mark.copyoffload_sanity
 @pytest.mark.incremental
 @pytest.mark.parametrize(
     "class_plan_config",
@@ -2079,6 +2082,7 @@ class TestCopyoffloadIndependentNonpersistentDiskMigration:
 
 
 @pytest.mark.copyoffload
+@pytest.mark.copyoffload_sanity
 @pytest.mark.incremental
 @pytest.mark.parametrize(
     "class_plan_config",
@@ -2644,6 +2648,7 @@ class TestCopyoffloadNonconformingNameMigration:
 
 @pytest.mark.copyoffload
 @pytest.mark.warm
+@pytest.mark.copyoffload_sanity
 @pytest.mark.incremental
 @pytest.mark.parametrize(
     "class_plan_config",
@@ -2820,6 +2825,7 @@ class TestCopyoffloadWarmMigration:
 
 
 @pytest.mark.copyoffload
+@pytest.mark.copyoffload_sanity
 @pytest.mark.incremental
 @pytest.mark.parametrize(
     "class_plan_config",


### PR DESCRIPTION
## Summary

Introduces a `copyoffload_sanity` pytest marker that selects a curated subset of 6 copy-offload tests for quick validation without running the full suite.

### Tests included

| Test ID | Test Class | Coverage |
| ------- | ---------- | -------- |
| MTV-562 | `TestCopyoffloadRdmVirtualDiskMigration` | RDM (Raw Device Mapping) virtual disk |
| MTV-564 | `TestCopyoffloadMultiDatastoreMigration` | VMs with disks across multiple datastores |
| MTV-565 | `TestCopyoffloadMixedDatastoreMigration` | Mixed XCOPY/non-XCOPY datastores with fallback |
| MTV-572 | `TestCopyoffloadScaleMigration` | Scale migration (5 VMs concurrently) |
| MTV-573 | `TestCopyoffload10MixedDisksMigration` | 10 mixed disks (thin and thick provisioned) |
| MTV-577 | `TestCopyoffloadWarmMigration` | Warm (live) migration with copy-offload |

Together these tests validate: different disk types (thin, thick, RDM), multi-disk and multi-datastore layouts, mixed XCOPY/non-XCOPY fallback behavior, concurrent scale migration, and warm migration.

### Changes

- Added `@pytest.mark.copyoffload_sanity` to 6 test classes in `test_copyoffload_migration.py`
- Registered `copyoffload_sanity` marker in `pytest.ini`
- Updated `CLAUDE.md` Test Markers table
- Updated `README.md` with new sanity section, test table, and usage examples

### Usage

```bash
uv run pytest -m copyoffload_sanity -v --tc=source_provider:vsphere-8.0.1 ...
```

### Jenkins

To run the sanity subset in Jenkins, set **MARKER** to `copyoffload_sanity` and leave **PYTEST_EXTRA_PARAMS** empty — the marker handles the filtering, no `-k` exclusion needed.

## Test plan

- [ ] `pytest --collect-only -m copyoffload_sanity` collects exactly 6 test classes (30 test methods)
- [ ] `pytest --collect-only -m copyoffload` still collects the full suite
- [ ] Pre-commit passes
- [ ] Jenkins run with `MARKER=copyoffload_sanity` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new test category for quick validation of core copy-offload scenarios.
  * Added test selection option to the Interactive Setup Tool wizard.

* **Documentation**
  * Updated documentation with the new test category, including example run commands and covered scenarios.
  * Added test category description to testing reference guide.

* **Tests**
  * Applied new test categorization to copy-offload test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->