### PR TITLE
feat: add pre-commit.ci configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 ---
+ci:
+    autofix_prs: false
+    autoupdate_commit_msg: "chore: pre-commit autoupdate"
+    autoupdate_schedule: weekly
+
 default_language_version:
   python: python3.13
 


### PR DESCRIPTION
Closes #425

## Changes
- Add `ci:` configuration block to `.pre-commit-config.yaml` for pre-commit.ci integration
  - `autofix_prs: false`
  - `autoupdate_commit_msg: "chore: pre-commit autoupdate"`
  - `autoupdate_schedule: weekly`

## Additional
- Config also applied directly to `v2.10` and `v2.11` branches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit configuration to refine CI workflow settings, including disabled automatic PR fixes and scheduled weekly autoupdate checks with standardized commit messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->