### PR TITLE
feat(MTV-595): copy-offload multi-disk on secondary datastore and path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -508,13 +508,14 @@ class TestNameHere:
   Shared disk tests insert `test_verify_shared_disk_data` before `test_check_vms`. This step mounts,
   writes, and reads a shared disk from both VMs to verify bidirectional access after migration.
   Uses `verify_shared_disk_data()` from `utilities/shared_disk.py`.
-- **6-step copy-offload pattern**: storagemap -> networkmap -> plan -> migrate -> check_vms -> check_xcopy_used
-  Copy-offload tests extend the base pattern with `test_check_xcopy_used` which calls
-  `verify_xcopy_used()` from `utilities/copyoffload_migration.py`. This is a separate step because it
+- **6-step copy-offload pattern**: storagemap -> networkmap -> plan -> migrate -> check_xcopy_used -> check_vms
+  `test_check_xcopy_used` calls `verify_xcopy_used()` from `utilities/copyoffload_migration.py`. This step
   validates the transfer mechanism (infrastructure), not the migrated VM (application), and provides
   clearer failure diagnostics.
 
-**Test method naming:** Test methods do one step each: `test_create_storagemap`, `test_create_networkmap`, `test_create_plan`, `test_migrate_vms`, `test_check_vms`
+**Test method naming:** Base tests: `test_create_storagemap`, `test_create_networkmap`, `test_create_plan`,
+`test_migrate_vms`, `test_check_vms`. Copy-offload tests: same through `test_migrate_vms`, then
+`test_check_xcopy_used`, `test_check_vms`.
 
 **Fixture parameters:** Each test method requests only the fixtures it needs. The example shows typical patterns.
 
