### PR TITLE
fix: sanitize destination VM name lookup for non-conforming names

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -57,7 +57,12 @@ from utilities.hooks import create_hook_if_configured
 from utilities.logger import separator, setup_logging
 from utilities.mtv_migration import get_vm_suffix
 from utilities.must_gather import run_must_gather
-from utilities.naming import generate_name_with_uuid, sanitize_kubernetes_name, sanitize_test_name_for_path
+from utilities.naming import (
+    generate_name_with_uuid,
+    resolve_destination_vm_name,
+    sanitize_kubernetes_name,
+    sanitize_test_name_for_path,
+)
 from utilities.pytest_utils import (
     collect_created_resources,
     enrich_junit_xml,
@@ -1396,7 +1401,7 @@ def cleanup_migrated_vms(
     vm_namespace = prepared_plan.get("_vm_target_namespace", target_namespace)
 
     for vm in prepared_plan["virtual_machines"]:
-        vm_name = vm.get("targetName", vm["name"])
+        vm_name = resolve_destination_vm_name(vm)
         vm_obj = VirtualMachine(
             client=ocp_admin_client,
             name=vm_name,

--- a/utilities/naming.py
+++ b/utilities/naming.py
@@ -1,4 +1,6 @@
 import re
+from typing import Any
+
 import shortuuid
 
 from exceptions.exceptions import InvalidVMNameError
@@ -43,6 +45,25 @@ def sanitize_kubernetes_name(name: str, max_length: int = 63) -> str:
             "The name must contain at least one alphanumeric character."
         )
     return sanitized
+
+
+def resolve_destination_vm_name(vm: dict[str, Any]) -> str:
+    """Resolve the expected Kubernetes destination VM name.
+
+    Uses the explicit targetName if set, otherwise predicts the name Forklift
+    will produce by sanitizing the source VM name to DNS-1123 conventions.
+
+    Args:
+        vm (dict[str, Any]): VM configuration dict from prepared_plan["virtual_machines"].
+
+    Returns:
+        str: The resolved destination VM name.
+
+    Raises:
+        InvalidVMNameError: If the VM name cannot be sanitized to a valid DNS-1123 name.
+        KeyError: If the VM dict does not contain a "name" key.
+    """
+    return vm.get("targetName") or sanitize_kubernetes_name(vm["name"])
 
 
 def sanitize_test_name_for_path(test_name: str) -> str:

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -23,6 +23,7 @@ from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 from libs.base_provider import BaseProvider
 from libs.forklift_inventory import ForkliftInventory
 from libs.providers.rhv import OvirtProvider
+from utilities.naming import resolve_destination_vm_name
 from utilities.ssh_utils import SSHConnectionManager
 from utilities.utils import get_cluster_version, get_value_from_py_config, rhv_provider
 from utilities.vmware_guest_operations import DATA_INTEGRITY_FILE
@@ -1261,7 +1262,7 @@ def check_vms(
 
     for vm in plan["virtual_machines"]:
         vm_name = vm["name"]
-        destination_vm_name = vm.get("targetName", vm_name)
+        destination_vm_name = resolve_destination_vm_name(vm)
         res[vm_name] = []
 
         source_vm = source_provider.vm_dict(


### PR DESCRIPTION
## Summary

Fixes `TestCopyoffloadNonconformingNameMigration` test failure where `check_vms()` and `cleanup_migrated_vms` looked up the migrated VM by its unsanitized source name.

**Jira:** [MTV-5188](https://redhat.atlassian.net/browse/MTV-5188)

## Problem

When a VM is cloned with `preserve_name_format=True` (e.g., `XCopy_Test_VM_CAPS`), the source name retains uppercase letters and underscores. Forklift sanitizes this to a DNS-1123 compliant name during migration. However, both `check_vms()` and `cleanup_migrated_vms` fell back to the raw unsanitized source name when no `targetName` was set:

```
Failed: VM validation failed — auto-vpph-XCopy_Test_VM_CAPS-q6mz:
  [check_ssh_connectivity - Resource `VirtualMachine`
   `auto-vpph/auto-vpph-XCopy_Test_VM_CAPS-q6mz` does not exist]
```

## Fix

- Extract `resolve_destination_vm_name()` helper in `utilities/naming.py` that uses `targetName` if explicitly set, otherwise predicts the name Forklift will produce via `sanitize_kubernetes_name()`
- Update `check_vms()` and `cleanup_migrated_vms` to use this helper

**Important:** We intentionally do NOT set `targetName` in the Plan CR. The test's purpose is to verify that Forklift's own name sanitization works correctly. Setting `targetName` would bypass that. Instead, we predict the sanitized name for the lookup.

## Impact on existing tests

- **Normal VMs** (already DNS-1123): `sanitize_kubernetes_name` returns the same string — no change
- **OVA VMs**: `targetName` is already set explicitly — helper picks it up via `vm.get("targetName")`
- **Non-conforming names**: Now correctly resolved via sanitization

## Test plan

- [x] Run `TestCopyoffloadNonconformingNameMigration` in Jenkins - passed
- [x] Verify other copyoffload tests still pass (normal names unaffected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized VM name resolution logic to improve code maintainability and ensure consistent destination VM naming across migration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->