### PR TITLE
test(xfs): add migration tests for VMs with XFS v4 filesystem

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -637,6 +637,7 @@ storage_class = py_config["storage_class"]
 # Correct — .get() for optional feature flags (not present in every test config)
 warm_migration = plan.get("warm_migration", False)
 copyoffload = plan.get("copyoffload", False)
+xfs_compatibility = plan.get("xfs_compatibility", False)
 
 # Correct — .get() with validation for external data
 vm_id = provider_data.get("vm_id")
@@ -649,7 +650,7 @@ if not vm_id:
 - `.get("key", <default>)` on `py_config`, `plan`, `tests_params`, or any dict we control
 - `.get("key")` on external data without validation afterward
 - Using `False` as default when the key is always present in config
-  (exception: `warm_migration`, `copyoffload`, and `enable_nested_virtualization`
+  (exception: `warm_migration`, `copyoffload`, `enable_nested_virtualization` and `xfs_compatibility`
   are optional flags — `.get()` is correct)
 
 ### Provider Config Key Access (MUST)
@@ -804,12 +805,18 @@ class TestNameHere:
   `test_verify_luks_encryption` calls `verify_luks_encryption()` from `utilities/post_migration.py`. LUKS
   secret setup is handled by the `luks_vm_specs` fixture in `tests/luks/conftest.py`, which resolves
   passphrases (per-VM override → provider fallback) and creates K8s Secrets.
+- **6-step XFS pattern**: storagemap -> networkmap -> plan -> migrate -> verify_xfs_version -> check_vms
+  XFS migration tests insert `test_verify_xfs_version` before `test_check_vms`. This step executes
+  `xfs_info` on the migrated VM to verify XFS v4 filesystem compatibility (validates `crc=0` in output).
+  Uses `check_vm_command_output()` from `utilities/post_migration.py`.
+  Requires `xfs_compatibility: True` in plan config and `xfs_check` config dict.
 
 **Test method naming:** Base tests: `test_create_storagemap`, `test_create_networkmap`, `test_create_plan`,
 `test_migrate_vms`, `test_check_vms`. Copy-offload tests: same through `test_migrate_vms`, then
 `test_check_xcopy_used`, `test_check_vms`. Copy-offload throttling tests: same through `test_migrate_vms`, then
 `test_verify_populator_throttling`, `test_check_xcopy_used`, `test_check_vms`. LUKS tests: same through `test_migrate_vms`, then
-`test_verify_luks_encryption`, `test_check_vms`.
+`test_verify_luks_encryption`, `test_check_vms`. XFS tests: same through `test_migrate_vms`, then
+`test_verify_xfs_version`, `test_check_vms`.
 
 **Fixture parameters:** Each test method requests only the fixtures it needs. The example shows typical patterns.
 
@@ -843,6 +850,24 @@ tests_params: dict = {
 | `disk_type`       | No       | "thin", "thick-lazy", "thick-eager" |
 | `luks`            | No       | True if VM has LUKS-encrypted disk  |
 | `luks_passphrase` | No       | Per-VM passphrase override          |
+
+**Plan Configuration Options:**
+
+| Option                | Required | Description                                           |
+| --------------------- | -------- | ----------------------------------------------------- |
+| `warm_migration`      | No       | True for warm migration                               |
+| `preserve_static_ips` | No       | True to preserve static IP addresses after migration  |
+| `copyoffload`         | No       | True to enable copy-offload (XCOPY) migration         |
+| `xfs_compatibility`   | No       | True to enable XFS v4 filesystem compatibility        |
+
+**Test Verification Configuration:**
+
+| Option                      | Required | Description                                                     |
+| --------------------------- | -------- | --------------------------------------------------------------- |
+| `xfs_check`                 | Yes*     | XFS filesystem verification config. Required for XFS tests      |
+| `xfs_check.command`         | Yes*     | Command to execute. Required when `xfs_check` is present        |
+| `xfs_check.mount_point`     | Yes*     | Mount point to check. Required when `xfs_check` is present      |
+| `xfs_check.expected_output` | Yes*     | Expected string in output. Required when `xfs_check` is present |
 
 ## Fixture Patterns
 
@@ -931,15 +956,16 @@ Class-scoped teardown fixture that cleans up migrated VMs after each test class 
 
 ## Test Markers
 
-| Marker                  | Purpose                               |
-| ----------------------- | ------------------------------------- |
-| `tier0`                 | Core functionality (smoke tests)      |
-| `tier1`                 | Extended functionality tests          |
-| `warm`                  | Warm migration tests                  |
-| `remote`                | Remote cluster tests                  |
-| `copyoffload`           | Copy-offload (XCOPY) tests            |
-| `copyoffload_sanity`    | Copy-offload sanity subset            |
-| `copyoffload_snapshots` | Copy-offload snapshot tests (vSphere) |
+| Marker                  | Purpose                                |
+| ----------------------- | -------------------------------------- |
+| `tier0`                 | Core functionality (smoke tests)       |
+| `tier1`                 | Extended functionality tests           |
+| `warm`                  | Warm migration tests                   |
+| `remote`                | Remote cluster tests                   |
+| `copyoffload`           | Copy-offload (XCOPY) tests             |
+| `copyoffload_sanity`    | Copy-offload sanity subset             |
+| `copyoffload_snapshots` | Copy-offload snapshot tests (vSphere)  |
+| `vsphere`               | VMware vSphere provider-specific tests |
 
 **Marker requirements for collection-time skipping (MUST):**
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ The Quick Start runs **tier0** tests (smoke tests). You can run other test categ
 | `copyoffload_sanity` | Copy-offload sanity subset (see below) | Quick copy-offload validation |
 | `warm` | Warm migrations (VMs stay running) | Specific scenario testing |
 | `upgrade` | Migration across MTV operator upgrades | Validating upgrade compatibility |
+| `vsphere` | vSphere-specific tests (XFS, etc.) | Testing vSphere specific scenarios |
 
 ### Copy-Offload Sanity Tests
 

--- a/conftest.py
+++ b/conftest.py
@@ -331,7 +331,7 @@ def pytest_collection_modifyitems(session, config, items):
             if source_provider_type != Provider.ProviderType.VSPHERE:
                 vsphere_only_skip = pytest.mark.skip(reason="Test is only applicable to vSphere source providers")
                 for item in items:
-                    if "copyoffload" in item.keywords or "shared_disk" in item.keywords:
+                    if "copyoffload" in item.keywords or "shared_disk" in item.keywords or "vsphere" in item.keywords:
                         item.add_marker(vsphere_only_skip)
 
     _session_store = get_fixture_store(session)

--- a/tests/cold/test_cold_migration_xfs.py
+++ b/tests/cold/test_cold_migration_xfs.py
@@ -1,0 +1,252 @@
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from ocp_resources.network_map import NetworkMap
+from ocp_resources.plan import Plan
+from ocp_resources.storage_map import StorageMap
+from pytest_testconfig import config as py_config
+
+from utilities.mtv_migration import (
+    create_plan_resource,
+    execute_migration,
+    get_network_migration_map,
+    get_storage_migration_map,
+)
+from utilities.post_migration import check_vms, check_vm_command_output
+from utilities.utils import populate_vm_ids
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from libs.base_provider import BaseProvider
+    from libs.forklift_inventory import ForkliftInventory
+    from libs.providers.openshift import OCPProvider
+    from utilities.ssh_utils import SSHConnectionManager
+
+
+@pytest.mark.vsphere
+@pytest.mark.tier1
+@pytest.mark.incremental
+@pytest.mark.parametrize(
+    "class_plan_config",
+    [
+        pytest.param(
+            py_config["tests_params"]["test_cold_migration_xfs"],
+            id="xfs-cold",
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures("cleanup_migrated_vms")
+class TestColdMigrationXfs:
+    """Cold migrate VM with XFS v4 filesystem from vSphere.
+
+    Test for following feature:
+    - XFS v4 filesystem
+    """
+
+    storage_map: StorageMap
+    network_map: NetworkMap
+    plan_resource: Plan
+
+    def test_create_storagemap(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: "DynamicClient",
+        source_provider: "BaseProvider",
+        destination_provider: "OCPProvider",
+        source_provider_inventory: "ForkliftInventory",
+        target_namespace: str,
+    ) -> None:
+        """Create StorageMap resource.
+
+        Args:
+            prepared_plan: Plan configuration with VM details
+            fixture_store: Fixture store for resource tracking
+            ocp_admin_client: OpenShift admin client
+            source_provider: Source provider instance
+            destination_provider: Destination provider instance
+            source_provider_inventory: Source provider inventory
+            target_namespace: Target namespace for migration
+
+        Raises:
+            AssertionError: If StorageMap creation fails
+        """
+        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.storage_map = get_storage_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            vms=vms,
+        )
+        assert self.storage_map, "StorageMap creation failed"
+
+    def test_create_networkmap(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: "DynamicClient",
+        source_provider: "BaseProvider",
+        destination_provider: "OCPProvider",
+        source_provider_inventory: "ForkliftInventory",
+        target_namespace: str,
+        multus_network_name: dict[str, str],
+    ) -> None:
+        """Create NetworkMap resource with optional custom pod network.
+
+        Args:
+            prepared_plan: Plan configuration with VM details
+            fixture_store: Fixture store for resource tracking
+            ocp_admin_client: OpenShift admin client
+            source_provider: Source provider instance
+            destination_provider: Destination provider instance
+            source_provider_inventory: Source provider inventory
+            target_namespace: Target namespace for migration
+            multus_network_name: Dict with NAD base name and namespace
+
+        Raises:
+            AssertionError: If NetworkMap creation fails
+        """
+        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.network_map = get_network_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            multus_network_name=multus_network_name,
+            vms=vms,
+        )
+        assert self.network_map, "NetworkMap creation failed"
+
+    def test_create_plan(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: "DynamicClient",
+        source_provider: "BaseProvider",
+        destination_provider: "OCPProvider",
+        target_namespace: str,
+        source_provider_inventory: "ForkliftInventory",
+    ) -> None:
+        """Create MTV Plan CR with XFS compatibility enabled.
+
+        Args:
+            prepared_plan: Plan configuration with VM details
+            fixture_store: Fixture store for resource tracking
+            ocp_admin_client: OpenShift admin client
+            source_provider: Source provider instance
+            destination_provider: Destination provider instance
+            target_namespace: Target namespace for migration
+            source_provider_inventory: Source provider inventory
+
+        Raises:
+            AssertionError: If Plan creation fails
+        """
+        populate_vm_ids(prepared_plan, source_provider_inventory)
+
+        self.__class__.plan_resource = create_plan_resource(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            storage_map=self.storage_map,
+            network_map=self.network_map,
+            virtual_machines_list=prepared_plan["virtual_machines"],
+            target_namespace=target_namespace,
+            target_power_state=prepared_plan["target_power_state"],
+            warm_migration=prepared_plan.get("warm_migration", False),
+            xfs_compatibility=prepared_plan.get("xfs_compatibility", False),
+        )
+        assert self.plan_resource, "Plan creation failed"
+
+    def test_migrate_vms(
+        self,
+        fixture_store: dict[str, Any],
+        ocp_admin_client: "DynamicClient",
+        target_namespace: str,
+    ) -> None:
+        """Execute cold migration.
+
+        Args:
+            fixture_store: Fixture store for resource tracking
+            ocp_admin_client: OpenShift admin client
+            target_namespace: Target namespace for migration
+        """
+        execute_migration(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            plan=self.plan_resource,
+            target_namespace=target_namespace,
+        )
+
+    def test_verify_xfs_version(
+        self,
+        prepared_plan: dict[str, Any],
+        source_provider: "BaseProvider",
+        source_provider_data: dict[str, Any],
+        source_vms_namespace: str,
+        vm_ssh_connections: "SSHConnectionManager",
+    ) -> None:
+        """Verify XFS filesystem on migrated VMs.
+
+        Args:
+            prepared_plan: Plan configuration with VM details
+            source_provider: Source provider instance
+            source_provider_data: Provider configuration from .providers.json
+            source_vms_namespace: Source VMs namespace
+            vm_ssh_connections: SSH connection manager for VMs
+        """
+        xfs_check = prepared_plan["xfs_check"]
+        for vm in prepared_plan["virtual_machines"]:
+            source_vm_info = source_provider.vm_dict(
+                name=vm["name"],
+                namespace=source_vms_namespace,
+                source=True,
+            )
+            check_vm_command_output(
+                vm=vm,
+                vm_ssh_connections=vm_ssh_connections,
+                source_vm_info=source_vm_info,
+                source_provider_data=source_provider_data,
+                command=[xfs_check["command"], xfs_check["mount_point"]],
+                expected_output=xfs_check["expected_output"],
+            )
+
+    def test_check_vms(
+        self,
+        prepared_plan: dict[str, Any],
+        source_provider: "BaseProvider",
+        destination_provider: "OCPProvider",
+        source_provider_data: dict[str, Any],
+        source_vms_namespace: str,
+        source_provider_inventory: "ForkliftInventory",
+        vm_ssh_connections: "SSHConnectionManager",
+    ) -> None:
+        """Validate migrated VMs.
+
+        Args:
+            prepared_plan: Plan configuration with VM details
+            source_provider: Source provider instance
+            destination_provider: Destination provider instance
+            source_provider_data: Provider configuration from .providers.json
+            source_vms_namespace: Source VMs namespace
+            source_provider_inventory: Source provider inventory
+            vm_ssh_connections: SSH connection manager for VMs
+        """
+        check_vms(
+            plan=prepared_plan,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            network_map_resource=self.network_map,
+            storage_map_resource=self.storage_map,
+            source_provider_data=source_provider_data,
+            source_vms_namespace=source_vms_namespace,
+            source_provider_inventory=source_provider_inventory,
+            vm_ssh_connections=vm_ssh_connections,
+        )

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -708,6 +708,40 @@ tests_params: dict = {
         ],
         "warm_migration": False,
     },
+    "test_warm_migration_xfs": {
+        "virtual_machines": [
+            {
+                "name": "mtv-feature-rhel7-xfs",
+                "source_vm_power": "on",
+                "guest_agent": True,
+            },
+        ],
+        "warm_migration": True,
+        "target_power_state": "on",
+        "xfs_compatibility": True,
+        "xfs_check": {
+            "command": "/usr/sbin/xfs_info",
+            "mount_point": "/",
+            "expected_output": "crc=0",
+        },
+    },
+    "test_cold_migration_xfs": {
+        "virtual_machines": [
+            {
+                "name": "mtv-feature-rhel8-2xfs",
+                "source_vm_power": "on",
+                "guest_agent": True,
+            },
+        ],
+        "warm_migration": False,
+        "target_power_state": "on",
+        "xfs_compatibility": True,
+        "xfs_check": {
+            "command": "/usr/sbin/xfs_info",
+            "mount_point": "/sdb1",
+            "expected_output": "crc=0",
+        },
+    },
 }
 
 for _dir in dir():

--- a/tests/warm/test_warm_migration_xfs.py
+++ b/tests/warm/test_warm_migration_xfs.py
@@ -1,0 +1,256 @@
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from ocp_resources.network_map import NetworkMap
+from ocp_resources.plan import Plan
+from ocp_resources.storage_map import StorageMap
+from pytest_testconfig import config as py_config
+
+from utilities.mtv_migration import (
+    create_plan_resource,
+    execute_migration,
+    get_network_migration_map,
+    get_storage_migration_map,
+)
+
+from utilities.post_migration import check_vms, check_vm_command_output
+from utilities.migration_utils import get_cutover_value
+from utilities.utils import populate_vm_ids
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from libs.base_provider import BaseProvider
+    from libs.forklift_inventory import ForkliftInventory
+    from libs.providers.openshift import OCPProvider
+    from utilities.ssh_utils import SSHConnectionManager
+
+
+@pytest.mark.vsphere
+@pytest.mark.warm
+@pytest.mark.tier1
+@pytest.mark.incremental
+@pytest.mark.parametrize(
+    "class_plan_config",
+    [
+        pytest.param(
+            py_config["tests_params"]["test_warm_migration_xfs"],
+            id="xfs-warm",
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures("cleanup_migrated_vms", "precopy_interval_forkliftcontroller")
+class TestWarmMigrationXfs:
+    """Warm migrate VM with XFS v4 filesystem from vSphere.
+
+    Test for following feature:
+    - XFS v4 filesystem
+    """
+
+    storage_map: StorageMap
+    network_map: NetworkMap
+    plan_resource: Plan
+
+    def test_create_storagemap(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: "DynamicClient",
+        source_provider: "BaseProvider",
+        destination_provider: "OCPProvider",
+        source_provider_inventory: "ForkliftInventory",
+        target_namespace: str,
+    ) -> None:
+        """Create StorageMap resource.
+
+        Args:
+            prepared_plan: Plan configuration with VM details
+            fixture_store: Fixture store for resource tracking
+            ocp_admin_client: OpenShift admin client
+            source_provider: Source provider instance
+            destination_provider: Destination provider instance
+            source_provider_inventory: Source provider inventory
+            target_namespace: Target namespace for migration
+
+        Raises:
+            AssertionError: If StorageMap creation fails
+        """
+        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.storage_map = get_storage_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            vms=vms,
+        )
+        assert self.storage_map, "StorageMap creation failed"
+
+    def test_create_networkmap(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: "DynamicClient",
+        source_provider: "BaseProvider",
+        destination_provider: "OCPProvider",
+        source_provider_inventory: "ForkliftInventory",
+        target_namespace: str,
+        multus_network_name: dict[str, str],
+    ) -> None:
+        """Create NetworkMap resource with optional custom pod network.
+
+        Args:
+            prepared_plan: Plan configuration with VM details
+            fixture_store: Fixture store for resource tracking
+            ocp_admin_client: OpenShift admin client
+            source_provider: Source provider instance
+            destination_provider: Destination provider instance
+            source_provider_inventory: Source provider inventory
+            target_namespace: Target namespace for migration
+            multus_network_name: Dict with NAD base name and namespace
+
+        Raises:
+            AssertionError: If NetworkMap creation fails
+        """
+        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.network_map = get_network_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            multus_network_name=multus_network_name,
+            vms=vms,
+        )
+        assert self.network_map, "NetworkMap creation failed"
+
+    def test_create_plan(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: "DynamicClient",
+        source_provider: "BaseProvider",
+        destination_provider: "OCPProvider",
+        target_namespace: str,
+        source_provider_inventory: "ForkliftInventory",
+    ) -> None:
+        """Create MTV Plan CR with XFS compatibility enabled.
+
+        Args:
+            prepared_plan: Plan configuration with VM details
+            fixture_store: Fixture store for resource tracking
+            ocp_admin_client: OpenShift admin client
+            source_provider: Source provider instance
+            destination_provider: Destination provider instance
+            target_namespace: Target namespace for migration
+            source_provider_inventory: Source provider inventory
+
+        Raises:
+            AssertionError: If Plan creation fails
+        """
+        populate_vm_ids(prepared_plan, source_provider_inventory)
+
+        self.__class__.plan_resource = create_plan_resource(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            storage_map=self.storage_map,
+            network_map=self.network_map,
+            virtual_machines_list=prepared_plan["virtual_machines"],
+            target_namespace=target_namespace,
+            target_power_state=prepared_plan["target_power_state"],
+            warm_migration=prepared_plan.get("warm_migration", False),
+            xfs_compatibility=prepared_plan.get("xfs_compatibility", False),
+        )
+        assert self.plan_resource, "Plan creation failed"
+
+    def test_migrate_vms(
+        self,
+        fixture_store: dict[str, Any],
+        ocp_admin_client: "DynamicClient",
+        target_namespace: str,
+    ) -> None:
+        """Execute warm migration with cutover.
+
+        Args:
+            fixture_store: Fixture store for resource tracking
+            ocp_admin_client: OpenShift admin client
+            target_namespace: Target namespace for migration
+        """
+        execute_migration(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            plan=self.plan_resource,
+            target_namespace=target_namespace,
+            cut_over=get_cutover_value(),
+        )
+
+    def test_verify_xfs_version(
+        self,
+        prepared_plan: dict[str, Any],
+        source_provider: "BaseProvider",
+        source_provider_data: dict[str, Any],
+        source_vms_namespace: str,
+        vm_ssh_connections: "SSHConnectionManager",
+    ) -> None:
+        """Verify XFS filesystem on migrated VMs.
+
+        Args:
+            prepared_plan: Plan configuration with VM details
+            source_provider: Source provider instance
+            source_provider_data: Provider configuration from .providers.json
+            source_vms_namespace: Source VMs namespace
+            vm_ssh_connections: SSH connection manager for VMs
+        """
+        xfs_check = prepared_plan["xfs_check"]
+        for vm in prepared_plan["virtual_machines"]:
+            source_vm_info = source_provider.vm_dict(
+                name=vm["name"],
+                namespace=source_vms_namespace,
+                source=True,
+            )
+            check_vm_command_output(
+                vm=vm,
+                vm_ssh_connections=vm_ssh_connections,
+                source_vm_info=source_vm_info,
+                source_provider_data=source_provider_data,
+                command=[xfs_check["command"], xfs_check["mount_point"]],
+                expected_output=xfs_check["expected_output"],
+            )
+
+    def test_check_vms(
+        self,
+        prepared_plan: dict[str, Any],
+        source_provider: "BaseProvider",
+        destination_provider: "OCPProvider",
+        source_provider_data: dict[str, Any],
+        source_vms_namespace: str,
+        source_provider_inventory: "ForkliftInventory",
+        vm_ssh_connections: "SSHConnectionManager",
+    ) -> None:
+        """Validate migrated VMs.
+
+        Args:
+            prepared_plan: Plan configuration with VM details
+            source_provider: Source provider instance
+            destination_provider: Destination provider instance
+            source_provider_data: Provider configuration from .providers.json
+            source_vms_namespace: Source VMs namespace
+            source_provider_inventory: Source provider inventory
+            vm_ssh_connections: SSH connection manager for VMs
+        """
+        check_vms(
+            plan=prepared_plan,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            network_map_resource=self.network_map,
+            storage_map_resource=self.storage_map,
+            source_provider_data=source_provider_data,
+            source_vms_namespace=source_vms_namespace,
+            source_provider_inventory=source_provider_inventory,
+            vm_ssh_connections=vm_ssh_connections,
+        )

--- a/utilities/mtv_migration.py
+++ b/utilities/mtv_migration.py
@@ -146,6 +146,7 @@ def create_plan_resource(
     migrate_shared_disks: bool | None = None,
     target_power_state: str | None = None,
     enable_nested_virtualization: bool | None = None,
+    xfs_compatibility: bool = False,
 ) -> Plan:
     """Create MTV Plan CR resource.
 
@@ -181,6 +182,7 @@ def create_plan_resource(
         target_power_state (str | None): Target power state for VMs after migration (e.g., 'on', 'off'). Defaults to None.
         enable_nested_virtualization (bool | None): Whether to enable nested virtualization on migrated VMs.
             When False, CPU features vmx/svm are disabled. Defaults to None (not set on Plan CR).
+        xfs_compatibility (bool): Whether to use XFS-compatible virt-v2v image for VMs with XFS v4 filesystems. Defaults to False.
 
     Returns:
         Plan: The created Plan CR resource.
@@ -254,6 +256,9 @@ def create_plan_resource(
         # The volume populator framework requires this to generate consistent PVC names
         # Note: generateName is enabled by default, so Kubernetes adds random suffix automatically
         plan_kwargs["pvc_name_template"] = "pvc"
+
+    if xfs_compatibility:
+        plan_kwargs["xfs_compatibility"] = xfs_compatibility
 
     plan = create_and_store_resource(**plan_kwargs)
 

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -25,7 +25,7 @@ from libs.base_provider import BaseProvider
 from libs.forklift_inventory import ForkliftInventory
 from libs.providers.rhv import OvirtProvider
 from utilities.naming import resolve_destination_vm_name
-from utilities.ssh_utils import SSHConnectionManager, VMSSHConnection
+from utilities.ssh_utils import SSHConnectionManager, VMSSHConnection, run_cmd_in_vm
 from utilities.utils import get_cluster_version, get_value_from_py_config, rhv_provider
 from utilities.vmware_guest_operations import DATA_INTEGRITY_FILE
 
@@ -1507,6 +1507,53 @@ def check_ssl_configuration(source_provider: BaseProvider) -> None:
     )
 
     LOGGER.info(f"SSL configuration verified: insecureSkipVerify='{actual_value}' matches config")
+
+
+def check_vm_command_output(
+    vm: dict[str, Any],
+    vm_ssh_connections: SSHConnectionManager,
+    source_vm_info: dict[str, Any],
+    source_provider_data: dict[str, Any],
+    command: list[str],
+    expected_output: str,
+) -> None:
+    """Execute a command on VM via SSH and verify expected output is present.
+
+    Args:
+        vm: VM dict from plan["virtual_machines"]
+        vm_ssh_connections: SSH connections fixture manager
+        source_vm_info: Source VM information from source_provider.vm_dict()
+        source_provider_data: Provider configuration from .providers.json
+        command: Command to execute
+        expected_output: Expected string in command output
+
+    Raises:
+        ValueError: If VM is Windows (Linux-only feature)
+        AssertionError: If expected_output not found in command stdout
+    """
+    vm_name = vm["name"]
+    destination_vm_name = resolve_destination_vm_name(vm)
+
+    if source_vm_info.get("win_os", False):
+        raise ValueError(
+            f"Command output verification is only supported on Linux guests. VM '{vm_name}' is a Windows guest."
+        )
+
+    LOGGER.info(f"Running command on VM {destination_vm_name}: {' '.join(command)}")
+
+    ssh_username, ssh_password = get_ssh_credentials_from_provider_config(source_provider_data, source_vm_info)
+    ssh_conn = vm_ssh_connections.create(vm_name=destination_vm_name, username=ssh_username, password=ssh_password)
+
+    with ssh_conn:
+        stdout = run_cmd_in_vm(ssh_conn, command, f"Command on VM {destination_vm_name}")
+        LOGGER.info(f"Command output:\n{stdout}")
+
+        if expected_output not in stdout:
+            raise AssertionError(
+                f"Expected '{expected_output}' not found in command output on VM {destination_vm_name}. "
+                f"Command: {' '.join(command)}\n"
+                f"Output: {stdout}"
+            )
 
 
 def check_vms(

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -17,41 +17,12 @@ from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 from exceptions.exceptions import GuestCommandError
 from utilities.naming import resolve_destination_vm_name
 from utilities.post_migration import get_ssh_credentials_from_provider_config
-from utilities.ssh_utils import SSHConnectionManager, VMSSHConnection
+from utilities.ssh_utils import SSHConnectionManager, VMSSHConnection, run_cmd_in_vm
 
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
 
 LOGGER = get_logger(name=__name__)
-
-
-def _run_cmd_on_vm(
-    ssh_conn: VMSSHConnection,
-    cmd: list[str],
-    description: str,
-) -> str:
-    """Execute a command on a VM via SSH using the explicit executor pattern.
-
-    Uses the same approach as check_static_ip_preservation() in post_migration.py:
-    creates an executor with the correct user and port-forward port.
-
-    Args:
-        ssh_conn (VMSSHConnection): SSH connection object (must be connected via context manager).
-        cmd (list[str]): Command to execute.
-        description (str): Human-readable description for logging.
-
-    Returns:
-        str: Command stdout.
-
-    Raises:
-        GuestCommandError: If the command fails (non-zero return code).
-    """
-    executor = ssh_conn.rrmngmnt_host.executor(user=ssh_conn.rrmngmnt_user)  # type: ignore[union-attr]
-    executor.port = ssh_conn.local_port
-    rc, stdout, stderr = executor.run_cmd(cmd)
-    if rc != 0:
-        raise GuestCommandError(f"{description} failed (rc={rc}): {stderr}")
-    return stdout
 
 
 def _mount_shared_partition(ssh_conn: VMSSHConnection, partition: str, mount_point: str, vm_label: str) -> None:
@@ -66,8 +37,8 @@ def _mount_shared_partition(ssh_conn: VMSSHConnection, partition: str, mount_poi
     Raises:
         GuestCommandError: If mkdir or mount command fails.
     """
-    _run_cmd_on_vm(ssh_conn, ["sudo", "mkdir", "-p", mount_point], f"{vm_label} mkdir")
-    _run_cmd_on_vm(ssh_conn, ["sudo", "mount", partition, mount_point], f"{vm_label} mount")
+    run_cmd_in_vm(ssh_conn, ["sudo", "mkdir", "-p", mount_point], f"{vm_label} mkdir")
+    run_cmd_in_vm(ssh_conn, ["sudo", "mount", partition, mount_point], f"{vm_label} mount")
 
 
 def _umount_shared_partition(ssh_conn: VMSSHConnection, mount_point: str, vm_label: str) -> None:
@@ -81,7 +52,7 @@ def _umount_shared_partition(ssh_conn: VMSSHConnection, mount_point: str, vm_lab
     Raises:
         GuestCommandError: If umount command fails.
     """
-    _run_cmd_on_vm(ssh_conn, ["sudo", "umount", mount_point], f"{vm_label} umount")
+    run_cmd_in_vm(ssh_conn, ["sudo", "umount", mount_point], f"{vm_label} umount")
 
 
 def _write_marker(ssh_conn: VMSSHConnection, file_path: str, content: str, vm_label: str) -> None:
@@ -96,12 +67,12 @@ def _write_marker(ssh_conn: VMSSHConnection, file_path: str, content: str, vm_la
     Raises:
         GuestCommandError: If write or sync command fails.
     """
-    _run_cmd_on_vm(
+    run_cmd_in_vm(
         ssh_conn,
         ["sh", "-c", f"echo {shlex.quote(content)} | sudo tee {shlex.quote(file_path)} > /dev/null"],
         f"{vm_label} write test data",
     )
-    _run_cmd_on_vm(ssh_conn, ["sudo", "sync"], f"{vm_label} sync")
+    run_cmd_in_vm(ssh_conn, ["sudo", "sync"], f"{vm_label} sync")
 
 
 _VMI_VOLUME_STATUS_TIMEOUT = 300
@@ -286,7 +257,7 @@ def verify_shared_disk_data(
         with ssh_vm2:
             _mount_shared_partition(ssh_vm2, vm2_partition, mount_point, "VM2")
 
-            vm2_read_data = _run_cmd_on_vm(ssh_vm2, ["sudo", "cat", test_file_vm1], "VM2 read VM1 data")
+            vm2_read_data = run_cmd_in_vm(ssh_vm2, ["sudo", "cat", test_file_vm1], "VM2 read VM1 data")
             assert "Data from VM1" in vm2_read_data.strip(), f"VM2 cannot read VM1's data: {vm2_read_data}"
             LOGGER.info(f"VM2 ({vm2_name}): Successfully read VM1's data")
 
@@ -298,10 +269,10 @@ def verify_shared_disk_data(
         # Flush block device buffers to clear stale kernel cache.
         # XFS (non-cluster filesystem) retains metadata in kernel buffer cache.
         # Without this, VM1 won't see VM2's newly written files even after remount.
-        _run_cmd_on_vm(ssh_vm1, ["sudo", "blockdev", "--flushbufs", vm1_device], "VM1 flush buffers")
-        _run_cmd_on_vm(ssh_vm1, ["sudo", "mount", vm1_partition, mount_point], "VM1 remount")
+        run_cmd_in_vm(ssh_vm1, ["sudo", "blockdev", "--flushbufs", vm1_device], "VM1 flush buffers")
+        run_cmd_in_vm(ssh_vm1, ["sudo", "mount", vm1_partition, mount_point], "VM1 remount")
 
-        vm1_read_data = _run_cmd_on_vm(ssh_vm1, ["sudo", "cat", test_file_vm2], "VM1 read VM2 data")
+        vm1_read_data = run_cmd_in_vm(ssh_vm1, ["sudo", "cat", test_file_vm2], "VM1 read VM2 data")
         assert "Data from VM2" in vm1_read_data.strip(), f"VM1 cannot read VM2's data: {vm1_read_data}"
         LOGGER.info(f"VM1 ({vm1_name}): Successfully read VM2's data")
 

--- a/utilities/ssh_utils.py
+++ b/utilities/ssh_utils.py
@@ -19,10 +19,41 @@ from pytest_testconfig import config as py_config
 from rrmngmnt import Host, RootUser, User, UserWithPKey
 from simple_logger.logger import get_logger
 from timeout_sampler import TimeoutSampler, TimeoutExpiredError
+from exceptions.exceptions import GuestCommandError
 
 from libs.base_provider import BaseProvider
 
 LOGGER = get_logger(__name__)
+
+
+def run_cmd_in_vm(
+    ssh_conn: "VMSSHConnection",
+    cmd: list[str],
+    description: str,
+) -> str:
+    """Execute a command in a VM via SSH using the explicit executor pattern.
+
+    Args:
+        ssh_conn (VMSSHConnection): SSH connection object (must be connected via context manager).
+        cmd (list[str]): Command to execute.
+        description (str): Human-readable description for logging and error messages.
+
+    Returns:
+        str: Command stdout.
+
+    Raises:
+        ConnectionError: If SSH connection is not established.
+        GuestCommandError: If the command fails (non-zero return code).
+    """
+    if ssh_conn.rrmngmnt_host is None or ssh_conn.rrmngmnt_user is None or ssh_conn.local_port is None:
+        raise ConnectionError(f"{description}: SSH connection is not fully established")
+
+    executor = ssh_conn.rrmngmnt_host.executor(user=ssh_conn.rrmngmnt_user)
+    executor.port = ssh_conn.local_port
+    rc, stdout, stderr = executor.run_cmd(cmd)
+    if rc != 0:
+        raise GuestCommandError(f"{description} failed (rc={rc}): {stderr}")
+    return stdout
 
 
 class VMSSHConnection:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional XFS v4 compatibility flag to migration planning, enabling automated XFS verification after migration.
* **Tests**
  * Introduced new end-to-end warm and cold XFS verification suites for vSphere-to-OpenShift migrations.
  * Updated test selection so vSphere-marked XFS scenarios are skipped when used with non-vSphere providers.
* **Documentation**
  * Expanded configuration and testing guidance for the XFS verification step and added/updated vSphere marker documentation.
* **Refactor**
  * Unified remote VM command execution used by post-migration and shared-disk verification flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->