### PR TITLE
MTV-597: warm copy-offload virtual RDM test + note MTV-5622

### DIFF
--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -831,13 +831,13 @@ class VMWareProvider(BaseProvider):
             None,
         )
         if not scsi_controller:
-            raise RuntimeError(f"No SCSI controller found on VM '{vm.name}'")
+            raise ValueError(f"No SCSI controller found on VM '{vm.name}'")
 
         used_units = {dev.unitNumber for dev in vm.config.hardware.device if dev.controllerKey == scsi_controller.key}
         # Unit 7 reserved for SCSI controller
         unit_number = next((i for i in range(16) if i != 7 and i not in used_units), None)
         if unit_number is None:
-            raise RuntimeError(f"No available unit number on VM '{vm.name}'")
+            raise ValueError(f"No available unit number on VM '{vm.name}'")
 
         # Create RDM disk spec
         spec = vim.vm.device.VirtualDeviceSpec()
@@ -867,6 +867,8 @@ class VMWareProvider(BaseProvider):
         config_spec.deviceChange = [spec]
 
         if enable_cbt:
+            # CBT is VM-level; make it explicit when adding an RDM disk for warm migrations.
+            config_spec.changeTrackingEnabled = True
             cbt_key = f"scsi{scsi_controller.busNumber}:{unit_number}.ctkEnabled"
             existing_extra_config: dict[str, str] = {
                 option.key: str(option.value) for option in (vm.config.extraConfig or [])

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -813,7 +813,9 @@ class VMWareProvider(BaseProvider):
         Args:
             vm: The target VM object.
             rdm_type: "virtual" or "physical" compatibility mode.
-            enable_cbt: When True, enable per-disk CBT for the new RDM in the same reconfigure.
+            enable_cbt: When True (warm migration), enable per-disk CBT for the new RDM via
+                extraConfig only. VM-level CBT is already set during clone; RDM is attached
+                post-clone so its scsi bus:unit key must be added here.
 
         """
         lun_uuid = self.copyoffload_config["rdm_lun_uuid"]
@@ -867,8 +869,7 @@ class VMWareProvider(BaseProvider):
         config_spec.deviceChange = [spec]
 
         if enable_cbt:
-            # CBT is VM-level; make it explicit when adding an RDM disk for warm migrations.
-            config_spec.changeTrackingEnabled = True
+            # Match clone_vm: per-disk extraConfig only (VM-level ctkEnabled was set at clone).
             cbt_key = f"scsi{scsi_controller.busNumber}:{unit_number}.ctkEnabled"
             existing_extra_config: dict[str, str] = {
                 option.key: str(option.value) for option in (vm.config.extraConfig or [])

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -802,12 +802,18 @@ class VMWareProvider(BaseProvider):
         finally:
             container.Destroy()
 
-    def add_rdm_disk_to_vm(self, vm: vim.VirtualMachine, rdm_type: Literal["virtual", "physical"]) -> None:
+    def add_rdm_disk_to_vm(
+        self,
+        vm: vim.VirtualMachine,
+        rdm_type: Literal["virtual", "physical"],
+        enable_cbt: bool = False,
+    ) -> None:
         """Add an RDM disk to an existing VM. Must be called post-clone since RDM requires VMFS datastore.
 
         Args:
             vm: The target VM object.
             rdm_type: "virtual" or "physical" compatibility mode.
+            enable_cbt: When True, enable per-disk CBT for the new RDM in the same reconfigure.
 
         """
         lun_uuid = self.copyoffload_config["rdm_lun_uuid"]
@@ -859,6 +865,20 @@ class VMWareProvider(BaseProvider):
 
         config_spec = vim.vm.ConfigSpec()
         config_spec.deviceChange = [spec]
+
+        if enable_cbt:
+            cbt_key = f"scsi{scsi_controller.busNumber}:{unit_number}.ctkEnabled"
+            existing_extra_config: dict[str, str] = {
+                option.key: str(option.value) for option in (vm.config.extraConfig or [])
+            }
+            if existing_extra_config.get(cbt_key, "").lower() != "true":
+                disk_cbt_option = vim.option.OptionValue()
+                disk_cbt_option.key = cbt_key
+                disk_cbt_option.value = "true"
+                config_spec.extraConfig = [disk_cbt_option]
+                LOGGER.info(f"Enabling CTK for RDM disk {cbt_key} on VM '{vm.name}'")
+            else:
+                LOGGER.info(f"CBT already enabled for RDM disk {cbt_key} on VM '{vm.name}'")
 
         task = vm.ReconfigVM_Task(spec=config_spec)
         self.wait_task(task=task, action_name=f"Adding RDM disk to VM {vm.name}", wait_timeout=120)
@@ -1449,7 +1469,7 @@ class VMWareProvider(BaseProvider):
 
         # Add RDM disks post-clone (RDM requires VMFS datastore, can't be added during clone on NFS)
         for rdm_config in rdm_disks:
-            self.add_rdm_disk_to_vm(vm=res, rdm_type=rdm_config["rdm_type"])
+            self.add_rdm_disk_to_vm(vm=res, rdm_type=rdm_config["rdm_type"], enable_cbt=enable_ctk)
 
         return res
 

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -806,6 +806,7 @@ class VMWareProvider(BaseProvider):
         self,
         vm: vim.VirtualMachine,
         rdm_type: Literal["virtual", "physical"],
+        *,
         enable_cbt: bool = False,
     ) -> None:
         """Add an RDM disk to an existing VM. Must be called post-clone since RDM requires VMFS datastore.

--- a/tests/copyoffload/test_copyoffload_migration.py
+++ b/tests/copyoffload/test_copyoffload_migration.py
@@ -1772,7 +1772,6 @@ class TestCopyoffloadRdmPhysicalDiskMigration:
 )
 @pytest.mark.usefixtures(
     "vmware_cloud_init_ready",
-    "multus_network_name",
     "precopy_interval_forkliftcontroller",
     "copyoffload_config",
     "copyoffload_ssh_key",
@@ -1780,7 +1779,13 @@ class TestCopyoffloadRdmPhysicalDiskMigration:
     "cleanup_migrated_vms",
 )
 class TestCopyoffloadWarmRdmVirtualDiskMigration:
