### PR TITLE
fix: correct must-gather plan lookup and fallback command

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -362,15 +362,14 @@ def pytest_exception_interact(node, call, report):
         return
 
     if not node.session.config.getoption("skip_data_collector"):
-        _session_store = get_fixture_store(node.session)
         _data_collector_path = Path(
             f"{node.session.config.getoption('data_collector_path')}/{sanitize_test_name_for_path(node.name)}"
         )
-        # Handle both function-based tests and class-based tests
-        test_name = node._pyfuncitem.name if hasattr(node, "_pyfuncitem") else node.name
-        plans = _session_store["teardown"].get("Plan", [])
-        plan = [plan for plan in plans if plan.get("test_name", "") == test_name]
-        plan = plan[0] if plan else None
+        plan = None
+        if hasattr(node, "cls") and node.cls and hasattr(node.cls, "plan_resource"):
+            plan_obj = node.cls.plan_resource
+            if plan_obj:
+                plan = {"name": plan_obj.name, "namespace": plan_obj.namespace}
 
         run_must_gather(data_collector_path=_data_collector_path, plan=plan)
 

--- a/utilities/must_gather.py
+++ b/utilities/must_gather.py
@@ -175,11 +175,13 @@ def run_must_gather(data_collector_path: Path, plan: dict[str, str] | None = Non
         if plan:
             plan_name = plan["name"]
             plan_namespace = plan["namespace"]
+            LOGGER.info(f"Running targeted must-gather for plan '{plan_name}' in namespace '{plan_namespace}'")
             run_command(
                 shlex.split(f"{_must_gather_base_cmd} -- NS={plan_namespace} PLAN={plan_name} /usr/bin/targeted"),
                 verify_stderr=False,
             )
         else:
-            run_command(shlex.split(f"{_must_gather_base_cmd} -- NS={mtv_namespace}"), verify_stderr=False)
+            LOGGER.info("Running full must-gather collection")
+            run_command(shlex.split(_must_gather_base_cmd), verify_stderr=False)
     except Exception as ex:
         LOGGER.exception(f"Failed to run must-gather. {ex}")


### PR DESCRIPTION
Get Plan directly from test class attribute (node.cls.plan_resource) instead of test_name lookup from fixture_store - most tests have no test_name. Use default entry point for full must-gather when no plan is found - currently It's broken because uses filter NS={mtv_namespace} but does not specify proper entry point (targeted), and use targeted collection with PLAN= when a plan is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted must-gather diagnostic collection to remove namespace scoping for full collection runs, ensuring complete data gathering.

* **Chores**
  * Enhanced must-gather operations with informational logging to provide visibility into data collection execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->