### PR TITLE
feat: add provider-type markers and OVA cold migration test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -23,5 +23,11 @@ markers =
     shared_disk: Shared disk migration tests (vSphere only)
     incremental: marks tests as incremental (xfail on previous failure)
     min_mtv_version: mark test to require minimum MTV version (e.g., @pytest.mark.min_mtv_version("2.6.0"))
+    ova: OVA provider-specific tests
+    vsphere: vSphere provider-specific tests
+    esxi: ESXi provider-specific tests
+    rhv: RHV provider-specific tests
+    openstack: OpenStack provider-specific tests
+    openshift: OpenShift provider-specific tests
 
 junit_logging = all

--- a/tests/cold/test_cold_migration_comprehensive.py
+++ b/tests/cold/test_cold_migration_comprehensive.py
@@ -23,6 +23,10 @@ if TYPE_CHECKING:
     from utilities.ssh_utils import SSHConnectionManager
 
 
+@pytest.mark.vsphere
+@pytest.mark.rhv
+@pytest.mark.openstack
+@pytest.mark.openshift
 @pytest.mark.parametrize(
     "class_plan_config",
     [pytest.param(py_config["tests_params"]["test_cold_migration_comprehensive"])],

--- a/tests/cold/test_mtv_cold_migration.py
+++ b/tests/cold/test_mtv_cold_migration.py
@@ -14,6 +14,11 @@ from utilities.post_migration import check_vms
 from utilities.utils import get_value_from_py_config, populate_vm_ids
 
 
+@pytest.mark.vsphere
+@pytest.mark.rhv
+@pytest.mark.openstack
+@pytest.mark.openshift
+@pytest.mark.esxi
 @pytest.mark.tier0
 @pytest.mark.incremental
 @pytest.mark.parametrize(
@@ -147,6 +152,10 @@ class TestSanityColdMtvMigration:
         )
 
 
+@pytest.mark.vsphere
+@pytest.mark.rhv
+@pytest.mark.openstack
+@pytest.mark.openshift
 @pytest.mark.remote
 @pytest.mark.incremental
 @pytest.mark.skipif(not get_value_from_py_config("remote_ocp_cluster"), reason="No remote OCP cluster provided")

--- a/tests/cold/test_ova_cold_migration.py
+++ b/tests/cold/test_ova_cold_migration.py
@@ -1,10 +1,3 @@
-"""Shared disk migration tests for RHEL VMs (MTV-676).
-
-Tests VM-level migrateSharedDisks overrides in a single migration plan.
-The owner VM (migrateSharedDisks=true) migrates the shared disk PVC, while
-the consumer VM (migrateSharedDisks=false) skips it.
-"""
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
@@ -22,7 +15,6 @@ from utilities.mtv_migration import (
     get_storage_migration_map,
 )
 from utilities.post_migration import check_vms
-from utilities.shared_disk import verify_shared_disk_data
 from utilities.utils import populate_vm_ids
 
 if TYPE_CHECKING:
@@ -34,23 +26,22 @@ if TYPE_CHECKING:
     from utilities.ssh_utils import SSHConnectionManager
 
 
-@pytest.mark.vsphere
-@pytest.mark.shared_disk
 @pytest.mark.tier0
+@pytest.mark.ova
 @pytest.mark.incremental
 @pytest.mark.parametrize(
     "class_plan_config",
     [
         pytest.param(
-            py_config["tests_params"]["test_shared_disk_rhel_migration"],
+            py_config["tests_params"]["test_ova_cold_migration"],
         )
     ],
     indirect=True,
-    ids=["shared-disk-rhel"],
+    ids=["ova-cold"],
 )
 @pytest.mark.usefixtures("cleanup_migrated_vms")
-class TestSharedDiskRhelMigration:
-    """MTV-676: Cold migrate RHEL VMs with VM-level migrateSharedDisks overrides."""
+class TestOvaColdMigration:
+    """OVA cold migration test with destination-side validation."""
 
     storage_map: StorageMap
     network_map: NetworkMap
@@ -58,15 +49,15 @@ class TestSharedDiskRhelMigration:
 
     def test_create_storagemap(
         self,
-        prepared_plan: dict[str, Any],
-        fixture_store: dict[str, Any],
-        ocp_admin_client: "DynamicClient",
-        source_provider: "BaseProvider",
-        destination_provider: "OCPProvider",
-        source_provider_inventory: "ForkliftInventory",
-        target_namespace: str,
-    ) -> None:
-        """Create StorageMap resource for both VMs."""
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        destination_provider,
+        source_provider_inventory,
+        target_namespace,
+    ):
+        """Create StorageMap resource for migration."""
         vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
         self.__class__.storage_map = get_storage_migration_map(
             fixture_store=fixture_store,
@@ -81,16 +72,16 @@ class TestSharedDiskRhelMigration:
 
     def test_create_networkmap(
         self,
-        prepared_plan: dict[str, Any],
-        fixture_store: dict[str, Any],
-        ocp_admin_client: "DynamicClient",
-        source_provider: "BaseProvider",
-        destination_provider: "OCPProvider",
-        source_provider_inventory: "ForkliftInventory",
-        target_namespace: str,
-        multus_network_name: dict[str, str],
-    ) -> None:
-        """Create NetworkMap resource for both VMs."""
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        destination_provider,
+        source_provider_inventory,
+        target_namespace,
+        multus_network_name,
+    ):
+        """Create NetworkMap resource for migration."""
         vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
         self.__class__.network_map = get_network_migration_map(
             fixture_store=fixture_store,
@@ -108,13 +99,14 @@ class TestSharedDiskRhelMigration:
         self,
         prepared_plan: dict[str, Any],
         fixture_store: dict[str, Any],
-        ocp_admin_client: "DynamicClient",
-        source_provider: "BaseProvider",
-        destination_provider: "OCPProvider",
+        ocp_admin_client: DynamicClient,
+        source_provider: BaseProvider,
+        destination_provider: OCPProvider,
         target_namespace: str,
-        source_provider_inventory: "ForkliftInventory",
+        source_provider_inventory: ForkliftInventory,
+        target_vm_labels: dict[str, Any],
     ) -> None:
