### PR TITLE
feat: add NIC name preservation check for vSphere migrations

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1150,15 +1150,12 @@ def prepared_plan(
                         "Static IP verification may not work for this VM."
                     )
 
-                try:
-                    detect_guest_nic_names(
-                        source_provider=source_provider,
-                        vm=provider_vm_api,
-                        source_provider_data=fixture_store["source_provider_data"],
-                        vm_details=source_vm_details,
-                    )
-                except Exception as e:
-                    LOGGER.warning(f"Failed to detect guest NIC names for VM {vm['name']}: {e}")
+                detect_guest_nic_names(
+                    source_provider=source_provider,
+                    vm=provider_vm_api,
+                    source_provider_data=fixture_store["source_provider_data"],
+                    vm_details=source_vm_details,
+                )
 
         # Relink shared disks between clones (VMware-specific)
         # When VMs with shared disks are cloned, each clone gets independent disk copies,

--- a/conftest.py
+++ b/conftest.py
@@ -86,7 +86,7 @@ from utilities.utils import (
     resolve_providers_json_path,
 )
 from utilities.virtctl import add_to_path, download_virtctl_from_cluster
-from utilities.vmware_guest_operations import detect_vmware_ip_origins_via_guest_ops
+from utilities.vmware_guest_operations import detect_guest_nic_names, detect_vmware_ip_origins_via_guest_ops
 from utilities.worker_node_selection import get_worker_nodes, select_node_by_available_memory
 
 RESULTS_PATH = Path("./.xdist_results/")
@@ -1149,6 +1149,16 @@ def prepared_plan(
                         f"Failed to detect IP origins via Guest Operations for VM {vm['name']}: {e}. "
                         "Static IP verification may not work for this VM."
                     )
+
+                try:
+                    detect_guest_nic_names(
+                        source_provider=source_provider,
+                        vm=provider_vm_api,
+                        source_provider_data=fixture_store["source_provider_data"],
+                        vm_details=source_vm_details,
+                    )
+                except Exception as e:
+                    LOGGER.warning(f"Failed to detect guest NIC names for VM {vm['name']}: {e}")
 
         # Relink shared disks between clones (VMware-specific)
         # When VMs with shared disks are cloned, each clone gets independent disk copies,

--- a/libs/providers/openshift.py
+++ b/libs/providers/openshift.py
@@ -251,6 +251,7 @@ class OCPProvider(BaseProvider):
                 "macAddress": mac_addr,
                 "ip": self.get_ip_by_mac_address(mac_address=mac_addr, vm=cnv_vm) if not _source else "",
                 "network": "pod" if network.get("pod", False) else network["multus"]["networkName"].split("/")[1],
+                "guest_interface_name": interface.get("interfaceName", ""),
             })
 
         disk_idx = 0

--- a/libs/providers/openshift.py
+++ b/libs/providers/openshift.py
@@ -251,7 +251,7 @@ class OCPProvider(BaseProvider):
                 "macAddress": mac_addr,
                 "ip": self.get_ip_by_mac_address(mac_address=mac_addr, vm=cnv_vm) if not _source else "",
                 "network": "pod" if network.get("pod", False) else network["multus"]["networkName"].split("/")[1],