@@ -534,7 +535,7 @@ tests_params: dict = {
 1. Create the test file in the feature subdirectory described in **Test File Location (MUST)** (for example, `tests/<feature>/test_<feature>_migration.py`)
 2. Create a test class with `@pytest.mark.parametrize` using `class_plan_config` and `indirect=True`
 3. Add pytest markers at class level (tier0, warm, remote, copyoffload)
-4. Implement the 5 test methods following the pattern above (6 for copy-offload tests — add `test_check_xcopy_used`)
+4. Implement the 5 test methods following the pattern above (6 for copy-offload tests — use the 6-step copy-offload pattern)
 
 **VM Configuration Options:**
 

--- a/tests/copyoffload/conftest.py
+++ b/tests/copyoffload/conftest.py
@@ -119,6 +119,31 @@ def mixed_datastore_config(source_provider_data: dict[str, Any]) -> None:
     LOGGER.info(f"✓ Mixed datastore configuration validated: non_xcopy_datastore_id = {non_xcopy_datastore_id}")
 
 
+@pytest.fixture(scope="class")
+def multi_datastore_config(source_provider_data: dict[str, Any]) -> None:
+    """Validate multi-datastore configuration for copy-offload tests using a secondary datastore.
+
+    Args:
+        source_provider_data (dict[str, Any]): Source provider configuration data.
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If secondary_datastore_id is missing.
+    """
+    copyoffload_config_data: dict[str, Any] = source_provider_data.get("copyoffload", {})
+    secondary_datastore_id: str | None = copyoffload_config_data.get("secondary_datastore_id")
+
+    if not secondary_datastore_id:
+        raise ValueError(
+            "Multi-datastore copy-offload tests require 'secondary_datastore_id' "
+            "to be configured in the copyoffload section."
+        )
+
+    LOGGER.info("✓ Multi-datastore configuration validated: secondary_datastore_id = %s", secondary_datastore_id)
+
+
 @pytest.fixture(scope="session")
 def copyoffload_storage_secret(
     fixture_store: dict[str, Any],

--- a/tests/copyoffload/test_copyoffload_migration.py
+++ b/tests/copyoffload/test_copyoffload_migration.py
@@ -1759,6 +1759,187 @@ class TestCopyoffloadMultiDatastoreMigration:
 
 @pytest.mark.vsphere
 @pytest.mark.copyoffload
+@pytest.mark.incremental
+@pytest.mark.parametrize(
+    "class_plan_config",
+    [pytest.param(py_config["tests_params"]["test_copyoffload_multi_disk_different_datastore_path_migration"])],
+    indirect=True,
+    ids=["MTV-595:copyoffload-multi-disk-different-datastore-path"],
+)
+@pytest.mark.usefixtures(
+    "vmware_cloud_init_ready",
+    "multus_network_name",
+    "copyoffload_config",
+    "copyoffload_ssh_key",
+    "cleanup_migrated_vms",
+)
+class TestCopyoffloadMultiDiskDifferentDatastorePathMigration:
+    """Copy-offload migration (MTV-595): multi-disk VM with secondary disk on another datastore and folder."""
+
+    storage_map: StorageMap
+    network_map: NetworkMap
+    plan_resource: Plan
+
+    def test_create_storagemap(
+        self,
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        destination_provider,
+        source_provider_inventory,
+        target_namespace,
+        source_provider_data,
+        copyoffload_storage_secret,
+    ):
+        """Create StorageMap with copy-offload configuration for multiple datastores."""
+        copyoffload_config_data = source_provider_data["copyoffload"]
+        storage_vendor_product = copyoffload_config_data["storage_vendor_product"]
+        datastore_id = copyoffload_config_data["datastore_id"]
+        secondary_datastore_id = copyoffload_config_data["secondary_datastore_id"]
+        storage_class = py_config["storage_class"]
+
+        if not secondary_datastore_id:
+            pytest.fail(
+                "Multi-disk different-datastore-path test requires 'secondary_datastore_id' in the copyoffload section."
+            )
+
+        LOGGER.info("Primary datastore: %s", datastore_id)
+        LOGGER.info("Secondary datastore (custom path disk): %s", secondary_datastore_id)
+
+        vms_names = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+
+        offload_plugin_config = {
+            "vsphereXcopyConfig": {
+                "secretRef": copyoffload_storage_secret.name,
+                "storageVendorProduct": storage_vendor_product,
+            }
+        }
+
+        self.__class__.storage_map = get_storage_migration_map(
+            fixture_store=fixture_store,
+            target_namespace=target_namespace,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            ocp_admin_client=ocp_admin_client,
+            source_provider_inventory=source_provider_inventory,
+            vms=vms_names,
+            storage_class=storage_class,
+            datastore_id=datastore_id,
+            secondary_datastore_id=secondary_datastore_id,
+            offload_plugin_config=offload_plugin_config,
+            volume_mode="Block",
+        )
+        assert self.storage_map, "StorageMap creation failed"
+
+    def test_create_networkmap(
+        self,
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        destination_provider,
+        source_provider_inventory,
+        target_namespace,
+        multus_network_name,
+    ):
+        """Create NetworkMap resource."""
+        vms_names = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.network_map = get_network_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            multus_network_name=multus_network_name,
+            target_namespace=target_namespace,
+            vms=vms_names,
+        )
+        assert self.network_map, "NetworkMap creation failed"
+
+    def test_create_plan(
+        self,
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        destination_provider,
+        target_namespace,
+        source_provider_inventory,
+    ):
+        """Create MTV Plan CR resource."""
+        for vm in prepared_plan["virtual_machines"]:
+            vm_name = vm["name"]
+            vm_data = source_provider_inventory.get_vm(vm_name)
+            vm["id"] = vm_data["id"]
+
+        self.__class__.plan_resource = create_plan_resource(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            storage_map=self.storage_map,
+            network_map=self.network_map,
+            virtual_machines_list=prepared_plan["virtual_machines"],
+            target_namespace=target_namespace,
+            warm_migration=prepared_plan.get("warm_migration", False),
+            copyoffload=prepared_plan.get("copyoffload", False),
+        )
+        assert self.plan_resource, "Plan creation failed"
+
+    def test_migrate_vms(self, fixture_store, ocp_admin_client, target_namespace):
+        """Execute migration."""
+        execute_migration(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            plan=self.plan_resource,
+            target_namespace=target_namespace,
+        )
+
+    def test_check_xcopy_used(self, ocp_admin_client: DynamicClient, target_namespace: str) -> None:
+        """Verify XCOPY acceleration was used for all disks.
+
+        Args:
+            ocp_admin_client (DynamicClient): OpenShift admin client.
+            target_namespace (str): Namespace where populate pods exist.
+        """
+        verify_xcopy_used(
+            ocp_admin_client=ocp_admin_client,
+            plan=self.plan_resource,
+            target_namespace=target_namespace,
+            expected_xcopy_used=True,
+        )
+
+    def test_check_vms(
+        self,
+        prepared_plan,
+        source_provider,
+        destination_provider,
+        source_provider_data,
+        target_namespace,
+        source_vms_namespace,
+        source_provider_inventory,
+        vm_ssh_connections,
+    ):
+        """Validate migrated VMs and verify disk count."""
+        check_vms(
+            plan=prepared_plan,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            network_map_resource=self.network_map,
+            storage_map_resource=self.storage_map,
+            source_provider_data=source_provider_data,
+            source_vms_namespace=source_vms_namespace,
+            source_provider_inventory=source_provider_inventory,
+            vm_ssh_connections=vm_ssh_connections,
+        )
+        verify_vm_disk_count(
+            destination_provider=destination_provider, plan=prepared_plan, target_namespace=target_namespace
+        )
+
+
+@pytest.mark.vsphere
+@pytest.mark.copyoffload
 @pytest.mark.copyoffload_sanity
 @pytest.mark.incremental
 @pytest.mark.parametrize(

--- a/tests/copyoffload/test_copyoffload_migration.py
+++ b/tests/copyoffload/test_copyoffload_migration.py
@@ -1770,6 +1770,7 @@ class TestCopyoffloadMultiDatastoreMigration:
     "vmware_cloud_init_ready",
     "multus_network_name",
     "copyoffload_config",
+    "multi_datastore_config",
     "copyoffload_ssh_key",
     "cleanup_migrated_vms",
 )
@@ -1782,27 +1783,22 @@ class TestCopyoffloadMultiDiskDifferentDatastorePathMigration:
 
     def test_create_storagemap(
         self,
-        prepared_plan,
-        fixture_store,
-        ocp_admin_client,
-        source_provider,
-        destination_provider,
-        source_provider_inventory,
-        target_namespace,
-        source_provider_data,
-        copyoffload_storage_secret,
-    ):
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: DynamicClient,
+        source_provider: BaseProvider,
+        destination_provider: OCPProvider,
+        source_provider_inventory: ForkliftInventory,
+        target_namespace: str,
+        source_provider_data: dict[str, Any],
+        copyoffload_storage_secret: Secret,
+    ) -> None:
         """Create StorageMap with copy-offload configuration for multiple datastores."""
         copyoffload_config_data = source_provider_data["copyoffload"]
         storage_vendor_product = copyoffload_config_data["storage_vendor_product"]
         datastore_id = copyoffload_config_data["datastore_id"]
         secondary_datastore_id = copyoffload_config_data["secondary_datastore_id"]
         storage_class = py_config["storage_class"]
