### PR TITLE
fix: handle stale vCenter VM references in get_obj iteration

### DIFF
--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -787,8 +787,10 @@ class VMWareProvider(BaseProvider):
             managed_objects = getattr(container, "view", [])
             for obj in managed_objects:
                 try:
+                    # Check by name first
                     if obj.name == name:
                         return obj
+                    # For datastores, also check by MoRef ID
                     if vimtype == [vim.Datastore] and hasattr(obj, "_moId") and obj._moId == name:
                         return obj
                 except vmodl.fault.ManagedObjectNotFound:

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -11,7 +11,7 @@ from ocp_resources.provider import Provider
 from ocp_resources.resource import Resource, ResourceEditor
 from ocp_resources.secret import Secret
 from pyVim.connect import Disconnect, SmartConnect
-from pyVmomi import vim
+from pyVmomi import vim, vmodl
 from simple_logger.logger import get_logger
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
@@ -786,12 +786,13 @@ class VMWareProvider(BaseProvider):
             # Access the view property which contains the managed objects
             managed_objects = getattr(container, "view", [])
             for obj in managed_objects:
-                # Check by name first
-                if obj.name == name:
-                    return obj
-                # For datastores, also check by MoRef ID
-                if vimtype == [vim.Datastore] and hasattr(obj, "_moId") and obj._moId == name:
-                    return obj
+                try:
+                    if obj.name == name:
+                        return obj
+                    if vimtype == [vim.Datastore] and hasattr(obj, "_moId") and obj._moId == name:
+                        return obj
+                except vmodl.fault.ManagedObjectNotFound:
+                    continue
 
             raise ValueError(f"Object of type {vimtype} with name '{name}' not found.")
 

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -794,6 +794,7 @@ class VMWareProvider(BaseProvider):
                     if vimtype == [vim.Datastore] and hasattr(obj, "_moId") and obj._moId == name:
                         return obj
                 except vmodl.fault.ManagedObjectNotFound:
+                    LOGGER.debug(f"Skipping stale managed object reference while searching for '{name}'")
                     continue
 
             raise ValueError(f"Object of type {vimtype} with name '{name}' not found.")


### PR DESCRIPTION
## Summary

Fixes `pyVmomi.VmomiSupport.vmodl.fault.ManagedObjectNotFound` errors that cause test failures when iterating vCenter managed objects in `VMWareProvider.get_obj()`.

**Jira:** [MTV-5184](https://redhat.atlassian.net/browse/MTV-5184)

## Problem

When `get_obj()` creates a `ContainerView` and iterates through managed objects, another parallel test worker (or vCenter itself) may delete a VM between the time the view is created and when `obj.name` is accessed. This raises `vmodl.fault.ManagedObjectNotFound`, crashing the entire test.

This was observed in Jenkins CI across multiple copyoffload tests:
- `test_check_vms[MTV-560:copyoffload-thin-snapshots]`
- `test_check_vms[MTV-560:copyoffload-thick-lazy-zeroed]`
- `test_create_storagemap[MTV-560:copyoffload-thin]`

Stack trace:
```
libs/providers/vmware.py:790: in get_obj
    if obj.name == name:
pyVmomi/SoapAdapter.py:1518: vmodl.fault.ManagedObjectNotFound
    msg = "The object 'vim.VirtualMachine:vm-164643' has already been deleted
          or has not been completely created"
```

## Fix

- Import `vmodl` alongside `vim` from `pyVmomi`
- Wrap the property access (`obj.name`, `obj._moId`) inside the `get_obj` loop with a `try/except vmodl.fault.ManagedObjectNotFound` block
- On catch, `continue` to the next object — the stale reference is simply skipped

This is the standard approach for handling stale `ContainerView` references in pyVmomi, as the view is a point-in-time snapshot that can become stale.

## Test plan

- [x] Run copyoffload tests in Jenkins to verify the fix resolves the flaky failures
- [x] Verify that `get_obj` still correctly finds objects by name
- [x] Verify that `get_obj` still correctly finds datastores by MoRef ID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VMware provider resilience by making object lookups tolerant of transient/unavailable managed objects during container iteration. This prevents lookup failures when individual objects become temporarily unreachable, reduces noisy errors, and improves overall stability and reliability of inventory discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->