### PR TITLE
feat(MTV-582): add copy-offload thick eager disk migration test

### DIFF
--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -77,7 +77,7 @@ class VMWareProvider(BaseProvider):
     DISK_TYPE_MAP = {
         "thin": ("sparse", "Setting disk provisioning to 'thin' (sparse)."),
         "thick-lazy": ("flat", "Setting disk provisioning to 'thick-lazy' (flat)."),
-        "thick-eager": ("eagerZeroedThick", "Setting disk provisioning to 'thick-eager' (eagerZeroedThick)."),
+        "thick-eager": ("flat", "Setting disk provisioning to 'thick-eager' (flat + eagerlyScrub)."),
     }
     DISK_PROVISION_TYPE_MAP = {
         "thin": {"thinProvisioned": True, "eagerlyScrub": False},
@@ -1267,6 +1267,26 @@ class VMWareProvider(BaseProvider):
                 LOGGER.info(log_message)
             else:
                 LOGGER.warning("Disk type '%s' not recognized. Using vSphere default.", disk_type)
+
+            if disk_type.lower() == "thick-eager":
+                disk_locators: list[vim.vm.RelocateSpec.DiskLocator] = []
+                for device in source_vm.config.hardware.device:
+                    if not isinstance(device, vim.vm.device.VirtualDisk):
+                        continue
+                    if not isinstance(device.backing, vim.vm.device.VirtualDisk.FlatVer2BackingInfo):
+                        LOGGER.debug(
+                            f"Skipping non-flat disk '{device.deviceInfo.label}' for eager scrub configuration."
+                        )
+                        continue
+                    locator = vim.vm.RelocateSpec.DiskLocator()
+                    locator.diskId = device.key
+                    locator.datastore = target_datastore
+                    locator.diskBackingInfo = vim.vm.device.VirtualDisk.FlatVer2BackingInfo()
+                    locator.diskBackingInfo.eagerlyScrub = True
+                    locator.diskBackingInfo.thinProvisioned = False
+                    disk_locators.append(locator)
+                relocate_spec.disk = disk_locators
+                LOGGER.info(f"Set eagerlyScrub=True on {len(disk_locators)} disk(s) for thick-eager provisioning.")
 
         # Handle adding new disks - RDM disks are filtered out and added post-clone
         disks_to_add = kwargs.get("add_disks", [])

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -1286,7 +1286,13 @@ class VMWareProvider(BaseProvider):
                     locator.diskBackingInfo.thinProvisioned = False
                     disk_locators.append(locator)
                 relocate_spec.disk = disk_locators
-                LOGGER.info(f"Set eagerlyScrub=True on {len(disk_locators)} disk(s) for thick-eager provisioning.")
+                if not disk_locators:
+                    LOGGER.warning(
+                        f"thick-eager requested but no FlatVer2BackingInfo disks found on '{source_vm.name}'; "
+                        f"clone will not be eager-zeroed."
+                    )
+                else:
+                    LOGGER.info(f"Set eagerlyScrub=True on {len(disk_locators)} disk(s) for thick-eager provisioning.")
 
         # Handle adding new disks - RDM disks are filtered out and added post-clone
         disks_to_add = kwargs.get("add_disks", [])

--- a/tests/copyoffload/test_copyoffload_migration.py
+++ b/tests/copyoffload/test_copyoffload_migration.py
@@ -711,6 +711,174 @@ class TestCopyoffloadThickLazyMigration:
 @pytest.mark.incremental
 @pytest.mark.parametrize(
     "class_plan_config",
+    [pytest.param(py_config["tests_params"]["test_copyoffload_thick_eager_migration"])],
+    indirect=True,
+    ids=["MTV-582:copyoffload-thick-eager"],
+)
+@pytest.mark.usefixtures(
+    "vmware_cloud_init_ready",
+    "multus_network_name",
+    "copyoffload_config",
+    "copyoffload_ssh_key",
+    "cleanup_migrated_vms",
+)
+class TestCopyoffloadThickEagerMigration:
+    """Copy-offload migration test - thick eager disk."""
+
+    storage_map: StorageMap
+    network_map: NetworkMap
+    plan_resource: Plan
+
+    def test_create_storagemap(
+        self,
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        destination_provider,
+        source_provider_inventory,
+        target_namespace,
+        source_provider_data,
+        copyoffload_storage_secret,
+    ):
+        """Create StorageMap with copy-offload configuration."""
+        copyoffload_config_data = source_provider_data["copyoffload"]
+        storage_vendor_product = copyoffload_config_data["storage_vendor_product"]
+        datastore_id = copyoffload_config_data["datastore_id"]
+        storage_class = py_config["storage_class"]
+
+        vms_names = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+
+        offload_plugin_config = {
+            "vsphereXcopyConfig": {
+                "secretRef": copyoffload_storage_secret.name,
+                "storageVendorProduct": storage_vendor_product,
+            }
+        }
+
+        self.__class__.storage_map = get_storage_migration_map(
+            fixture_store=fixture_store,
+            target_namespace=target_namespace,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            ocp_admin_client=ocp_admin_client,
+            source_provider_inventory=source_provider_inventory,
+            vms=vms_names,
+            storage_class=storage_class,
+            datastore_id=datastore_id,
+            offload_plugin_config=offload_plugin_config,
+            access_mode="ReadWriteOnce",
+            volume_mode="Block",
+        )
+        assert self.storage_map, "StorageMap creation failed"
+
+    def test_create_networkmap(
+        self,
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        destination_provider,
+        source_provider_inventory,
+        target_namespace,
+        multus_network_name,
+    ):
+        """Create NetworkMap resource."""
+        vms_names = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.network_map = get_network_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            multus_network_name=multus_network_name,
+            target_namespace=target_namespace,
+            vms=vms_names,
+        )
+        assert self.network_map, "NetworkMap creation failed"
+
+    def test_create_plan(
+        self,
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        destination_provider,
+        target_namespace,
+        source_provider_inventory,
+    ):
+        """Create MTV Plan CR resource."""
+        for vm in prepared_plan["virtual_machines"]:
+            vm_name = vm["name"]
+            vm_data = source_provider_inventory.get_vm(vm_name)
+            vm["id"] = vm_data["id"]
+
+        self.__class__.plan_resource = create_plan_resource(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            storage_map=self.storage_map,
+            network_map=self.network_map,
+            virtual_machines_list=prepared_plan["virtual_machines"],
+            target_namespace=target_namespace,
+            warm_migration=prepared_plan.get("warm_migration", False),
+            copyoffload=prepared_plan.get("copyoffload", False),
+        )
+        assert self.plan_resource, "Plan creation failed"
+
+    def test_migrate_vms(self, fixture_store, ocp_admin_client, target_namespace):
+        """Execute migration."""
+        execute_migration(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            plan=self.plan_resource,
+            target_namespace=target_namespace,
+        )
+
+    def test_check_xcopy_used(self, ocp_admin_client: DynamicClient, target_namespace: str) -> None:
+        """Verify XCOPY acceleration was used for all disks.
+
+        Args:
+            ocp_admin_client (DynamicClient): OpenShift admin client.
+            target_namespace (str): Namespace where populate pods exist.
+        """
+        verify_xcopy_used(
+            ocp_admin_client=ocp_admin_client,
+            plan=self.plan_resource,
+            target_namespace=target_namespace,
+            expected_xcopy_used=True,
+        )
+
+    def test_check_vms(
+        self,
+        prepared_plan,
+        source_provider,
+        destination_provider,
+        source_provider_data,
+        target_namespace,
+        source_vms_namespace,
+        source_provider_inventory,
+        vm_ssh_connections,
+    ):
+        """Validate migrated VMs."""
+        check_vms(
+            plan=prepared_plan,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            network_map_resource=self.network_map,
+            storage_map_resource=self.storage_map,
+            source_provider_data=source_provider_data,
+            source_vms_namespace=source_vms_namespace,
+            source_provider_inventory=source_provider_inventory,
+            vm_ssh_connections=vm_ssh_connections,
+        )
+
+
+@pytest.mark.copyoffload
+@pytest.mark.incremental
+@pytest.mark.parametrize(
+    "class_plan_config",
     [pytest.param(py_config["tests_params"]["test_copyoffload_multi_disk_migration"])],
     indirect=True,
     ids=["MTV-561:copyoffload-multi-disk"],

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -85,6 +85,18 @@ tests_params: dict = {
         "warm_migration": False,
         "copyoffload": True,
     },
+    "test_copyoffload_thick_eager_migration": {
+        "virtual_machines": [
+            {
+                "name": "xcopy-template-test",
+                "guest_agent": True,
+                "clone": True,
+                "disk_type": "thick-eager",
+            },
+        ],
+        "warm_migration": False,
+        "copyoffload": True,
+    },
     "test_copyoffload_multi_disk_migration": {
         "virtual_machines": [
             {


### PR DESCRIPTION
## Summary
- Adds a new copy-offload test case (`TestCopyoffloadThickEagerMigration`) for thick eager zeroed disk migrations, following the standard 6-step copy-offload pattern.
- Fixes a bug in `VMWareProvider.clone_vm` where `thick-eager` disk type was mapped to `"eagerZeroedThick"` for `RelocateSpec.Transformation`, which is not a valid vSphere enum value. The fix uses `"flat"` transform with per-disk `DiskLocator` entries setting `eagerlyScrub=True` — the correct vSphere approach for eager zeroed thick cloning.

## Changes
- **`libs/providers/vmware.py`**: Fixed `DISK_TYPE_MAP` for `thick-eager` (use `flat` instead of invalid `eagerZeroedThick`). Added `DiskLocator` logic to set `eagerlyScrub=True` on each disk backing during clone.
- **`tests/tests_config/config.py`**: Added `test_copyoffload_thick_eager_migration` configuration entry.
- **`tests/copyoffload/test_copyoffload_migration.py`**: Added `TestCopyoffloadThickEagerMigration` test class.

## Test plan
- [x] Pre-commit checks pass
- [x] Jenkins run passed on `prabinovRedhat/feat/MTV-582-copyoffload-thick-eager` with `TestCopyoffloadThickEagerMigration`
- [x] Verified cloned VM shows "Thick Provision Eager Zeroed" in vCenter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for handling "thick-eager" disks during copy-offload migrations, ensuring those disks are prepared for XCOPY-accelerated transfers.

* **Tests**
  * Added end-to-end test and test configuration for thick-eager copy-offload migrations, validating XCOPY acceleration across disks and post-migration VM integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->