### PR TITLE
feat: improve OVA provider support for parallel execution and post-migration validation

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1028,10 +1028,6 @@ def prepared_plan(
                     LOGGER.info(f"Overriding VM name '{vm['name']}' with '{default_vm_override}' from provider config")
                     vm["name"] = default_vm_override
 
-    # OVA provider uses a fixed VM from the OVA file
-    if source_provider.type == Provider.ProviderType.OVA:
-        plan["virtual_machines"] = [{"name": "1nisim-rhel9-efi"}]
-
     if source_provider.type != Provider.ProviderType.OVA:
         openshift_source_provider: bool = source_provider.type == Provider.ProviderType.OPENSHIFT
 

--- a/conftest.py
+++ b/conftest.py
@@ -57,7 +57,7 @@ from utilities.hooks import create_hook_if_configured
 from utilities.logger import separator, setup_logging
 from utilities.mtv_migration import get_vm_suffix
 from utilities.must_gather import run_must_gather
-from utilities.naming import generate_name_with_uuid, sanitize_test_name_for_path
+from utilities.naming import generate_name_with_uuid, sanitize_kubernetes_name, sanitize_test_name_for_path
 from utilities.pytest_utils import (
     collect_created_resources,
     enrich_junit_xml,
@@ -1128,6 +1128,12 @@ def prepared_plan(
                         f"Failed to detect IP origins via Guest Operations for VM {vm['name']}: {e}. "
                         "Static IP verification may not work for this VM."
                     )
+    else:
+        # OVA VMs aren't cloned — add unique targetName to prevent destination VM name conflicts
+        # across parallel test sessions. The source VM name stays unchanged (must match OVA file).
+        session_uuid = fixture_store["session_uuid"]
+        for vm in virtual_machines:
+            vm["targetName"] = sanitize_kubernetes_name(f"{session_uuid}-{vm['name']}")
 
     # Create Hooks if configured
     create_hook_if_configured(plan, "pre_hook", "pre", fixture_store, ocp_admin_client, target_namespace)
@@ -1344,7 +1350,7 @@ def cleanup_migrated_vms(
     vm_namespace = prepared_plan.get("_vm_target_namespace", target_namespace)
 
     for vm in prepared_plan["virtual_machines"]:
-        vm_name = vm["name"]
+        vm_name = vm.get("targetName", vm["name"])
         vm_obj = VirtualMachine(
             client=ocp_admin_client,
             name=vm_name,

--- a/libs/providers/ova.py
+++ b/libs/providers/ova.py
@@ -34,6 +34,16 @@ class OVAProvider(BaseProvider):
         result_vm_info = copy.deepcopy(self.VIRTUAL_MACHINE_TEMPLATE)
         result_vm_info["provider_type"] = self.type
         result_vm_info["power_state"] = "off"
+        result_vm_info["win_os"] = False
+
+        # Detect Windows OS from Forklift inventory's OVF metadata
+        source_provider_inventory: ForkliftInventory | None = kwargs.get("source_provider_inventory")
+        vm_name: str | None = kwargs.get("name")
+        if source_provider_inventory and vm_name:
+            vm_data = source_provider_inventory.get_vm(name=vm_name)
+            raw_os_type: str = vm_data.get("osType", "")
+            result_vm_info["win_os"] = "win" in raw_os_type.lower()
+            LOGGER.info(f"OVA VM '{vm_name}' OS type: '{raw_os_type}', win_os={result_vm_info['win_os']}")
 
         return result_vm_info
 

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -1167,10 +1167,6 @@ def check_vms(
 ) -> None:
     res: dict[str, list[str]] = {}
 
-    if source_provider.type == Provider.ProviderType.OVA:
-        LOGGER.info("Source OVA VMS do not have any stats")
-        return
-
     # Use custom VM namespace (always set by prepared_plan fixture)
     vm_namespace = plan["_vm_target_namespace"]
 
@@ -1206,6 +1202,7 @@ def check_vms(
             vm_kwargs["guest_agent_timeout"] = guest_agent_timeout
         destination_vm = destination_provider.vm_dict(**vm_kwargs)
 
+        # Group 1: All providers — destination checks
         try:
             check_vms_power_state(
                 source_vm=source_vm,
@@ -1215,64 +1212,6 @@ def check_vms(
             )
         except Exception as exp:
             res[vm_name].append(f"check_vms_power_state - {str(exp)}")
-
-        try:
-            check_cpu(source_vm=source_vm, destination_vm=destination_vm)
-        except Exception as exp:
-            res[vm_name].append(f"check_cpu - {str(exp)}")
-
-        try:
-            check_memory(source_vm=source_vm, destination_vm=destination_vm)
-        except Exception as exp:
-            res[vm_name].append(f"check_memory - {str(exp)}")
-
-        # TODO: Remove when OCP to OCP migration is done with 2 clusters
-        if source_provider.type != Provider.ProviderType.OPENSHIFT:
-            try:
-                check_network(
-                    source_vm=source_vm,
-                    destination_vm=destination_vm,
-                    network_migration_map=network_map_resource,
-                )
-            except Exception as exp:
-                res[vm_name].append(f"check_network - {str(exp)}")
-
-        try:
-            check_storage(source_vm=source_vm, destination_vm=destination_vm, storage_map_resource=storage_map_resource)
-        except Exception as exp:
-            res[vm_name].append(f"check_storage - {str(exp)}")
-
-        # Check PVC names if pvcNameTemplate was specified
-        if plan.get("pvc_name_template"):
-            try:
-                check_pvc_names(
-                    source_vm=plan.get("source_vms_data", {}).get(vm["name"], source_vm),
-                    destination_vm=destination_vm,
-                    pvc_name_template=plan["pvc_name_template"],
-                    use_generate_name=plan.get("pvc_name_template_use_generate_name", False),
-                    source_provider=source_provider,
-                    source_provider_inventory=source_provider_inventory,
-                )
-            except Exception as exp:
-                res[vm_name].append(f"check_pvc_names - {str(exp)}")
-
-        if source_provider.type == Provider.ProviderType.VSPHERE:
-            if snapshots_before_migration := vm.get("snapshots_before_migration"):
-                try:
-                    check_snapshots(
-                        snapshots_before_migration=snapshots_before_migration,
-                        snapshots_after_migration=source_vm["snapshots_data"],
-                    )
-                except Exception as exp:
-                    res[vm_name].append(f"check_snapshots - {str(exp)}")
-
-            # Check serial number preservation (VMware UUID -> OpenShift serial)
-            try:
-                check_serial_preservation(
-                    source_vm=source_vm, destination_vm=destination_vm, destination_provider=destination_provider
-                )
-            except Exception as exp:
-                res[vm_name].append(f"check_serial_preservation - {str(exp)}")
 
         if vm_guest_agent:
             try:
@@ -1323,7 +1262,6 @@ def check_vms(
                 f"(power_state: {destination_vm.get('power_state', 'unknown')})"
             )
 
-        # Check node placement if configured
         if plan.get("target_node_selector") and labeled_worker_node:
             try:
                 check_vm_node_placement(
@@ -1333,7 +1271,6 @@ def check_vms(
             except Exception as exp:
                 res[vm_name].append(f"check_vm_node_placement - {str(exp)}")
 
-        # Check VM labels if configured
         if plan.get("target_labels") and target_vm_labels:
             try:
                 check_vm_labels(
@@ -1343,7 +1280,6 @@ def check_vms(
             except Exception as exp:
                 res[vm_name].append(f"check_vm_labels - {str(exp)}")
 
-        # Check affinity if configured
         if plan.get("target_affinity"):
             try:
                 check_vm_affinity(
@@ -1353,6 +1289,70 @@ def check_vms(
             except Exception as exp:
                 res[vm_name].append(f"check_vm_affinity - {str(exp)}")
 
+        # Group 2: Source-comparison checks — require real source VM data (OVA has none)
+        if source_provider.type != Provider.ProviderType.OVA:
+            try:
+                check_cpu(source_vm=source_vm, destination_vm=destination_vm)
+            except Exception as exp:
+                res[vm_name].append(f"check_cpu - {str(exp)}")
+
+            try:
+                check_memory(source_vm=source_vm, destination_vm=destination_vm)
+            except Exception as exp:
+                res[vm_name].append(f"check_memory - {str(exp)}")
+
+            # TODO: Remove when OCP to OCP migration is done with 2 clusters
+            if source_provider.type != Provider.ProviderType.OPENSHIFT:
+                try:
+                    check_network(
+                        source_vm=source_vm,
+                        destination_vm=destination_vm,
+                        network_migration_map=network_map_resource,
+                    )
+                except Exception as exp:
+                    res[vm_name].append(f"check_network - {str(exp)}")
+
+            try:
+                check_storage(
+                    source_vm=source_vm, destination_vm=destination_vm, storage_map_resource=storage_map_resource
+                )
+            except Exception as exp:
+                res[vm_name].append(f"check_storage - {str(exp)}")
+
+            if plan.get("pvc_name_template"):
+                try:
+                    check_pvc_names(
+                        source_vm=plan.get("source_vms_data", {}).get(vm["name"], source_vm),
+                        destination_vm=destination_vm,
+                        pvc_name_template=plan["pvc_name_template"],
+                        use_generate_name=plan.get("pvc_name_template_use_generate_name", False),
+                        source_provider=source_provider,
+                        source_provider_inventory=source_provider_inventory,
+                    )
+                except Exception as exp:
+                    res[vm_name].append(f"check_pvc_names - {str(exp)}")
+        else:
+            LOGGER.info(f"Skipping source-comparison checks for OVA VM '{vm_name}' (no source stats)")
+
+        # Group 3: vSphere-specific checks
+        if source_provider.type == Provider.ProviderType.VSPHERE:
+            if snapshots_before_migration := vm.get("snapshots_before_migration"):
+                try:
+                    check_snapshots(
+                        snapshots_before_migration=snapshots_before_migration,
+                        snapshots_after_migration=source_vm["snapshots_data"],
+                    )
+                except Exception as exp:
+                    res[vm_name].append(f"check_snapshots - {str(exp)}")
+
+            try:
+                check_serial_preservation(
+                    source_vm=source_vm, destination_vm=destination_vm, destination_provider=destination_provider
+                )
+            except Exception as exp:
+                res[vm_name].append(f"check_serial_preservation - {str(exp)}")
+
+        # Group 4: RHV-specific checks
         if rhv_provider(source_provider_data) and isinstance(source_provider, OvirtProvider):
             try:
                 check_false_vm_power_off(source_provider=source_provider, source_vm=source_vm)

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -1184,6 +1184,7 @@ def check_vms(
 
     for vm in plan["virtual_machines"]:
         vm_name = vm["name"]
+        destination_vm_name = vm.get("targetName", vm_name)
         res[vm_name] = []
 
         source_vm = source_provider.vm_dict(
@@ -1195,7 +1196,7 @@ def check_vms(
         vm_guest_agent = vm.get("guest_agent")
         vm_kwargs = {
             "wait_for_guest_agent": vm_guest_agent,
-            "name": vm_name,
+            "name": destination_vm_name,
             "namespace": vm_namespace,
         }
         if (guest_agent_timeout := plan.get("guest_agent_timeout")) is not None:
@@ -1223,7 +1224,7 @@ def check_vms(
         if vm_ssh_connections and destination_vm.get("power_state") == "on":
             try:
                 check_ssh_connectivity(
-                    vm_name=vm_name,
+                    vm_name=destination_vm_name,
                     vm_ssh_connections=vm_ssh_connections,
                     source_provider_data=source_provider_data,
                     source_vm_info=source_vm,
@@ -1249,7 +1250,7 @@ def check_vms(
             ):
                 try:
                     check_static_ip_preservation(
-                        vm_name=vm_name,
+                        vm_name=destination_vm_name,
                         vm_ssh_connections=vm_ssh_connections,
                         source_vm_data=source_vm_data,
                         source_provider_data=source_provider_data,

--- a/utilities/utils.py
+++ b/utilities/utils.py
@@ -362,7 +362,10 @@ def create_source_provider(
         sdk_endpoint=source_provider_data_copy.get("endpoint_type"),
         annotations=provider_annotations or None,
     )
-    ocp_resource_provider.wait_for_status(Provider.Status.READY, timeout=600, stop_status="ConnectionFailed")
+    # OVA (NFS-based) can transiently report ConnectionFailed while NFS initializes;
+    # allow retry until timeout instead of failing immediately.
+    stop_status = None if ova_provider(provider_data=source_provider_data_copy) else "ConnectionFailed"
+    ocp_resource_provider.wait_for_status(Provider.Status.READY, timeout=600, stop_status=stop_status)
 
     # this is for communication with the provider
     with source_provider(ocp_resource=ocp_resource_provider, **provider_args) as _source_provider:


### PR DESCRIPTION
-    Reorganize post-migration checks by provider capability — group check_vms() validations into provider-aware sections (all providers, source-comparison, vSphere-specific, RHV-specific) so OVA skips checks that require source VM data it doesn't have
-    Tolerate transient ConnectionFailed for OVA provider readiness — skip stop_status for OVA providers so wait_for_status retries through transient NFS ConnectionFailed instead of failing immediately
-    Detect Windows OS for OVA VMs from Forklift inventory — query the osType field from Forklift inventory OVF metadata so OVA VMs use the correct SSH credentials (Windows vs Linux)
-    Add unique targetName for OVA destination VMs — set a session-UUID-prefixed targetName on OVA VMs via the Plan CRD to prevent destination VM name conflicts across parallel test sessions 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OVA VM naming to prevent conflicts across parallel migration sessions.
  * Enhanced OVA provider initialization for more reliable connectivity handling.
  * Added OS type detection for OVA-sourced virtual machines.
  * Refined post-migration verification to appropriately validate VMs based on source provider type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->