### PR TITLE
fix: normalize VMware API URL to use FQDN when TLS verification is enabled

### DIFF
--- a/utilities/utils.py
+++ b/utilities/utils.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager, suppress
 from pathlib import Path
 from subprocess import STDOUT, check_output
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 import pytest
 from kubernetes.dynamic import DynamicClient
@@ -187,6 +188,30 @@ def _fetch_and_store_cacert(
     return cert_file
 
 
+def _normalize_vmware_url_for_tls(api_url: str, fqdn: str) -> str:
+    """Replace the host in a VMware API URL with the FQDN for TLS verification.
+
+    When TLS verification is enabled (insecure=False), the URL host must match
+    the certificate's hostname SANs. VMware provider data may contain an IP
+    address in ``api_url`` while the certificate is issued for the FQDN.
+
+    Args:
+        api_url (str): Original API URL (e.g., "https://10.6.46.250/sdk").
+        fqdn (str): Fully qualified domain name matching the certificate.
+
+    Returns:
+        str: URL with host replaced by FQDN (e.g., "https://vcenter.example.com/sdk").
+    """
+    parsed = urlparse(api_url)
+    # Preserve port from original URL if fqdn doesn't include one
+    if ":" not in fqdn and parsed.port:
+        netloc = f"{fqdn}:{parsed.port}"
+    else:
+        netloc = fqdn
+    normalized = parsed._replace(netloc=netloc)
+    return urlunparse(normalized)
+
+
 def background(func):
     """Use @background above the function you want to run in the background"""
 
@@ -286,6 +311,15 @@ def create_source_provider(
             provider_args["copyoffload"] = source_provider_data_copy["copyoffload"]
 
         if not insecure:
+            original_url = source_provider_data_copy["api_url"]
+            normalized_url = _normalize_vmware_url_for_tls(
+                api_url=original_url,
+                fqdn=source_provider_data_copy["fqdn"],
+            )
+            if normalized_url != original_url:
+                LOGGER.info(f"Normalized VMware API URL for TLS: '{original_url}' -> '{normalized_url}'")
+            source_provider_data_copy["api_url"] = normalized_url
+            secret_string_data["url"] = normalized_url
             _fetch_and_store_cacert(source_provider_data_copy, secret_string_data, tmp_dir, session_uuid)
 
     elif rhv_provider(provider_data=source_provider_data_copy):


### PR DESCRIPTION
## Problem

When `insecureSkipVerify` is `false` (TLS verification enabled) and the VMware provider's `api_url` in `.providers.json` uses an IP address (e.g., `https://10.6.46.250/sdk`), the Provider CR never reaches `Ready`. MTV correctly rejects the TLS connection because the vCenter certificate has hostname SANs but no IP SANs for the raw IP.

The CA certificate is fetched using `fqdn` (which matches the cert), but the Provider CR and Secret are created with the raw `api_url` IP — causing a mismatch.

Since `source_provider` is session-scoped, this blocks all tests in the session.

## Fix

Added `_normalize_vmware_url_for_tls()` helper that replaces the host in `api_url` with the configured `fqdn` when TLS verification is enabled. Both the Secret URL and Provider CR URL are updated before creation, ensuring the URL host matches the certificate's hostname SANs.

## Testing

This fix addresses the failure seen in Jenkins build `mtv-2.12-ocp-4.22-api-test-runner-vsphere8-remote-ceph-rbd` #70, where all 10 tests (5 cold + 5 warm remote OCP) failed during `source_provider` fixture setup with a 600s timeout.

Closes #481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * VMware provider API URLs are now normalized when TLS verification is enabled, replacing the URL host with the provider FQDN.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/mtv-api-tests/pull/482)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->