-        """Create MTV Plan CR with VM-level migrateSharedDisks overrides."""
+        """Create MTV Plan CR resource."""
         populate_vm_ids(prepared_plan, source_provider_inventory)
 
         self.__class__.plan_resource = create_plan_resource(
@@ -127,18 +119,19 @@ class TestSharedDiskRhelMigration:
             virtual_machines_list=prepared_plan["virtual_machines"],
             target_namespace=target_namespace,
             warm_migration=prepared_plan["warm_migration"],
-            migrate_shared_disks=prepared_plan["migrate_shared_disks"],
             target_power_state=prepared_plan["target_power_state"],
+            target_labels=target_vm_labels["vm_labels"],
+            target_affinity=prepared_plan["target_affinity"],
         )
         assert self.plan_resource, "Plan creation failed"
 
     def test_migrate_vms(
         self,
-        fixture_store: dict[str, Any],
-        ocp_admin_client: "DynamicClient",
-        target_namespace: str,
-    ) -> None:
-        """Execute migration for both VMs in a single plan."""
+        fixture_store,
+        ocp_admin_client,
+        target_namespace,
+    ):
+        """Execute migration."""
         execute_migration(
             ocp_admin_client=ocp_admin_client,
             fixture_store=fixture_store,
@@ -146,30 +139,18 @@ class TestSharedDiskRhelMigration:
             target_namespace=target_namespace,
         )
 
