### PR TITLE
fix: prefer kubeconfig over username/password authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,56 @@ podman run --rm \
 
 ---
 
+### Cluster Authentication
+
+The test framework supports two authentication methods with automatic precedence:
+
+#### Authentication Methods (in order of precedence)
+
+1. **Kubeconfig File** (Preferred - Token-based)
+   - Location: `~/.kube/config` or path from `KUBECONFIG` environment variable
+   - Created automatically by `oc login`
+   - Works with modern Kubernetes/OpenShift clusters
+   - **Recommended for all workflows**
+
+2. **Username/Password** (Legacy fallback)
+   - Specified via `--tc=cluster_username` and `--tc=cluster_password`
+   - Used only when kubeconfig is not available
+   - May not work with clusters that don't support HTTP basic authentication
+
+#### How It Works
+
+```bash
+# Method 1: Use oc login (creates kubeconfig) - RECOMMENDED
+oc login https://api.your-cluster.com:6443 -u kubeadmin -p your-password
+
+# Then run tests WITHOUT passing credentials (uses kubeconfig automatically)
+podman run --rm \
+  -v $(pwd)/.providers.json:/app/.providers.json:ro \
+  -v ${HOME}/.kube/config:/app/.kube/config:ro \
+  ghcr.io/redhatqe/mtv-api-tests:latest \
+  uv run pytest -m tier0 -v \
+    --tc=source_provider:vsphere-8.0.1 \
+    --tc=storage_class:YOUR-STORAGE-CLASS
+
+# Method 2: Pass credentials directly (legacy fallback)
+# Only used if kubeconfig doesn't exist
+podman run --rm \
+  -v $(pwd)/.providers.json:/app/.providers.json:ro \
+  ghcr.io/redhatqe/mtv-api-tests:latest \
+  uv run pytest -m tier0 -v \
+    --tc=cluster_host:https://api.your-cluster.com:6443 \
+    --tc=cluster_username:kubeadmin \
+    --tc=cluster_password:your-password \
+    --tc=source_provider:vsphere-8.0.1 \
+    --tc=storage_class:YOUR-STORAGE-CLASS
+```
+
+> **Note**: If both kubeconfig and username/password are provided, kubeconfig takes precedence.
+> This ensures compatibility with modern Kubernetes authentication while maintaining backward compatibility.
+
+---
+
 ## Running Different Test Categories
 
 The Quick Start runs **tier0** tests (smoke tests). You can run other test categories by changing the `-m` marker:

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ oc login https://api.your-cluster.com:6443 -u kubeadmin -p your-password
 podman run --rm \
   -v $(pwd)/.providers.json:/app/.providers.json:ro \
   -v ${HOME}/.kube/config:/app/.kube/config:ro \
+  -e KUBECONFIG=/app/.kube/config \
   ghcr.io/redhatqe/mtv-api-tests:latest \
   uv run pytest -m tier0 -v \
     --tc=source_provider:vsphere-8.0.1 \

--- a/utilities/utils.py
+++ b/utilities/utils.py
@@ -667,23 +667,29 @@ def get_cluster_client() -> DynamicClient:
     """
     # Try to use kubeconfig first (works with oc login and token-based auth)
     # This is the preferred method as it supports modern Kubernetes authentication
-    kubeconfig_path = os.environ.get("KUBECONFIG", os.path.expanduser("~/.kube/config"))
-    if os.path.exists(kubeconfig_path):
-        try:
-            LOGGER.info(f"Attempting to use kubeconfig from {kubeconfig_path}")
-            # Call get_client without parameters to use kubeconfig
-            client = get_client()
-            if isinstance(client, DynamicClient):
-                LOGGER.info(f"Successfully created client from kubeconfig (cluster: {client.configuration.host})")
-                return client
-            else:
-                LOGGER.warning(
-                    f"Kubeconfig client returned unexpected type {type(client).__name__}, "
-                    f"falling back to username/password authentication"
-                )
-        except Exception as e:
-            LOGGER.warning(f"Failed to load kubeconfig from {kubeconfig_path}: {e}")
-            LOGGER.warning("Falling back to username/password authentication")
+    # Build list of kubeconfig paths to try: KUBECONFIG env var first, then default
+    kubeconfig_candidates = []
+    if os.environ.get("KUBECONFIG"):
+        kubeconfig_candidates.append(os.environ.get("KUBECONFIG"))
+    kubeconfig_candidates.append(os.path.expanduser("~/.kube/config"))
+
+    for kubeconfig_path in kubeconfig_candidates:
+        if os.path.exists(kubeconfig_path):
+            try:
+                LOGGER.info(f"Attempting to use kubeconfig from {kubeconfig_path}")
+                # Call get_client without parameters to use kubeconfig
+                client = get_client()
+                if isinstance(client, DynamicClient):
+                    LOGGER.info(f"Successfully created client from kubeconfig (cluster: {client.configuration.host})")
+                    return client
+                else:
+                    LOGGER.warning(
+                        f"Kubeconfig client returned unexpected type {type(client).__name__}, "
+                        f"falling back to username/password authentication"
+                    )
+            except Exception:
+                LOGGER.exception(f"Failed to load kubeconfig from {kubeconfig_path}, trying next candidate")
+                # Continue to next candidate or fall through to username/password
 
     # Fall back to username/password authentication (legacy behavior)
     # Note: This may not work with modern Kubernetes clusters that don't support HTTP basic auth

--- a/utilities/utils.py
+++ b/utilities/utils.py
@@ -640,6 +640,12 @@ class VirtualMachineFromInstanceType(VirtualMachine):
 def get_cluster_client() -> DynamicClient:
     """Get a DynamicClient for the cluster.
 