-    """Copy-offload warm migration (MTV-597): virtual/dependent RDM disk."""
+    """Copy-offload warm migration (MTV-597): virtual/dependent RDM disk.
+
+    Note:
+        This scenario is currently affected by [MTV-5622]: warm copy-offload migration
+        may fail preflight when a virtual RDM disk is attached (parent VMDK not found
+        on eco-iscsi-ds3).
+    """
 
     storage_map: StorageMap
     network_map: NetworkMap
@@ -1788,16 +1793,16 @@ class TestCopyoffloadWarmRdmVirtualDiskMigration:
 
     def test_create_storagemap(
         self,
-        prepared_plan,
-        fixture_store,
-        ocp_admin_client,
-        source_provider,
-        destination_provider,
-        source_provider_inventory,
-        target_namespace,
-        source_provider_data,
-        copyoffload_storage_secret,
-    ):
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: DynamicClient,
+        source_provider: BaseProvider,
+        destination_provider: BaseProvider,
+        source_provider_inventory: ForkliftInventory,
+        target_namespace: str,
+        source_provider_data: dict[str, Any],
+        copyoffload_storage_secret: Secret,
+    ) -> None:
         """Create StorageMap with copy-offload configuration."""
         copyoffload_config_data = source_provider_data["copyoffload"]
         storage_vendor_product = copyoffload_config_data["storage_vendor_product"]
@@ -1830,15 +1835,15 @@ class TestCopyoffloadWarmRdmVirtualDiskMigration:
 
     def test_create_networkmap(
         self,
-        prepared_plan,
-        fixture_store,
-        ocp_admin_client,
-        source_provider,
-        destination_provider,
-        source_provider_inventory,
-        target_namespace,
-        multus_network_name,
-    ):
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: DynamicClient,
+        source_provider: BaseProvider,
+        destination_provider: BaseProvider,
+        source_provider_inventory: ForkliftInventory,
+        target_namespace: str,
+        multus_network_name: dict[str, str],
+    ) -> None:
         """Create NetworkMap resource."""
         vms_names = [vm["name"] for vm in prepared_plan["virtual_machines"]]
         self.__class__.network_map = get_network_migration_map(
@@ -1855,14 +1860,14 @@ class TestCopyoffloadWarmRdmVirtualDiskMigration:
 
     def test_create_plan(
         self,
-        prepared_plan,
-        fixture_store,
-        ocp_admin_client,
-        source_provider,
-        destination_provider,
-        target_namespace,
-        source_provider_inventory,
-    ):
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: DynamicClient,
+        source_provider: BaseProvider,
+        destination_provider: OCPProvider,
+        target_namespace: str,
+        source_provider_inventory: ForkliftInventory,
+    ) -> None:
         """Create MTV Plan CR resource."""
         for vm in prepared_plan["virtual_machines"]:
             vm_name = vm["name"]
