### PR TITLE
feat(MTV-596): copy-offload physical RDM disk migration test

### DIFF
--- a/tests/copyoffload/conftest.py
+++ b/tests/copyoffload/conftest.py
@@ -144,6 +144,28 @@ def multi_datastore_config(source_provider_data: dict[str, Any]) -> None:
     LOGGER.info("✓ Multi-datastore configuration validated: secondary_datastore_id = %s", secondary_datastore_id)
 
 
+@pytest.fixture(scope="class")
+def rdm_config(source_provider_data: dict[str, Any]) -> None:
+    """Validate RDM configuration for copy-offload RDM disk tests.
+
+    Args:
+        source_provider_data (dict[str, Any]): Source provider configuration data.
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If rdm_lun_uuid is missing.
+    """
+    copyoffload_config_data: dict[str, Any] = source_provider_data.get("copyoffload", {})
+    rdm_lun_uuid: str | None = copyoffload_config_data.get("rdm_lun_uuid")
+
+    if not rdm_lun_uuid:
+        raise ValueError("RDM copy-offload tests require 'rdm_lun_uuid' to be configured in the copyoffload section.")
+
+    LOGGER.info("✓ RDM configuration validated: rdm_lun_uuid = %s", rdm_lun_uuid)
+
+
 @pytest.fixture(scope="session")
 def copyoffload_storage_secret(
     fixture_store: dict[str, Any],

--- a/tests/copyoffload/test_copyoffload_migration.py
+++ b/tests/copyoffload/test_copyoffload_migration.py
@@ -1420,7 +1420,13 @@ class TestCopyoffloadMultiDiskDifferentPathMigration:
     indirect=True,
     ids=["MTV-562:copyoffload-rdm-virtual"],
 )
-@pytest.mark.usefixtures("vmware_cloud_init_ready", "multus_network_name", "copyoffload_config", "cleanup_migrated_vms")
+@pytest.mark.usefixtures(
+    "vmware_cloud_init_ready",
+    "multus_network_name",
+    "copyoffload_config",
+    "rdm_config",
+    "cleanup_migrated_vms",
+)
 class TestCopyoffloadRdmVirtualDiskMigration:
     """Copy-offload migration test - RDM virtual disk."""
 
@@ -1445,10 +1451,6 @@ class TestCopyoffloadRdmVirtualDiskMigration:
         storage_vendor_product = copyoffload_config_data["storage_vendor_product"]
         datastore_id = copyoffload_config_data["datastore_id"]
         storage_class = py_config["storage_class"]
-
-        # Validate RDM LUN is configured
-        if "rdm_lun_uuid" not in copyoffload_config_data or not copyoffload_config_data["rdm_lun_uuid"]:
-            pytest.fail("rdm_lun_uuid is required in copyoffload configuration for RDM disk tests")
 
         vms_names = [vm["name"] for vm in prepared_plan["virtual_machines"]]
 

--- a/tests/copyoffload/test_copyoffload_migration.py
+++ b/tests/copyoffload/test_copyoffload_migration.py
@@ -1424,6 +1424,7 @@ class TestCopyoffloadMultiDiskDifferentPathMigration:
     "vmware_cloud_init_ready",
     "multus_network_name",
     "copyoffload_config",
+    "copyoffload_ssh_key",
     "rdm_config",
     "cleanup_migrated_vms",
 )
@@ -1595,6 +1596,7 @@ class TestCopyoffloadRdmVirtualDiskMigration:
     "vmware_cloud_init_ready",
     "multus_network_name",
     "copyoffload_config",
+    "copyoffload_ssh_key",
     "rdm_config",
     "cleanup_migrated_vms",
 )
@@ -1768,7 +1770,13 @@ class TestCopyoffloadRdmPhysicalDiskMigration:
     indirect=True,
     ids=["MTV-564:copyoffload-multi-datastore"],
 )
