### PR TITLE
fix: use cloud-init's own boot-finished file instead of custom cloud-init.finish

### DIFF
--- a/utilities/copyoffload_migration.py
+++ b/utilities/copyoffload_migration.py
@@ -93,7 +93,7 @@ def wait_for_vmware_cloud_init_all_vms(
     """Wait for cloud-init to finish on all VMware VMs in the plan.
 
     Iterates over all VMs in the plan and waits for each to signal
-    cloud-init completion via the presence of ``/cloud-init.finish``.
+    cloud-init completion via the presence of ``/var/lib/cloud/instance/boot-finished``.
 
     Args:
         prepared_plan (dict[str, Any]): Processed plan config with VM data
@@ -113,7 +113,7 @@ def wait_for_vmware_cloud_init_all_vms(
             "source_provider_data": source_provider_data,
             "vm_name": vm_name,
             "provider_vm_api": provider_vm_api,
-            "file_name": "/cloud-init.finish",
+            "file_name": "/var/lib/cloud/instance/boot-finished",
         }
         if "source_vm_power" in vm_data:
             cloud_init_kwargs["target_power_state"] = vm_data["source_vm_power"]
@@ -138,7 +138,7 @@ def wait_for_cloud_init(
         source_provider_data: Source provider configuration data
         vm_name: Name of the VM
         provider_vm_api: Provider VM object
-        file_name: Full path to the file to check for (e.g., "/cloud-init.finish")
+        file_name: Full path to the file to check for (e.g., "/var/lib/cloud/instance/boot-finished")
         timeout: Timeout in seconds (default: 2000)
         target_power_state: Expected source VM power state for downstream validation ("on" or "off",
             default: "off"). When "off", logs that MTV will handle shutdown. Does not change VM power.


### PR DESCRIPTION
cloud-init creates /var/lib/cloud/instance/boot-finished only after all cloud-init scripts complete, making the custom /cloud-init.finish file redundant. Using the native file is more reliable and eliminates the risk of tests hanging if the custom file is never created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated copy-offload cloud-init readiness checking to use the correct boot-finished sentinel file, improving the reliability of system initialization status detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/mtv-api-tests/pull/506?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->