-
-        if not secondary_datastore_id:
-            pytest.fail(
-                "Multi-disk different-datastore-path test requires 'secondary_datastore_id' in the copyoffload section."
-            )
 
         LOGGER.info("Primary datastore: %s", datastore_id)
         LOGGER.info("Secondary datastore (custom path disk): %s", secondary_datastore_id)
@@ -1834,15 +1830,15 @@ class TestCopyoffloadMultiDiskDifferentDatastorePathMigration:
 
     def test_create_networkmap(
         self,
-        prepared_plan,
-        fixture_store,
-        ocp_admin_client,
-        source_provider,
-        destination_provider,
-        source_provider_inventory,
-        target_namespace,
-        multus_network_name,
-    ):
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: DynamicClient,
+        source_provider: BaseProvider,
+        destination_provider: OCPProvider,
+        source_provider_inventory: ForkliftInventory,
+        target_namespace: str,
+        multus_network_name: dict[str, str],
+    ) -> None:
         """Create NetworkMap resource."""
         vms_names = [vm["name"] for vm in prepared_plan["virtual_machines"]]
         self.__class__.network_map = get_network_migration_map(
@@ -1859,14 +1855,14 @@ class TestCopyoffloadMultiDiskDifferentDatastorePathMigration:
 
     def test_create_plan(
         self,
-        prepared_plan,
-        fixture_store,
-        ocp_admin_client,
-        source_provider,
-        destination_provider,
-        target_namespace,
-        source_provider_inventory,
-    ):
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: DynamicClient,
+        source_provider: BaseProvider,
+        destination_provider: OCPProvider,
+        target_namespace: str,
+        source_provider_inventory: ForkliftInventory,
+    ) -> None:
         """Create MTV Plan CR resource."""
         for vm in prepared_plan["virtual_machines"]:
             vm_name = vm["name"]