-    def test_verify_shared_disk_data(
-        self,
-        prepared_plan: dict[str, Any],
-        vm_ssh_connections: "SSHConnectionManager",
-        source_provider_data: dict[str, Any],
-    ) -> None:
-        """Verify shared disk read/write access from both VMs."""
-        verify_shared_disk_data(
-            prepared_plan=prepared_plan,
-            vm_ssh_connections=vm_ssh_connections,
-            source_provider_data=source_provider_data,
-        )
-
     def test_check_vms(
         self,
         prepared_plan: dict[str, Any],
-        source_provider: "BaseProvider",
-        destination_provider: "OCPProvider",
+        source_provider: BaseProvider,
+        destination_provider: OCPProvider,
         source_provider_data: dict[str, Any],
         source_vms_namespace: str,
-        source_provider_inventory: "ForkliftInventory",
-        vm_ssh_connections: "SSHConnectionManager",
+        source_provider_inventory: ForkliftInventory,
+        vm_ssh_connections: SSHConnectionManager | None,
+        target_vm_labels: dict[str, Any],
     ) -> None:
-        """Validate both migrated VMs."""
+        """Validate migrated VMs."""
         check_vms(
             plan=prepared_plan,
             source_provider=source_provider,
@@ -180,4 +161,5 @@ class TestSharedDiskRhelMigration:
             source_vms_namespace=source_vms_namespace,
             source_provider_inventory=source_provider_inventory,
             vm_ssh_connections=vm_ssh_connections,
+            target_vm_labels=target_vm_labels,
         )

--- a/tests/copyoffload/test_copyoffload_migration.py
+++ b/tests/copyoffload/test_copyoffload_migration.py
@@ -55,6 +55,7 @@ EARLY_COMPLETION_MSG = (
 )
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.incremental
 @pytest.mark.parametrize(
@@ -479,6 +480,7 @@ class CopyoffloadSnapshotBase:
             vm.stop(wait=True, timeout=300)
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.incremental
 @pytest.mark.parametrize(
@@ -519,6 +521,7 @@ class TestCopyoffloadThinSnapshotsMigration(CopyoffloadSnapshotBase):
     """Copy-offload migration test - thin disk with snapshots."""
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.incremental
 @pytest.mark.parametrize(
@@ -539,6 +542,7 @@ class TestCopyoffload2TbVmSnapshotsMigration(CopyoffloadSnapshotBase):
     """Copy-offload migration test - 2TB VM with snapshots."""
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.incremental
 @pytest.mark.parametrize(
@@ -707,6 +711,7 @@ class TestCopyoffloadThickLazyMigration:
         )
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.incremental
 @pytest.mark.parametrize(
@@ -878,6 +883,7 @@ class TestCopyoffloadMultiDiskMigration:
         )
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.incremental
 @pytest.mark.parametrize(
@@ -1049,6 +1055,7 @@ class TestCopyoffloadMultiDiskDifferentPathMigration:
         )
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.copyoffload_sanity
 @pytest.mark.incremental
@@ -1219,6 +1226,7 @@ class TestCopyoffloadRdmVirtualDiskMigration:
         )
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.copyoffload_sanity
 @pytest.mark.incremental
@@ -1396,6 +1404,7 @@ class TestCopyoffloadMultiDatastoreMigration:
         )
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.copyoffload_sanity
 @pytest.mark.incremental
@@ -1567,6 +1576,7 @@ class TestCopyoffloadMixedDatastoreMigration:
         )
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.incremental
 @pytest.mark.parametrize(
@@ -1842,6 +1852,7 @@ class TestCopyoffloadFallbackLargeMigration:
         )
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.incremental
 @pytest.mark.parametrize(
@@ -2007,6 +2018,7 @@ class TestCopyoffloadIndependentPersistentDiskMigration:
         )
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.incremental
 @pytest.mark.parametrize(
@@ -2174,6 +2186,7 @@ class TestCopyoffloadIndependentNonpersistentDiskMigration:
         )
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.copyoffload_sanity
 @pytest.mark.incremental
@@ -2340,6 +2353,7 @@ class TestCopyoffload10MixedDisksMigration:
         )
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.incremental
 @pytest.mark.parametrize(
@@ -2505,6 +2519,7 @@ class TestCopyoffloadLargeVmMigration:
         )
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.incremental
 @pytest.mark.parametrize(
@@ -2739,6 +2754,7 @@ class TestCopyoffloadNonconformingNameMigration:
         )
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.warm
 @pytest.mark.copyoffload_sanity