-                "guest_interface_name": interface.get("interfaceName", ""),
+                "guest_interface_name": interface.get("interfaceName") or "",
             })
 
         disk_idx = 0

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -722,10 +722,16 @@ def check_nic_name_preservation(source_vm_data: dict[str, Any], destination_vm: 
             network_interfaces with guest_interface_name field
 
     Raises:
+        ValueError: If source or destination has no network interfaces
         AssertionError: If any NIC name doesn't match between source and destination
     """
     source_nics = source_vm_data.get("network_interfaces", [])
     dest_nics = destination_vm.get("network_interfaces", [])
+
+    if not source_nics:
+        raise ValueError("Source VM has no network interfaces — cannot verify NIC name preservation")
+    if not dest_nics:
+        raise ValueError("Destination VM has no network interfaces — cannot verify NIC name preservation")
 
     for source_nic in source_nics:
         source_nic_name = source_nic.get("guest_nic_name")

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -708,6 +708,42 @@ def check_network(source_vm: dict[str, Any], destination_vm: dict[str, Any], net
         assert destination_vm_nic["network"] == expected_network_name
 
 
+def check_nic_name_preservation(source_vm_data: dict[str, Any], destination_vm: dict[str, Any]) -> None:
+    """Verify that guest OS NIC names are preserved after migration.
+
+    Compares source NIC names (collected via VMware Guest Operations before migration)
+    against destination NIC names (reported by guest agent on KubeVirt VMI).
+    Matches NICs by MAC address.
+
+    Args:
+        source_vm_data: Source VM data from plan["source_vms_data"], containing
+            network_interfaces with guest_nic_name field
+        destination_vm: Destination VM data from vm_dict(), containing
+            network_interfaces with guest_interface_name field
+
+    Raises:
+        AssertionError: If any NIC name doesn't match between source and destination
+    """
+    source_nics = source_vm_data.get("network_interfaces", [])
+    dest_nics = destination_vm.get("network_interfaces", [])
+
+    for source_nic in source_nics:
+        source_nic_name = source_nic.get("guest_nic_name")
+        if not source_nic_name:
+            continue
+
+        source_mac = source_nic.get("macAddress", "").lower()
+
+        for dest_nic in dest_nics:
+            if dest_nic.get("macAddress", "").lower() == source_mac:
+                dest_nic_name = dest_nic.get("guest_interface_name", "")
+                assert dest_nic_name == source_nic_name, (
+                    f"NIC name mismatch: source {source_nic_name} != destination {dest_nic_name} (MAC {source_mac})"
+                )
+                LOGGER.info(f"NIC name preserved: {source_nic_name} (MAC {source_mac})")
+                break
+
+
 def check_storage(source_vm: dict[str, Any], destination_vm: dict[str, Any], storage_map_resource: StorageMap) -> None:
     destination_disks = destination_vm["disks"]
     source_vm_disks_storage = [disk["storage"]["name"] for disk in source_vm["disks"]]
@@ -1395,6 +1431,16 @@ def check_vms(
                     )
                 except Exception as exp:
                     res[vm_name].append(f"check_static_ip_preservation - {str(exp)}")
+
+            # NIC name preservation check - for vSphere VMs with guest NIC names collected
+            if source_vm_data and source_provider.type == Provider.ProviderType.VSPHERE:
+                try:
+                    check_nic_name_preservation(
+                        source_vm_data=source_vm_data,
+                        destination_vm=destination_vm,
+                    )
+                except Exception as exp:
+                    res[vm_name].append(f"check_nic_name_preservation - {str(exp)}")
         elif vm_ssh_connections:
             LOGGER.info(
                 f"Skipping SSH connectivity check for VM {vm_name} - destination VM is not powered on "

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -1439,7 +1439,12 @@ def check_vms(
                     res[vm_name].append(f"check_static_ip_preservation - {str(exp)}")
 
             # NIC name preservation check - for vSphere VMs with guest NIC names collected
-            if source_vm_data and source_provider.type == Provider.ProviderType.VSPHERE:
+            # Requires guest agent to be running so destination VM has guest_interface_name populated
+            if (
+                source_vm_data
+                and destination_vm.get("guest_agent_running")
+                and source_provider.type == Provider.ProviderType.VSPHERE
+            ):
                 try:
                     check_nic_name_preservation(
                         source_vm_data=source_vm_data,

--- a/utilities/vmware_guest_operations.py
+++ b/utilities/vmware_guest_operations.py
@@ -251,6 +251,77 @@ def detect_vmware_ip_origins_via_guest_ops(
     _apply_ip_origins_to_vm_details(vm_details=vm_details, origins=origins, vm_name=vm.name)
 
 
+def detect_guest_nic_names(
+    source_provider: VMWareProvider,
+    vm: vim.VirtualMachine,
+    source_provider_data: dict[str, Any],
+    vm_details: dict[str, Any],
+) -> None:
+    """Detect guest OS NIC names via VMware Guest Operations API.
+
+    Runs 'ip link' inside the guest to collect NIC name and MAC address pairs,
+    then stores the guest NIC name on matching network interfaces in vm_details.
+
+    Args:
+        source_provider: VMware provider instance with content and host attributes
+        vm: VMware VM object (must be powered on with VMware Tools running)
+        source_provider_data: Provider config containing guest credentials
+        vm_details: VM details dict from vm_dict(), updated in-place
+
+    Raises:
+        ValueError: If guest credentials are not found in provider config
+        GuestCommandError: If the guest command fails
+    """
+    try:
+        guest_username = source_provider_data["guest_vm_linux_user"]
+        guest_password = source_provider_data["guest_vm_linux_password"]
+    except KeyError as e:
+        raise ValueError(
+            f"Linux VM credentials not found in provider config: {e}. "
+            "Required: guest_vm_linux_user, guest_vm_linux_password"
+        ) from e
+
+    LOGGER.info(f"Detecting guest NIC names via Guest Operations for VM {vm.name}")
+
+    auth = vim.vm.guest.NamePasswordAuthentication(
+        username=guest_username, password=guest_password, interactiveSession=False
+    )
+
+    vcenter_host = source_provider.host
+    if vcenter_host is None:
+        raise ValueError(f"vCenter host not available for provider used by VM {vm.name}")
+
+    script = (
+        "ip -o link show | awk -F': ' '{print $2}' | while read dev; do "
+        "mac=$(cat /sys/class/net/$dev/address 2>/dev/null); "
+        '[ -n "$mac" ] && [ "$dev" != "lo" ] && printf "%s|%s\\n" "$dev" "$mac"; '
+        "done"
+    )
+
+    output = run_command_in_vmware_guest(
+        content=source_provider.content,
+        vm=vm,
+        auth=auth,
+        command=script,
+        vcenter_host=vcenter_host,
+    )
+
+    for line in output.strip().splitlines():
+        if "|" not in line:
+            continue
+        nic_name, mac = line.split("|", 1)
+        nic_name = nic_name.strip()
+        mac = mac.strip().lower()
+
+        for nic in vm_details.get("network_interfaces", []):
+            if nic.get("macAddress", "").lower() == mac:
+                nic["guest_nic_name"] = nic_name
+                LOGGER.info(f"VM {vm.name}: NIC {nic_name} matched to MAC {mac}")
+                break
+        else:
+            LOGGER.warning(f"VM {vm.name}: NIC {nic_name} not found in vm_details")
+
+
 def create_data_integrity_marker(
     source_provider: VMWareProvider,
     vm: vim.VirtualMachine,

--- a/utilities/vmware_guest_operations.py
+++ b/utilities/vmware_guest_operations.py
@@ -275,6 +275,7 @@ def detect_guest_nic_names(
     Raises:
         ValueError: If guest credentials are not found in provider config
         GuestCommandError: If the guest command fails
+        json.JSONDecodeError: If the command output is not valid JSON
     """
     try:
         guest_username = source_provider_data["guest_vm_linux_user"]

--- a/utilities/vmware_guest_operations.py
+++ b/utilities/vmware_guest_operations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import shlex
 import ssl
 import urllib.request
@@ -259,8 +260,11 @@ def detect_guest_nic_names(
 ) -> None:
     """Detect guest OS NIC names via VMware Guest Operations API.
 
-    Runs 'ip link' inside the guest to collect NIC name and MAC address pairs,
+    Runs 'ip -j link show' inside the guest to collect NIC name and MAC address pairs,
     then stores the guest NIC name on matching network interfaces in vm_details.
+
+    Note: Only supports Linux guest operating systems. The caller must ensure this
+    is only invoked for VMs running a Linux guest OS.
 
     Args:
         source_provider: VMware provider instance with content and host attributes
@@ -291,27 +295,20 @@ def detect_guest_nic_names(
     if vcenter_host is None:
         raise ValueError(f"vCenter host not available for provider used by VM {vm.name}")
 
-    script = (
-        "ip -o link show | awk -F': ' '{print $2}' | while read dev; do "
-        "mac=$(cat /sys/class/net/$dev/address 2>/dev/null); "
-        '[ -n "$mac" ] && [ "$dev" != "lo" ] && printf "%s|%s\\n" "$dev" "$mac"; '
-        "done"
-    )
-
     output = run_command_in_vmware_guest(
         content=source_provider.content,
         vm=vm,
         auth=auth,
-        command=script,
+        command="ip -j link show",
         vcenter_host=vcenter_host,
     )
 
-    for line in output.strip().splitlines():
-        if "|" not in line:
+    interfaces = json.loads(output)
+    for iface in interfaces:
+        nic_name = iface.get("ifname", "")
+        mac = iface.get("address", "").lower()
+        if not mac or nic_name == "lo":
             continue
-        nic_name, mac = line.split("|", 1)
-        nic_name = nic_name.strip()
-        mac = mac.strip().lower()
 
         for nic in vm_details.get("network_interfaces", []):
             if nic.get("macAddress", "").lower() == mac:


### PR DESCRIPTION
- Jira: https://redhat.atlassian.net/browse/MTV-5005

## Summary

Adds automatic NIC name preservation verification for all vSphere Linux VM migrations (MTV-5007, MTV-4897).

- New `detect_guest_nic_names()` in `utilities/vmware_guest_operations.py` — runs `ip link show` inside VMware guest via Guest Operations API, stores NIC name per MAC in `guest_nic_name` field
- Call `detect_guest_nic_names()` in `conftest.py` `prepared_plan` for vSphere Linux VMs (after IP origins detection)
- Add `guest_interface_name` field (from KubeVirt VMI `interfaceName`) to network_interfaces in `libs/providers/openshift.py`
- New `check_nic_name_preservation()` in `utilities/post_migration.py` — matches by MAC address, asserts source NIC name == destination NIC name; hooked into `check_vms()` for vSphere migrations
- Non-blocking: if Guest Ops fails, warning logged, check silently skips (no false failures for powered-off VMs or Windows)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guest OS network interface names are now automatically detected during VMware migrations.
  * Post-migration validation now checks that source NIC names are preserved on the destination VM and reports discrepancies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->