@@ -1887,7 +1883,12 @@ class TestCopyoffloadMultiDiskDifferentDatastorePathMigration:
         )
         assert self.plan_resource, "Plan creation failed"
 
-    def test_migrate_vms(self, fixture_store, ocp_admin_client, target_namespace):
+    def test_migrate_vms(
+        self,
+        fixture_store: dict[str, Any],
+        ocp_admin_client: DynamicClient,
+        target_namespace: str,
+    ) -> None:
         """Execute migration."""
         execute_migration(
             ocp_admin_client=ocp_admin_client,
@@ -1912,15 +1913,15 @@ class TestCopyoffloadMultiDiskDifferentDatastorePathMigration:
 
     def test_check_vms(
         self,
-        prepared_plan,
-        source_provider,
-        destination_provider,
-        source_provider_data,
-        target_namespace,
-        source_vms_namespace,
-        source_provider_inventory,
-        vm_ssh_connections,
-    ):
+        prepared_plan: dict[str, Any],
+        source_provider: BaseProvider,
+        destination_provider: OCPProvider,
+        source_provider_data: dict[str, Any],
+        target_namespace: str,
+        source_vms_namespace: str,
+        source_provider_inventory: ForkliftInventory,
+        vm_ssh_connections: SSHConnectionManager | None,
+    ) -> None:
         """Validate migrated VMs and verify disk count."""
         check_vms(
             plan=prepared_plan,

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -242,6 +242,27 @@ tests_params: dict = {
         "warm_migration": False,
         "copyoffload": True,
     },
+    "test_copyoffload_multi_disk_different_datastore_path_migration": {
+        "virtual_machines": [
+            {
+                "name": "xcopy-template-test",
+                "guest_agent": True,
+                "clone": True,
+                "disk_type": "thin",
+                "add_disks": [
+                    {
+                        "size_gb": 30,
+                        "disk_mode": "persistent",
+                        "provision_type": "thin",
+                        "datastore_id": "secondary_datastore_id",
+                        "datastore_path": "shared_disks",
+                    },
+                ],
+            },
+        ],
+        "warm_migration": False,
+        "copyoffload": True,
+    },
     "test_copyoffload_independent_persistent_disk_migration": {
         "virtual_machines": [
             {


### PR DESCRIPTION
- Jira: https://redhat.atlassian.net/browse/MTV-5039

## Summary

Adds `test_copyoffload_multi_disk_different_datastore_path_migration` plan config and `TestCopyoffloadMultiDiskDifferentDatastorePathMigration` for a multi-disk VM where the OS disk is on the primary datastore and a second disk is placed on `secondary_datastore_id` under the `shared_disks` folder path. Validates XCOPY usage and post-migration VM health (including disk count).

## Verification

`TestCopyoffloadMultiDiskDifferentDatastorePathMigration` passed in Jenkins / manual run.

## Requirements

Requires `copyoffload.secondary_datastore_id` in provider config (same as MTV-564).