@@ -1883,7 +1888,12 @@ class TestCopyoffloadWarmRdmVirtualDiskMigration:
         )
         assert self.plan_resource, "Plan creation failed"
 
-    def test_migrate_vms(self, fixture_store, ocp_admin_client, target_namespace):
+    def test_migrate_vms(
+        self,
+        fixture_store: dict[str, Any],
+        ocp_admin_client: DynamicClient,
+        target_namespace: str,
+    ) -> None:
         """Execute warm migration with cutover."""
         LOGGER.info("Executing warm copy-offload migration with virtual RDM disk")
         execute_migration(
@@ -1905,15 +1915,15 @@ class TestCopyoffloadWarmRdmVirtualDiskMigration:
 
     def test_check_vms(
         self,
-        prepared_plan,
-        source_provider,
-        destination_provider,
-        source_provider_data,
-        target_namespace,
-        source_vms_namespace,
-        source_provider_inventory,
-        vm_ssh_connections,
-    ):
+        prepared_plan: dict[str, Any],
+        source_provider: BaseProvider,
+        destination_provider: OCPProvider,
+        source_provider_data: dict[str, Any],
+        target_namespace: str,
+        source_vms_namespace: str,
+        source_provider_inventory: ForkliftInventory,
+        vm_ssh_connections: SSHConnectionManager | None,
+    ) -> None:
         """Validate migrated VMs and verify disk count."""
         check_vms(
             plan=prepared_plan,

--- a/tests/copyoffload/test_copyoffload_migration.py
+++ b/tests/copyoffload/test_copyoffload_migration.py
@@ -1762,6 +1762,177 @@ class TestCopyoffloadRdmPhysicalDiskMigration:
 
 @pytest.mark.vsphere
 @pytest.mark.copyoffload
+@pytest.mark.warm
+@pytest.mark.incremental
+@pytest.mark.parametrize(
+    "class_plan_config",
+    [pytest.param(py_config["tests_params"]["test_copyoffload_warm_rdm_virtual_disk_migration"])],
+    indirect=True,
+    ids=["MTV-597:copyoffload-warm-rdm-virtual"],
+)
+@pytest.mark.usefixtures(
+    "vmware_cloud_init_ready",
+    "multus_network_name",
+    "precopy_interval_forkliftcontroller",
+    "copyoffload_config",
+    "copyoffload_ssh_key",
+    "rdm_config",
+    "cleanup_migrated_vms",
+)
+class TestCopyoffloadWarmRdmVirtualDiskMigration:
+    """Copy-offload warm migration (MTV-597): virtual/dependent RDM disk."""
+
+    storage_map: StorageMap
+    network_map: NetworkMap
+    plan_resource: Plan
+
+    def test_create_storagemap(
+        self,
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        destination_provider,
+        source_provider_inventory,
+        target_namespace,
+        source_provider_data,
+        copyoffload_storage_secret,
+    ):
+        """Create StorageMap with copy-offload configuration."""
+        copyoffload_config_data = source_provider_data["copyoffload"]
+        storage_vendor_product = copyoffload_config_data["storage_vendor_product"]
+        datastore_id = copyoffload_config_data["datastore_id"]
+        storage_class = py_config["storage_class"]
+
+        vms_names = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+
+        offload_plugin_config = {
+            "vsphereXcopyConfig": {
+                "secretRef": copyoffload_storage_secret.name,
+                "storageVendorProduct": storage_vendor_product,
+            }
+        }
+
+        self.__class__.storage_map = get_storage_migration_map(
+            fixture_store=fixture_store,
+            target_namespace=target_namespace,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            ocp_admin_client=ocp_admin_client,
+            source_provider_inventory=source_provider_inventory,
+            vms=vms_names,
+            storage_class=storage_class,
+            datastore_id=datastore_id,
+            offload_plugin_config=offload_plugin_config,
+            volume_mode="Block",
+        )
+        assert self.storage_map, "StorageMap creation failed"
+
+    def test_create_networkmap(
+        self,
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        destination_provider,
+        source_provider_inventory,
+        target_namespace,
+        multus_network_name,
+    ):
+        """Create NetworkMap resource."""
+        vms_names = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.network_map = get_network_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            multus_network_name=multus_network_name,
+            target_namespace=target_namespace,
+            vms=vms_names,
+        )
+        assert self.network_map, "NetworkMap creation failed"
+
+    def test_create_plan(
+        self,
+        prepared_plan,
+        fixture_store,
+        ocp_admin_client,
+        source_provider,
+        destination_provider,
+        target_namespace,
+        source_provider_inventory,
+    ):
+        """Create MTV Plan CR resource."""
+        for vm in prepared_plan["virtual_machines"]:
+            vm_name = vm["name"]
+            vm_data = source_provider_inventory.get_vm(vm_name)
+            vm["id"] = vm_data["id"]
+
+        self.__class__.plan_resource = create_plan_resource(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            storage_map=self.storage_map,
+            network_map=self.network_map,
+            virtual_machines_list=prepared_plan["virtual_machines"],
+            target_namespace=target_namespace,
+            warm_migration=prepared_plan.get("warm_migration", False),
+            copyoffload=prepared_plan.get("copyoffload", False),
+        )
+        assert self.plan_resource, "Plan creation failed"
+
+    def test_migrate_vms(self, fixture_store, ocp_admin_client, target_namespace):
+        """Execute warm migration with cutover."""
+        LOGGER.info("Executing warm copy-offload migration with virtual RDM disk")
+        execute_migration(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            plan=self.plan_resource,
+            target_namespace=target_namespace,
+            cut_over=get_cutover_value(),
+        )
+
+    def test_check_xcopy_used(self, ocp_admin_client: DynamicClient, target_namespace: str) -> None:
+        """Verify XCOPY acceleration was used for all disks."""
+        verify_xcopy_used(
+            ocp_admin_client=ocp_admin_client,
+            plan=self.plan_resource,
+            target_namespace=target_namespace,
+            expected_xcopy_used=True,
+        )
+
+    def test_check_vms(
+        self,
+        prepared_plan,
+        source_provider,
+        destination_provider,
+        source_provider_data,
+        target_namespace,
+        source_vms_namespace,
+        source_provider_inventory,
+        vm_ssh_connections,
+    ):
+        """Validate migrated VMs and verify disk count."""
+        check_vms(
+            plan=prepared_plan,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            network_map_resource=self.network_map,
+            storage_map_resource=self.storage_map,
+            source_provider_data=source_provider_data,
+            source_vms_namespace=source_vms_namespace,
+            source_provider_inventory=source_provider_inventory,
+            vm_ssh_connections=vm_ssh_connections,
+        )
+        verify_vm_disk_count(
+            destination_provider=destination_provider, plan=prepared_plan, target_namespace=target_namespace
+        )
+
+
+@pytest.mark.vsphere
+@pytest.mark.copyoffload
 @pytest.mark.copyoffload_sanity
 @pytest.mark.incremental
 @pytest.mark.parametrize(

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -209,6 +209,21 @@ tests_params: dict = {
         "warm_migration": False,
         "copyoffload": True,
     },
+    "test_copyoffload_warm_rdm_virtual_disk_migration": {
+        "virtual_machines": [
+            {
+                "name": "xcopy-template-test",
+                "source_vm_power": "on",
+                "guest_agent": True,
+                "clone": True,
+                "add_disks": [
+                    {"rdm_type": "virtual"},  # virtualMode + persistent; LUN from copyoffload.rdm_lun_uuid
+                ],
+            },
+        ],
+        "warm_migration": True,
+        "copyoffload": True,
+    },
     "test_copyoffload_thick_lazy_snapshots_migration": {
         "virtual_machines": [
             {


### PR DESCRIPTION
### **User description**
## Summary
- Add warm copy-offload virtual/dependent RDM test (MTV-597) and supporting config.
- Align the new test with fixture/type conventions and document known issue [MTV-5622](https://redhat.atlassian.net/browse/MTV-5622).
- Refine VMware provider RDM attach path: use `ValueError` for invalid VM state and enable CBT when requested.

## Context
Warm copy-offload migration may fail preflight when a virtual RDM disk is attached (parent VMDK not found on `eco-iscsi-ds3`) — tracked in [MTV-5622](https://redhat.atlassian.net/browse/MTV-5622).

## Pre-commit
- `pre-commit run --all-files`


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add warm copy-offload virtual RDM disk migration test (MTV-597)

- Enable CBT per-disk for RDM disks during warm migrations

- Refine RDM attach error handling with ValueError exceptions

- Document known MTV-5622 preflight issue with virtual RDM disks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["add_rdm_disk_to_vm method"] -->|"enable_cbt parameter"| B["CBT configuration"]
  B -->|"VM-level + per-disk"| C["changeTrackingEnabled + ctkEnabled"]
  D["TestCopyoffloadWarmRdmVirtualDiskMigration"] -->|"warm migration flow"| E["storagemap, networkmap, plan, migrate"]
  E -->|"verify"| F["XCOPY used, VM disk count"]
  G["Error handling"] -->|"ValueError instead RuntimeError"| H["Invalid VM state detection"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vmware.py</strong><dd><code>Enable CBT for RDM disks and improve error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/providers/vmware.py

<ul><li>Add <code>enable_cbt</code> parameter to <code>add_rdm_disk_to_vm</code> method for warm <br>migrations<br> <li> Implement per-disk CBT configuration via extraConfig when <br><code>enable_cbt=True</code><br> <li> Replace <code>RuntimeError</code> with <code>ValueError</code> for invalid VM state errors (no <br>SCSI controller, no available unit)<br> <li> Pass <code>enable_ctk</code> flag from <code>clone_vm</code> to <code>add_rdm_disk_to_vm</code> call</ul>


</details>


  </td>
  <td><a href="https://github.com/RedHatQE/mtv-api-tests/pull/523/files#diff-da9eac1397837f9bbc4edea574035a99d493ac0dd4415a6e5d9bdd21c127cb9e">+26/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_copyoffload_migration.py</strong><dd><code>Add warm copy-offload virtual RDM migration test class</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/copyoffload/test_copyoffload_migration.py

<ul><li>Add new test class <code>TestCopyoffloadWarmRdmVirtualDiskMigration</code> for warm <br>copy-offload with virtual RDM<br> <li> Implement standard copy-offload test flow: storagemap, networkmap, <br>plan, migrate, verify XCOPY, check VMs<br> <li> Mark with <code>@pytest.mark.warm</code> and <code>@pytest.mark.copyoffload</code> (not sanity)<br> <li> Document MTV-5622 known issue affecting warm copy-offload with virtual <br>RDM preflight</ul>


</details>


  </td>
  <td><a href="https://github.com/RedHatQE/mtv-api-tests/pull/523/files#diff-db80427e906686abaa147f4acbd9f094731859e2b6ba40b40bd296fa73d91b8f">+181/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Add warm virtual RDM migration test configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/tests_config/config.py

<ul><li>Add <code>test_copyoffload_warm_rdm_virtual_disk_migration</code> configuration <br>with virtual RDM disk<br> <li> Set <code>warm_migration=True</code> and <code>copyoffload=True</code> for the new test scenario<br> <li> Configure VM with <code>source_vm_power="on"</code> for warm migration requirements<br> <li> Use <code>rdm_type="virtual"</code> for virtual/dependent RDM compatibility mode</ul>


</details>


  </td>
  <td><a href="https://github.com/RedHatQE/mtv-api-tests/pull/523/files#diff-bd44158c04d40b13a776c6a4f4fc5245a958147cff61e65765b8be7f518f40fe">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for enabling change block tracking (CBT) on raw device mapping (RDM) disks during virtual machine cloning operations.

* **Bug Fixes**
  * Improved error handling for RDM disk attachment failures with more specific exception types.

* **Tests**
  * Added comprehensive test coverage for warm copy-offload migrations with virtual RDM disks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/mtv-api-tests/pull/523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->