@@ -2917,6 +2933,7 @@ class TestCopyoffloadWarmMigration:
         )
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.copyoffload_sanity
 @pytest.mark.incremental
@@ -3089,6 +3106,7 @@ class TestCopyoffloadScaleMigration:
         )
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.incremental
 @pytest.mark.parametrize(
@@ -3586,6 +3604,7 @@ class TestSimultaneousCopyoffloadMigrations:
         )
 
 
+@pytest.mark.vsphere
 @pytest.mark.copyoffload
 @pytest.mark.incremental
 @pytest.mark.parametrize(

--- a/tests/hooks/test_post_hook_retain_failed_vm.py
+++ b/tests/hooks/test_post_hook_retain_failed_vm.py
@@ -26,6 +26,10 @@ if TYPE_CHECKING:
     from libs.base_provider import BaseProvider
 
 
+@pytest.mark.vsphere
+@pytest.mark.rhv
+@pytest.mark.openstack
+@pytest.mark.openshift
 @pytest.mark.tier0
 @pytest.mark.incremental
 @pytest.mark.parametrize(

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -61,6 +61,30 @@ tests_params: dict = {
         ],
         "warm_migration": False,
     },
+    "test_ova_cold_migration": {
+        "virtual_machines": [
+            {"name": "mtv-win2019-3disks", "guest_agent": True},
+        ],
+        "warm_migration": False,
+        "target_power_state": "on",
+        "target_labels": {
+            "mtv-comprehensive-label": None,  # None = auto-generate with session_uuid
+            "test-type": "comprehensive",  # Static value
+        },
+        "target_affinity": {
+            "podAffinity": {
+                "preferredDuringSchedulingIgnoredDuringExecution": [
+                    {
+                        "podAffinityTerm": {
+                            "labelSelector": {"matchLabels": {"app": "test"}},
+                            "topologyKey": "kubernetes.io/hostname",
+                        },
+                        "weight": 50,
+                    }
+                ]
+            }
+        },
+    },
     "test_copyoffload_thin_migration": {
         "virtual_machines": [
             {

--- a/tests/warm/test_mtv_warm_migration.py
+++ b/tests/warm/test_mtv_warm_migration.py
@@ -15,6 +15,8 @@ from utilities.post_migration import check_vms
 from utilities.utils import get_value_from_py_config, populate_vm_ids
 
 
+@pytest.mark.vsphere
+@pytest.mark.rhv
 @pytest.mark.tier0
 @pytest.mark.warm
 @pytest.mark.incremental
@@ -223,6 +225,8 @@ class TestSanityWarmMtvMigration:
         )
 
 
+@pytest.mark.vsphere
+@pytest.mark.rhv
 @pytest.mark.warm
 @pytest.mark.incremental
 @pytest.mark.parametrize(
@@ -429,6 +433,8 @@ class TestMtvMigrationWarm2disks2nics:
         )
 
 
+@pytest.mark.vsphere
+@pytest.mark.rhv
 @pytest.mark.warm
 @pytest.mark.remote
 @pytest.mark.incremental

--- a/tests/warm/test_warm_migration_comprehensive.py
+++ b/tests/warm/test_warm_migration_comprehensive.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
     from utilities.ssh_utils import SSHConnectionManager
 
 
+@pytest.mark.vsphere
+@pytest.mark.rhv
 @pytest.mark.tier0
 @pytest.mark.warm
 @pytest.mark.incremental


### PR DESCRIPTION
Add provider-specific pytest markers (ova, vsphere, esxi, rhv, openstack, openshift) to pytest.ini and apply them to all existing test classes to enable provider-based test selection and collection-time filtering.

Add new OVA cold migration test (TestOvaColdMigration) with config for mtv-win2019-3disks VM including target labels and affinity settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Introduced comprehensive OVA cold migration test suite with VM provisioning, storage/network mapping, plan creation, migration execution, and post-migration validation.
  * Extended platform-specific test categorization with markers for vSphere, RHV, OpenStack, OpenShift, and ESXi across cold/warm migration test modules.

* **Chores**
  * Updated pytest marker configuration and test parameters for improved test organization and OVA migration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->