-@pytest.mark.usefixtures("vmware_cloud_init_ready", "multus_network_name", "copyoffload_config", "cleanup_migrated_vms")
+@pytest.mark.usefixtures(
+    "vmware_cloud_init_ready",
+    "multus_network_name",
+    "copyoffload_config",
+    "copyoffload_ssh_key",
+    "cleanup_migrated_vms",
+)
 class TestCopyoffloadMultiDatastoreMigration:
     """Copy-offload migration test - multiple datastores."""
 
@@ -2132,6 +2140,7 @@ class TestCopyoffloadMultiDiskDifferentDatastorePathMigration:
     "multus_network_name",
     "copyoffload_config",
     "mixed_datastore_config",
+    "copyoffload_ssh_key",
     "cleanup_migrated_vms",
 )
 class TestCopyoffloadMixedDatastoreMigration:
@@ -2572,7 +2581,13 @@ class TestCopyoffloadFallbackLargeMigration:
     indirect=True,
     ids=["MTV-567:copyoffload-independent-persistent"],
 )
-@pytest.mark.usefixtures("vmware_cloud_init_ready", "multus_network_name", "copyoffload_config", "cleanup_migrated_vms")
+@pytest.mark.usefixtures(
+    "vmware_cloud_init_ready",
+    "multus_network_name",
+    "copyoffload_config",
+    "copyoffload_ssh_key",
+    "cleanup_migrated_vms",
+)
 class TestCopyoffloadIndependentPersistentDiskMigration:
     """Copy-offload migration test - independent persistent disk."""
 
@@ -2738,7 +2753,11 @@ class TestCopyoffloadIndependentPersistentDiskMigration:
     ids=["MTV-568:copyoffload-independent-nonpersistent"],
 )
 @pytest.mark.usefixtures(
-    "nonpersistent_disk_ready", "multus_network_name", "copyoffload_config", "cleanup_migrated_vms"
+    "nonpersistent_disk_ready",
+    "multus_network_name",
+    "copyoffload_config",
+    "copyoffload_ssh_key",
+    "cleanup_migrated_vms",
 )
 class TestCopyoffloadIndependentNonpersistentDiskMigration:
     """Copy-offload migration test - independent non-persistent disk."""
@@ -2905,7 +2924,13 @@ class TestCopyoffloadIndependentNonpersistentDiskMigration:
     indirect=True,
     ids=["MTV-573:copyoffload-10-mixed-disks"],
 )
-@pytest.mark.usefixtures("vmware_cloud_init_ready", "multus_network_name", "copyoffload_config", "cleanup_migrated_vms")
+@pytest.mark.usefixtures(
+    "vmware_cloud_init_ready",
+    "multus_network_name",
+    "copyoffload_config",
+    "copyoffload_ssh_key",
+    "cleanup_migrated_vms",
+)
 class TestCopyoffload10MixedDisksMigration:
     """Copy-offload migration test - 10 mixed disks (thin/thick)."""
 
@@ -3070,7 +3095,13 @@ class TestCopyoffload10MixedDisksMigration:
     indirect=True,
     ids=["MTV-600:copyoffload-large-vm"],
 )
-@pytest.mark.usefixtures("vmware_cloud_init_ready", "multus_network_name", "copyoffload_config", "cleanup_migrated_vms")
+@pytest.mark.usefixtures(
+    "vmware_cloud_init_ready",
+    "multus_network_name",
+    "copyoffload_config",
+    "copyoffload_ssh_key",
+    "cleanup_migrated_vms",
+)
 class TestCopyoffloadLargeVmMigration:
     """Copy-offload migration test - large VM (1TB)."""
 
@@ -3476,6 +3507,7 @@ class TestCopyoffloadNonconformingNameMigration:
     "multus_network_name",
     "precopy_interval_forkliftcontroller",
     "copyoffload_config",
+    "copyoffload_ssh_key",
     "cleanup_migrated_vms",
 )
 class TestCopyoffloadWarmMigration:

--- a/tests/copyoffload/test_copyoffload_migration.py
+++ b/tests/copyoffload/test_copyoffload_migration.py
@@ -1582,6 +1582,182 @@ class TestCopyoffloadRdmVirtualDiskMigration:
 
 @pytest.mark.vsphere
 @pytest.mark.copyoffload