+    Authentication is attempted in the following order:
+    1. Kubeconfig file (from KUBECONFIG env var or ~/.kube/config) - preferred method
+       This works with 'oc login' and token-based authentication.
+    2. Username/password credentials - fallback for legacy compatibility
+       Note: May not work with modern Kubernetes clusters that don't support HTTP basic auth.
+
     Credentials are resolved from pytest-testconfig (``py_config``) first,
     then from environment variables (``CLUSTER_HOST``,
     ``CLUSTER_USERNAME``, ``CLUSTER_PASSWORD``).
@@ -659,6 +665,23 @@ def get_cluster_client() -> DynamicClient:
     Raises:
         ValueError: If the client cannot be created.
     """
+    # Try to use kubeconfig first (works with oc login and token-based auth)
+    # This is the preferred method as it supports modern Kubernetes authentication
+    kubeconfig_path = os.environ.get("KUBECONFIG", os.path.expanduser("~/.kube/config"))
+    if os.path.exists(kubeconfig_path):
+        try:
+            LOGGER.info(f"Attempting to use kubeconfig from {kubeconfig_path}")
+            # Call get_client without parameters to use kubeconfig
+            client = get_client()
+            if isinstance(client, DynamicClient):
+                LOGGER.info("Successfully created client from kubeconfig")
+                return client
+        except Exception as e:
+            LOGGER.warning(f"Failed to load kubeconfig from {kubeconfig_path}: {e}")
+            LOGGER.warning("Falling back to username/password authentication")
+
+    # Fall back to username/password authentication (legacy behavior)
+    # Note: This may not work with modern Kubernetes clusters that don't support HTTP basic auth
     host = get_value_from_py_config("cluster_host")
     if host is None:
         host = os.environ.get("CLUSTER_HOST")
@@ -677,6 +700,12 @@ def get_cluster_client() -> DynamicClient:
         insecure_verify_skip = get_value_from_py_config("insecure_verify_skip")
         if insecure_verify_skip is None:
             insecure_verify_skip = True
+
+    LOGGER.info(
+        "Using username/password authentication. "
+        "Note: This may fail with modern Kubernetes clusters. "
+        "Consider using 'oc login' before running tests to create a valid kubeconfig."
+    )
     client = get_client(host=host, username=username, password=password, verify_ssl=not insecure_verify_skip)
     if not isinstance(client, DynamicClient):
         raise ValueError("Failed to get client for cluster")

--- a/utilities/utils.py
+++ b/utilities/utils.py
@@ -674,8 +674,13 @@ def get_cluster_client() -> DynamicClient:
             # Call get_client without parameters to use kubeconfig
             client = get_client()
             if isinstance(client, DynamicClient):
-                LOGGER.info("Successfully created client from kubeconfig")
+                LOGGER.info(f"Successfully created client from kubeconfig (cluster: {client.configuration.host})")
                 return client
+            else:
+                LOGGER.warning(
+                    f"Kubeconfig client returned unexpected type {type(client).__name__}, "
+                    f"falling back to username/password authentication"
+                )
         except Exception as e:
             LOGGER.warning(f"Failed to load kubeconfig from {kubeconfig_path}: {e}")
             LOGGER.warning("Falling back to username/password authentication")


### PR DESCRIPTION
### **User description**
## Problem

The mtv-2.11-ocp-4.20-copyoffload-tests Jenkins job (and similar jobs) were failing with authentication errors during test setup:

```
forbidden: User "system:anonymous" cannot get path "/apis"
kubernetes.dynamic.exceptions.ForbiddenError: 403
```

All 37 copyoffload sanity tests failed before execution during the ocp_admin_client fixture setup in conftest.py.

## Root Cause

The authentication flow had a critical mismatch:

1. Jenkins job runs `oc login` successfully, creating a valid kubeconfig with token-based authentication at ~/.kube/config
2. Jenkins passes OCP_USERNAME and OCP_PASSWORD to pytest via --tc parameters
3. The test framework's get_cluster_client() function receives these credentials via py_config
4. get_cluster_client() calls get_client(username=X, password=Y)
5. The Kubernetes Python client attempts HTTP basic authentication, which modern Kubernetes/OpenShift clusters do NOT support
6. Authentication fails silently, falling back to anonymous access
7. Anonymous user has no permissions → 403 Forbidden error

The issue is that username/password authentication is not supported by modern Kubernetes API servers, which require token-based or certificate-based authentication. When get_client() receives username/password, it cannot authenticate and falls back to anonymous access.

## Solution

Modified get_cluster_client() in utilities/utils.py to:

1. **First attempt**: Use kubeconfig file (KUBECONFIG env var or ~/.kube/config)
   - This works with `oc login` and token-based authentication
   - Supports modern Kubernetes authentication methods
   - Preferred method for all workflows

2. **Fallback**: Use username/password credentials if kubeconfig doesn't exist
   - Maintains backward compatibility with jobs that don't use `oc login`
   - Logs warning about potential incompatibility with modern clusters

## Backward Compatibility

This change is fully backward compatible:

- Jobs using `oc login`: Will now work correctly (currently broken)
- Jobs without kubeconfig: Continue using username/password (existing behavior)
- No changes required to Jenkins job configurations
- No breaking changes to the API or test invocation

## Testing

This fix resolves the authentication failures seen in:
- mtv-2.11-ocp-4.20-copyoffload-tests build #287
- All similar jobs that run `oc login` before pytest

The fix allows the test framework to use the token-based authentication created by `oc login` instead of attempting unsupported username/password authentication.

## Related Issues

- Failed job: mtv-2.11-ocp-4.20-copyoffload-tests/287
- Error: 403 Forbidden - User "system:anonymous" cannot get path "/apis"
- Impact: All copyoffload sanity tests (37 tests)


___

### **PR Type**
Bug fix


___

### **Description**
- Prioritize kubeconfig authentication over username/password credentials

- Fixes 403 Forbidden errors in Jenkins jobs using `oc login`

- Maintains backward compatibility with legacy username/password workflows

- Adds informative logging for authentication method selection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["get_cluster_client()"] --> B{"Kubeconfig exists?"}
  B -->|Yes| C["Load from kubeconfig"]
  C --> D{"Success?"}
  D -->|Yes| E["Return DynamicClient"]
  D -->|No| F["Log warning"]
  B -->|No| F
  F --> G["Fallback to username/password"]
  G --> H["Log compatibility warning"]
  H --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Implement kubeconfig-first authentication strategy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utilities/utils.py

<ul><li>Modified <code>get_cluster_client()</code> to attempt kubeconfig authentication <br>first before falling back to username/password<br> <li> Added check for kubeconfig file existence at <code>KUBECONFIG</code> env var or <br><code>~/.kube/config</code><br> <li> Wrapped kubeconfig loading in try-except with appropriate logging and <br>fallback handling<br> <li> Added informative log messages indicating authentication method <br>selection and potential compatibility issues<br> <li> Updated docstring to document the authentication priority order</ul>


</details>


  </td>
  <td><a href="https://github.com/RedHatQE/mtv-api-tests/pull/517/files#diff-f2cd59d13d09e6f5be55defefea728ef91ce80b1f8c0e67ccac41a3c7d1a6392">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Authentication now prefers kubeconfig (KUBECONFIG or ~/.kube/config) with username/password as a fallback.
  * Added clearer logging and a warning that username/password may fail on modern Kubernetes; recommends creating/using a kubeconfig when possible.

* **Documentation**
  * Added "Cluster Authentication" Quick Start section with usage examples for kubeconfig, oc login, and the username/password fallback, and notes on precedence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/mtv-api-tests/pull/517?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->