+@pytest.mark.incremental
+@pytest.mark.parametrize(
+    "class_plan_config",
+    [pytest.param(py_config["tests_params"]["test_copyoffload_rdm_physical_disk_migration"])],
+    indirect=True,
+    ids=["MTV-596:copyoffload-rdm-physical"],
+)
+@pytest.mark.usefixtures(
+    "vmware_cloud_init_ready",
+    "multus_network_name",
+    "copyoffload_config",
+    "rdm_config",
+    "cleanup_migrated_vms",
+)
+class TestCopyoffloadRdmPhysicalDiskMigration:
+    """Copy-offload migration (MTV-596): compatibility-mode physical RDM disk (independent persistent)."""
+
+    storage_map: StorageMap
+    network_map: NetworkMap
+    plan_resource: Plan
+
+    def test_create_storagemap(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: DynamicClient,
+        source_provider: BaseProvider,
+        destination_provider: OCPProvider,
+        source_provider_inventory: ForkliftInventory,
+        target_namespace: str,
+        source_provider_data: dict[str, Any],
+        copyoffload_storage_secret: Secret,
+    ) -> None:
+        """Create StorageMap with copy-offload configuration."""
+        copyoffload_config_data = source_provider_data["copyoffload"]
+        storage_vendor_product = copyoffload_config_data["storage_vendor_product"]
+        datastore_id = copyoffload_config_data["datastore_id"]
+        storage_class = py_config["storage_class"]
+
+        vms_names = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+
+        offload_plugin_config = {
+            "vsphereXcopyConfig": {
+                "secretRef": copyoffload_storage_secret.name,
+                "storageVendorProduct": storage_vendor_product,
+            }
+        }
+
+        self.__class__.storage_map = get_storage_migration_map(
+            fixture_store=fixture_store,
+            target_namespace=target_namespace,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            ocp_admin_client=ocp_admin_client,
+            source_provider_inventory=source_provider_inventory,
+            vms=vms_names,
+            storage_class=storage_class,
+            datastore_id=datastore_id,
+            offload_plugin_config=offload_plugin_config,
+            volume_mode="Block",
+        )
+        assert self.storage_map, "StorageMap creation failed"
+
+    def test_create_networkmap(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: DynamicClient,
+        source_provider: BaseProvider,
+        destination_provider: OCPProvider,
+        source_provider_inventory: ForkliftInventory,
+        target_namespace: str,
+        multus_network_name: dict[str, str],
+    ) -> None:
+        """Create NetworkMap resource."""
+        vms_names = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.network_map = get_network_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            multus_network_name=multus_network_name,
+            target_namespace=target_namespace,
+            vms=vms_names,
+        )
+        assert self.network_map, "NetworkMap creation failed"
+
+    def test_create_plan(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: DynamicClient,
+        source_provider: BaseProvider,
+        destination_provider: OCPProvider,
+        target_namespace: str,
+        source_provider_inventory: ForkliftInventory,
+    ) -> None:
+        """Create MTV Plan CR resource."""
+        for vm in prepared_plan["virtual_machines"]:
+            vm_name = vm["name"]
+            vm_data = source_provider_inventory.get_vm(vm_name)
+            vm["id"] = vm_data["id"]
+
+        self.__class__.plan_resource = create_plan_resource(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            storage_map=self.storage_map,
+            network_map=self.network_map,
+            virtual_machines_list=prepared_plan["virtual_machines"],
+            target_namespace=target_namespace,
+            warm_migration=prepared_plan.get("warm_migration", False),
+            copyoffload=prepared_plan.get("copyoffload", False),
+        )
+        assert self.plan_resource, "Plan creation failed"
+
+    def test_migrate_vms(
+        self,
+        fixture_store: dict[str, Any],
+        ocp_admin_client: DynamicClient,
+        target_namespace: str,
+    ) -> None:
+        """Execute migration."""
+        execute_migration(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            plan=self.plan_resource,
+            target_namespace=target_namespace,
+        )
+
+    def test_check_xcopy_used(self, ocp_admin_client: DynamicClient, target_namespace: str) -> None:
+        """Verify XCOPY acceleration was used for all disks.
+
+        Args:
+            ocp_admin_client (DynamicClient): OpenShift admin client.
+            target_namespace (str): Namespace where populate pods exist.
+        """
+        verify_xcopy_used(
+            ocp_admin_client=ocp_admin_client,
+            plan=self.plan_resource,
+            target_namespace=target_namespace,
+            expected_xcopy_used=True,
+        )
+
+    def test_check_vms(
+        self,
+        prepared_plan: dict[str, Any],
+        source_provider: BaseProvider,
+        destination_provider: OCPProvider,
+        source_provider_data: dict[str, Any],
+        target_namespace: str,
+        source_vms_namespace: str,
+        source_provider_inventory: ForkliftInventory,
+        vm_ssh_connections: SSHConnectionManager | None,
+    ) -> None:
+        """Validate migrated VMs and verify disk count."""
+        check_vms(
+            plan=prepared_plan,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            network_map_resource=self.network_map,
+            storage_map_resource=self.storage_map,
+            source_provider_data=source_provider_data,
+            source_vms_namespace=source_vms_namespace,
+            source_provider_inventory=source_provider_inventory,
+            vm_ssh_connections=vm_ssh_connections,
+        )
+        verify_vm_disk_count(
+            destination_provider=destination_provider, plan=prepared_plan, target_namespace=target_namespace
+        )
+
+
+@pytest.mark.vsphere
+@pytest.mark.copyoffload
 @pytest.mark.copyoffload_sanity
 @pytest.mark.incremental
 @pytest.mark.parametrize(

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -196,6 +196,20 @@ tests_params: dict = {
         "warm_migration": False,
         "copyoffload": True,
     },
+    "test_copyoffload_rdm_physical_disk_migration": {
+        "virtual_machines": [
+            {
+                "name": "xcopy-template-test",
+                "guest_agent": True,
+                "clone": True,
+                "add_disks": [
+                    {"rdm_type": "physical"},  # physicalMode + independent_persistent; LUN from rdm_lun_uuid
+                ],
+            },
+        ],
+        "warm_migration": False,
+        "copyoffload": True,
+    },
     "test_copyoffload_thick_lazy_snapshots_migration": {
         "virtual_machines": [
             {


### PR DESCRIPTION
- Jira: https://redhat.atlassian.net/browse/MTV-596
- Related: https://redhat.atlassian.net/browse/MTV-562 (virtual RDM; shared `rdm_config` fixture)

## Summary

Adds copy-offload automation for compatibility-mode physical RDM disks (MTV-596) and aligns MTV-562 with shared RDM configuration validation.

- New `test_copyoffload_rdm_physical_disk_migration` plan config (`rdm_type: physical` → `physicalMode` + `independent_persistent` in VMware provider)
- New `TestCopyoffloadRdmPhysicalDiskMigration` with full type annotations and standard copy-offload flow (XCOPY + VM checks)
- New `rdm_config` class fixture validating `copyoffload.rdm_lun_uuid` (used by MTV-562 and MTV-596)
- MTV-562: remove `pytest.fail` in storagemap step; use `rdm_config` fixture instead

## Verification

Jenkins: both `TestCopyoffloadRdmVirtualDiskMigration` (MTV-562) and `TestCopyoffloadRdmPhysicalDiskMigration` (MTV-596) passed.

## Requirements

- `copyoffload.rdm_lun_uuid` in provider config
- VMFS `datastore_id` for RDM mapping (same as existing RDM tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for RDM physical-disk copy-offload, including XCOPY verification and migrated-disk validation.
  * Added a centralized fixture to validate RDM configuration before class tests run.
  * Expanded existing copy-offload test classes to include SSH key setup and updated test configurations to enable the new physical-disk scenario.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/mtv-api-tests/pull/509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->