### PR TITLE
feat(MTV-4803): per-disk xcopyUsed verification for mixed datastore migration

### DIFF
--- a/tests/copyoffload/test_copyoffload_migration.py
+++ b/tests/copyoffload/test_copyoffload_migration.py
@@ -29,7 +29,7 @@ from simple_logger.logger import get_logger
 from libs.base_provider import BaseProvider
 from libs.forklift_inventory import ForkliftInventory
 from libs.providers.openshift import OCPProvider
-from utilities.copyoffload_migration import verify_mixed_datastore_xcopy_used, verify_xcopy_used
+from utilities.copyoffload_migration import verify_xcopy_used, verify_xcopy_used_per_datastore
 from utilities.migration_utils import get_cutover_value
 from utilities.mtv_migration import (
     create_plan_resource,
@@ -2473,12 +2473,14 @@ class TestCopyoffloadMixedDatastoreMigration:
             non_xcopy_datastore_id: source_provider.get_datastore_name_by_id(non_xcopy_datastore_id),
         }
 
-        verify_mixed_datastore_xcopy_used(
+        verify_xcopy_used_per_datastore(
             ocp_admin_client=ocp_admin_client,
             plan=self.plan_resource,
             target_namespace=target_namespace,
-            xcopy_datastore_id=xcopy_datastore_id,
-            non_xcopy_datastore_id=non_xcopy_datastore_id,
+            expected_xcopy_by_datastore_id={
+                xcopy_datastore_id: True,
+                non_xcopy_datastore_id: False,
+            },
             datastore_names_by_id=datastore_names_by_id,
         )
 

--- a/tests/copyoffload/test_copyoffload_migration.py
+++ b/tests/copyoffload/test_copyoffload_migration.py
@@ -29,7 +29,7 @@ from simple_logger.logger import get_logger
 from libs.base_provider import BaseProvider
 from libs.forklift_inventory import ForkliftInventory
 from libs.providers.openshift import OCPProvider
-from utilities.copyoffload_migration import verify_xcopy_used
+from utilities.copyoffload_migration import verify_mixed_datastore_xcopy_used, verify_xcopy_used
 from utilities.migration_utils import get_cutover_value
 from utilities.mtv_migration import (
     create_plan_resource,
@@ -2448,6 +2448,38 @@ class TestCopyoffloadMixedDatastoreMigration:
             fixture_store=fixture_store,
             plan=self.plan_resource,
             target_namespace=target_namespace,
+        )
+
+    def test_check_xcopy_used(
+        self,
+        ocp_admin_client: DynamicClient,
+        target_namespace: str,
+        source_provider: VMWareProvider,
+        source_provider_data: dict[str, Any],
+    ) -> None:
+        """Verify XCOPY per disk: XCOPY-capable datastore uses XCOPY, non-XCOPY uses fallback.
+
+        Args:
+            ocp_admin_client (DynamicClient): OpenShift admin client.
+            target_namespace (str): Namespace where populate pods exist.
+            source_provider (VMWareProvider): Source VMware provider for datastore name lookup.
+            source_provider_data (dict[str, Any]): Source provider configuration.
+        """
+        copyoffload_config_data: dict[str, Any] = source_provider_data["copyoffload"]
+        xcopy_datastore_id: str = copyoffload_config_data["datastore_id"]
+        non_xcopy_datastore_id: str = copyoffload_config_data["non_xcopy_datastore_id"]
+        datastore_names_by_id: dict[str, str] = {
+            xcopy_datastore_id: source_provider.get_datastore_name_by_id(xcopy_datastore_id),
+            non_xcopy_datastore_id: source_provider.get_datastore_name_by_id(non_xcopy_datastore_id),
+        }
+
+        verify_mixed_datastore_xcopy_used(
+            ocp_admin_client=ocp_admin_client,
+            plan=self.plan_resource,
+            target_namespace=target_namespace,
+            xcopy_datastore_id=xcopy_datastore_id,
+            non_xcopy_datastore_id=non_xcopy_datastore_id,
+            datastore_names_by_id=datastore_names_by_id,
         )
 
     def test_check_vms(

--- a/utilities/copyoffload_migration.py
+++ b/utilities/copyoffload_migration.py
@@ -293,6 +293,37 @@ def _parse_xcopy_used_from_log(pod: Pod) -> int:
     return int(matches[-1])
 
 
+_SOURCE_DATASTORE_FROM_LOG_RE = re.compile(
+    r'(?:source_vmdk|source)="\[([^\]]+)\]',
+)
+
+
+def _parse_source_datastore_name_from_log(pod: Pod) -> str:
+    """Parse the source vSphere datastore display name from a populate pod's logs.
+
+    Populator logs reference datastores by display name (not MoRef ID), e.g.
+    ``source_vmdk="[<datastore-name>] vm-folder/disk.vmdk"``. Callers correlate this
+    name to ``datastore_id`` / ``non_xcopy_datastore_id`` from provider configuration.
+
+    Args:
+        pod (Pod): The populate pod to read logs from.
+
+    Returns:
+        str: Datastore display name from the log.
+
+    Raises:
+        ValueError: If no source datastore pattern is found in the pod logs.
+    """
+    log_content: str = pod.log()
+    match = _SOURCE_DATASTORE_FROM_LOG_RE.search(log_content)
+    if not match:
+        raise ValueError(
+            f"Source datastore not found in populate pod '{pod.name}' logs "
+            '(expected source_vmdk="[<datastore>]..." or source="[<datastore>]...")'
+        )
+    return match.group(1)
+
+
 def verify_xcopy_used(
     ocp_admin_client: DynamicClient,
     plan: Plan,
@@ -332,4 +363,89 @@ def verify_xcopy_used(
 
         assert xcopy_used == expected_value, (
             f"Pod '{pod.name}' (PVC '{pvc_name}'): expected xcopyUsed={expected_value}, got xcopyUsed={xcopy_used}"
+        )
+
+
+def verify_mixed_datastore_xcopy_used(
+    ocp_admin_client: DynamicClient,
+    plan: Plan,
+    target_namespace: str,
+    xcopy_datastore_id: str,
+    non_xcopy_datastore_id: str,
+    datastore_names_by_id: dict[str, str],
+) -> None:
+    """Verify per-disk xcopyUsed for mixed XCOPY and non-XCOPY datastore migrations.
+
+    Expected XCOPY behavior is determined from provider configuration (MoRef IDs in
+    ``copyoffload.datastore_id`` and ``copyoffload.non_xcopy_datastore_id``). Populate
+    pod logs use vSphere datastore display names, so ``datastore_names_by_id`` maps each
+    configured ID to its display name for log correlation.
+
+    Args:
+        ocp_admin_client (DynamicClient): OpenShift admin client for API interactions.
+        plan (Plan): The Plan CR resource (used to find the migration UID).
+        target_namespace (str): Namespace where populate pods exist.
+        xcopy_datastore_id (str): MoRef ID of the XCOPY-capable datastore from provider config.
+        non_xcopy_datastore_id (str): MoRef ID of the non-XCOPY datastore from provider config.
+        datastore_names_by_id (dict[str, str]): Maps each MoRef ID to its vSphere display name.
+
+    Raises:
+        ValueError: If populate pods, datastore mapping, or source datastore cannot be determined.
+        AssertionError: If any disk's xcopyUsed value does not match its datastore type.
+    """
+    required_ids = {xcopy_datastore_id, non_xcopy_datastore_id}
+    if set(datastore_names_by_id.keys()) != required_ids:
+        raise ValueError(
+            "datastore_names_by_id must map exactly the XCOPY and non-XCOPY datastore IDs; "
+            f"expected {sorted(required_ids)}, got {sorted(datastore_names_by_id.keys())}"
+        )
+
+    migration_uid: str = _get_migration_uid(plan=plan)
+    LOGGER.info(
+        f"Checking mixed-datastore xcopyUsed for migration '{migration_uid}' "
+        f"(xcopy datastore '{xcopy_datastore_id}', non-xcopy datastore '{non_xcopy_datastore_id}')"
+    )
+
+    populate_pods: list[Pod] = _find_populate_pods(
+        ocp_admin_client=ocp_admin_client,
+        namespace=target_namespace,
+        migration_uid=migration_uid,
+    )
+    LOGGER.info(f"Found {len(populate_pods)} populate pod(s)")
+
+    verified_datastore_ids: set[str] = set()
+
+    for pod in populate_pods:
+        pvc_name: str = pod.instance.metadata.labels.get("pvcName", pod.name)
+        source_datastore_name: str = _parse_source_datastore_name_from_log(pod=pod)
+        xcopy_used: int = _parse_xcopy_used_from_log(pod=pod)
+
+        if source_datastore_name == datastore_names_by_id[xcopy_datastore_id]:
+            source_datastore_id = xcopy_datastore_id
+            expected_value = 1
+        elif source_datastore_name == datastore_names_by_id[non_xcopy_datastore_id]:
+            source_datastore_id = non_xcopy_datastore_id
+            expected_value = 0
+        else:
+            expected_names = {datastore_id: name for datastore_id, name in datastore_names_by_id.items()}
+            raise ValueError(
+                f"Pod '{pod.name}' (PVC '{pvc_name}'): source datastore '{source_datastore_name}' "
+                f"does not match provider-configured datastores {expected_names}"
+            )
+
+        verified_datastore_ids.add(source_datastore_id)
+        LOGGER.info(
+            f"Pod '{pod.name}' (PVC '{pvc_name}', datastore '{source_datastore_id}' / "
+            f"'{source_datastore_name}'): xcopyUsed={xcopy_used}"
+        )
+
+        assert xcopy_used == expected_value, (
+            f"Pod '{pod.name}' (PVC '{pvc_name}', datastore '{source_datastore_id}' / "
+            f"'{source_datastore_name}'): expected xcopyUsed={expected_value}, got xcopyUsed={xcopy_used}"
+        )
+
+    if verified_datastore_ids != required_ids:
+        raise ValueError(
+            "Mixed datastore migration must include one disk per configured datastore; "
+            f"verified datastore IDs: {sorted(verified_datastore_ids)}"
         )

--- a/utilities/copyoffload_migration.py
+++ b/utilities/copyoffload_migration.py
@@ -303,7 +303,7 @@ def _parse_source_datastore_name_from_log(pod: Pod) -> str:
 
     Populator logs reference datastores by display name (not MoRef ID), e.g.
     ``source_vmdk="[<datastore-name>] vm-folder/disk.vmdk"``. Callers correlate this
-    name to ``datastore_id`` / ``non_xcopy_datastore_id`` from provider configuration.
+    name to MoRef IDs from provider configuration via ``datastore_names_by_id``.
 
     Args:
         pod (Pod): The populate pod to read logs from.
@@ -366,44 +366,83 @@ def verify_xcopy_used(
         )
 
 
-def verify_mixed_datastore_xcopy_used(
+def _resolve_datastore_id_from_display_name(
+    source_datastore_name: str,
+    datastore_names_by_id: dict[str, str],
+) -> str:
+    """Map a vSphere datastore display name from populator logs to its MoRef ID.
+
+    Args:
+        source_datastore_name (str): Datastore display name parsed from populate pod logs.
+        datastore_names_by_id (dict[str, str]): Maps each MoRef ID to its vSphere display name.
+
+    Returns:
+        str: MoRef ID for the matching datastore.
+
+    Raises:
+        ValueError: If the display name does not match any configured datastore.
+    """
+    matching_ids: list[str] = [
+        datastore_id
+        for datastore_id, display_name in datastore_names_by_id.items()
+        if display_name == source_datastore_name
+    ]
+    if len(matching_ids) == 1:
+        return matching_ids[0]
+    if len(matching_ids) > 1:
+        raise ValueError(
+            f"Datastore display name '{source_datastore_name}' matches multiple configured IDs: {matching_ids}"
+        )
+    raise ValueError(
+        f"Source datastore '{source_datastore_name}' does not match provider-configured datastores "
+        f"{datastore_names_by_id}"
+    )
+
+
+def verify_xcopy_used_per_datastore(
     ocp_admin_client: DynamicClient,
     plan: Plan,
     target_namespace: str,
-    xcopy_datastore_id: str,
-    non_xcopy_datastore_id: str,
+    expected_xcopy_by_datastore_id: dict[str, bool],
     datastore_names_by_id: dict[str, str],
+    *,
+    require_all_datastores_seen: bool = True,
 ) -> None:
-    """Verify per-disk xcopyUsed for mixed XCOPY and non-XCOPY datastore migrations.
+    """Verify per-disk xcopyUsed based on each disk's source vSphere datastore.
 
-    Expected XCOPY behavior is determined from provider configuration (MoRef IDs in
-    ``copyoffload.datastore_id`` and ``copyoffload.non_xcopy_datastore_id``). Populate
-    pod logs use vSphere datastore display names, so ``datastore_names_by_id`` maps each
-    configured ID to its display name for log correlation.
+    Use when a migration has disks on multiple datastores with different expected XCOPY
+    behavior (e.g. mixed XCOPY-capable and fallback datastores). Provider configuration
+    supplies MoRef IDs and expected values; populate pod logs use datastore display names.
 
     Args:
         ocp_admin_client (DynamicClient): OpenShift admin client for API interactions.
         plan (Plan): The Plan CR resource (used to find the migration UID).
         target_namespace (str): Namespace where populate pods exist.
-        xcopy_datastore_id (str): MoRef ID of the XCOPY-capable datastore from provider config.
-        non_xcopy_datastore_id (str): MoRef ID of the non-XCOPY datastore from provider config.
-        datastore_names_by_id (dict[str, str]): Maps each MoRef ID to its vSphere display name.
+        expected_xcopy_by_datastore_id (dict[str, bool]): Maps each datastore MoRef ID to
+            whether XCOPY is expected (True → xcopyUsed=1, False → xcopyUsed=0).
+        datastore_names_by_id (dict[str, str]): Maps each MoRef ID to its vSphere display
+            name for correlating populate pod logs. Keys must match
+            ``expected_xcopy_by_datastore_id`` exactly.
+        require_all_datastores_seen (bool): When True, every configured datastore ID must
+            appear in at least one populate pod log. Set False when multiple disks may
+            share a datastore and you only need per-pod verification.
 
     Raises:
-        ValueError: If populate pods, datastore mapping, or source datastore cannot be determined.
-        AssertionError: If any disk's xcopyUsed value does not match its datastore type.
+        ValueError: If mappings are invalid, populate pods are missing, or a log datastore
+            cannot be matched.
+        AssertionError: If any disk's xcopyUsed value does not match its datastore expectation.
     """
-    required_ids = {xcopy_datastore_id, non_xcopy_datastore_id}
-    if set(datastore_names_by_id.keys()) != required_ids:
+    if set(expected_xcopy_by_datastore_id.keys()) != set(datastore_names_by_id.keys()):
         raise ValueError(
-            "datastore_names_by_id must map exactly the XCOPY and non-XCOPY datastore IDs; "
-            f"expected {sorted(required_ids)}, got {sorted(datastore_names_by_id.keys())}"
+            "expected_xcopy_by_datastore_id and datastore_names_by_id must have the same keys; "
+            f"expected keys {sorted(expected_xcopy_by_datastore_id.keys())}, "
+            f"name keys {sorted(datastore_names_by_id.keys())}"
         )
 
     migration_uid: str = _get_migration_uid(plan=plan)
     LOGGER.info(
-        f"Checking mixed-datastore xcopyUsed for migration '{migration_uid}' "
-        f"(xcopy datastore '{xcopy_datastore_id}', non-xcopy datastore '{non_xcopy_datastore_id}')"
+        f"Checking per-datastore xcopyUsed for migration '{migration_uid}' "
+        f"(datastores: {sorted(expected_xcopy_by_datastore_id.keys())})"
     )
 
     populate_pods: list[Pod] = _find_populate_pods(
@@ -418,20 +457,13 @@ def verify_mixed_datastore_xcopy_used(
     for pod in populate_pods:
         pvc_name: str = pod.instance.metadata.labels.get("pvcName", pod.name)
         source_datastore_name: str = _parse_source_datastore_name_from_log(pod=pod)
+        source_datastore_id: str = _resolve_datastore_id_from_display_name(
+            source_datastore_name=source_datastore_name,
+            datastore_names_by_id=datastore_names_by_id,
+        )
+        expected_xcopy_used: bool = expected_xcopy_by_datastore_id[source_datastore_id]
+        expected_value: int = 1 if expected_xcopy_used else 0
         xcopy_used: int = _parse_xcopy_used_from_log(pod=pod)
-
-        if source_datastore_name == datastore_names_by_id[xcopy_datastore_id]:
-            source_datastore_id = xcopy_datastore_id
-            expected_value = 1
-        elif source_datastore_name == datastore_names_by_id[non_xcopy_datastore_id]:
-            source_datastore_id = non_xcopy_datastore_id
-            expected_value = 0
-        else:
-            expected_names = {datastore_id: name for datastore_id, name in datastore_names_by_id.items()}
-            raise ValueError(
-                f"Pod '{pod.name}' (PVC '{pvc_name}'): source datastore '{source_datastore_name}' "
-                f"does not match provider-configured datastores {expected_names}"
-            )
 
         verified_datastore_ids.add(source_datastore_id)
         LOGGER.info(
@@ -444,8 +476,8 @@ def verify_mixed_datastore_xcopy_used(
             f"'{source_datastore_name}'): expected xcopyUsed={expected_value}, got xcopyUsed={xcopy_used}"
         )
 
-    if verified_datastore_ids != required_ids:
+    if require_all_datastores_seen and verified_datastore_ids != set(expected_xcopy_by_datastore_id.keys()):
         raise ValueError(
-            "Mixed datastore migration must include one disk per configured datastore; "
+            "Migration must include at least one disk from each configured datastore; "
             f"verified datastore IDs: {sorted(verified_datastore_ids)}"
         )

--- a/utilities/copyoffload_migration.py
+++ b/utilities/copyoffload_migration.py
@@ -273,40 +273,23 @@ def _find_populate_pods(ocp_admin_client: DynamicClient, namespace: str, migrati
     return populate_pods
 
 
-def _parse_xcopy_used_from_log(pod: Pod) -> int:
-    """Parse the last xcopyUsed value from a populate pod's logs.
-
-    Args:
-        pod (Pod): The populate pod to read logs from.
-
-    Returns:
-        int: The last xcopyUsed value (0 or 1).
-
-    Raises:
-        ValueError: If xcopyUsed is not found in the pod logs.
-    """
-    log_content: str = pod.log()
-    matches: list[str] = re.findall(r"xcopyUsed=(\d+)", log_content)
-    if not matches:
-        raise ValueError(f"xcopyUsed not found in populate pod '{pod.name}' logs")
-
-    return int(matches[-1])
-
-
 _SOURCE_DATASTORE_FROM_LOG_RE = re.compile(
     r'(?:source_vmdk|source)="\[([^\]]+)\]',
 )
+_XCOPY_USED_LOG_RE = re.compile(r"xcopyUsed=(\d+)")
+_COPY_OFFLOAD_FAILED_ERR_RE = re.compile(r'"copy-offload failed" err="([^"]+)"')
 
 
-def _parse_source_datastore_name_from_log(pod: Pod) -> str:
-    """Parse the source vSphere datastore display name from a populate pod's logs.
+def _parse_source_datastore_name_from_log_content(pod_name: str, log_content: str) -> str:
+    """Parse the source vSphere datastore display name from populate pod log text.
 
     Populator logs reference datastores by display name (not MoRef ID), e.g.
     ``source_vmdk="[<datastore-name>] vm-folder/disk.vmdk"``. Callers correlate this
     name to MoRef IDs from provider configuration via ``datastore_names_by_id``.
 
     Args:
-        pod (Pod): The populate pod to read logs from.
+        pod_name (str): Populate pod name (for error messages).
+        log_content (str): Full populate pod log text.
 
     Returns:
         str: Datastore display name from the log.
@@ -314,14 +297,50 @@ def _parse_source_datastore_name_from_log(pod: Pod) -> str:
     Raises:
         ValueError: If no source datastore pattern is found in the pod logs.
     """
-    log_content: str = pod.log()
     match = _SOURCE_DATASTORE_FROM_LOG_RE.search(log_content)
     if not match:
         raise ValueError(
-            f"Source datastore not found in populate pod '{pod.name}' logs "
+            f"Source datastore not found in populate pod '{pod_name}' logs "
             '(expected source_vmdk="[<datastore>]..." or source="[<datastore>]...")'
         )
     return match.group(1)
+
+
+def _parse_xcopy_used_from_log_content(pod_name: str, log_content: str) -> tuple[int, str]:
+    """Parse the last xcopyUsed value and its log line from populate pod log text.
+
+    Args:
+        pod_name (str): Populate pod name (for error messages).
+        log_content (str): Full populate pod log text.
+
+    Returns:
+        tuple[int, str]: Last xcopyUsed value (0 or 1) and the log line it appeared on.
+
+    Raises:
+        ValueError: If the populator failed before logging xcopyUsed, or xcopyUsed is missing.
+    """
+    matches: list[re.Match[str]] = list(_XCOPY_USED_LOG_RE.finditer(log_content))
+    if not matches:
+        failure_match = _COPY_OFFLOAD_FAILED_ERR_RE.search(log_content)
+        if failure_match is not None:
+            raise ValueError(
+                f"Populate pod '{pod_name}' copy-offload failed before xcopyUsed was logged: {failure_match.group(1)}"
+            )
+        if '"copy-offload failed"' in log_content:
+            raise ValueError(
+                f"Populate pod '{pod_name}' copy-offload failed before xcopyUsed was logged; "
+                "see populate pod logs for details"
+            )
+        raise ValueError(f"xcopyUsed not found in populate pod '{pod_name}' logs")
+
+    last_match = matches[-1]
+    line_start = log_content.rfind("\n", 0, last_match.start()) + 1
+    line_end = log_content.find("\n", last_match.end())
+    if line_end == -1:
+        line_end = len(log_content)
+    last_log_line: str = log_content[line_start:line_end].strip()
+
+    return int(last_match.group(1)), last_log_line
 
 
 def verify_xcopy_used(
@@ -358,11 +377,16 @@ def verify_xcopy_used(
 
     for pod in populate_pods:
         pvc_name: str = pod.instance.metadata.labels.get("pvcName", pod.name)
-        xcopy_used: int = _parse_xcopy_used_from_log(pod=pod)
-        LOGGER.info(f"Pod '{pod.name}' (PVC '{pvc_name}'): xcopyUsed={xcopy_used}")
+        log_content: str = pod.log()
+        xcopy_used, xcopy_log_line = _parse_xcopy_used_from_log_content(
+            pod_name=pod.name,
+            log_content=log_content,
+        )
+        LOGGER.info(f"Pod '{pod.name}' (PVC '{pvc_name}'): xcopyUsed={xcopy_used}; log: {xcopy_log_line}")
 
         assert xcopy_used == expected_value, (
-            f"Pod '{pod.name}' (PVC '{pvc_name}'): expected xcopyUsed={expected_value}, got xcopyUsed={xcopy_used}"
+            f"Pod '{pod.name}' (PVC '{pvc_name}'): expected xcopyUsed={expected_value}, "
+            f"got xcopyUsed={xcopy_used}; log: {xcopy_log_line}"
         )
 
 
@@ -456,24 +480,32 @@ def verify_xcopy_used_per_datastore(
 
     for pod in populate_pods:
         pvc_name: str = pod.instance.metadata.labels.get("pvcName", pod.name)
-        source_datastore_name: str = _parse_source_datastore_name_from_log(pod=pod)
+        log_content: str = pod.log()
+        source_datastore_name: str = _parse_source_datastore_name_from_log_content(
+            pod_name=pod.name,
+            log_content=log_content,
+        )
         source_datastore_id: str = _resolve_datastore_id_from_display_name(
             source_datastore_name=source_datastore_name,
             datastore_names_by_id=datastore_names_by_id,
         )
         expected_xcopy_used: bool = expected_xcopy_by_datastore_id[source_datastore_id]
         expected_value: int = 1 if expected_xcopy_used else 0
-        xcopy_used: int = _parse_xcopy_used_from_log(pod=pod)
+        xcopy_used, xcopy_log_line = _parse_xcopy_used_from_log_content(
+            pod_name=pod.name,
+            log_content=log_content,
+        )
 
         verified_datastore_ids.add(source_datastore_id)
         LOGGER.info(
             f"Pod '{pod.name}' (PVC '{pvc_name}', datastore '{source_datastore_id}' / "
-            f"'{source_datastore_name}'): xcopyUsed={xcopy_used}"
+            f"'{source_datastore_name}'): xcopyUsed={xcopy_used}; log: {xcopy_log_line}"
         )
 
         assert xcopy_used == expected_value, (
             f"Pod '{pod.name}' (PVC '{pvc_name}', datastore '{source_datastore_id}' / "
-            f"'{source_datastore_name}'): expected xcopyUsed={expected_value}, got xcopyUsed={xcopy_used}"
+            f"'{source_datastore_name}'): expected xcopyUsed={expected_value}, got xcopyUsed={xcopy_used}; "
+            f"log: {xcopy_log_line}"
         )
 
     if require_all_datastores_seen and verified_datastore_ids != set(expected_xcopy_by_datastore_id.keys()):

--- a/utilities/copyoffload_migration.py
+++ b/utilities/copyoffload_migration.py
@@ -343,6 +343,39 @@ def _parse_xcopy_used_from_log_content(pod_name: str, log_content: str) -> tuple
     return int(last_match.group(1)), last_log_line
 
 
+def _log_xcopy_verification_result(
+    pod_name: str,
+    pvc_name: str,
+    expected_value: int,
+    actual_value: int,
+    xcopy_log_line: str,
+    *,
+    datastore_id: str | None = None,
+    datastore_display_name: str | None = None,
+) -> None:
+    """Log expected vs actual xcopyUsed for a populate pod verification.
+
+    Args:
+        pod_name (str): Populate pod name.
+        pvc_name (str): PVC label from the pod.
+        expected_value (int): Expected xcopyUsed (0 or 1).
+        actual_value (int): Actual xcopyUsed parsed from logs.
+        xcopy_log_line (str): Log line containing the last xcopyUsed value.
+        datastore_id (str | None): Optional MoRef ID when verifying per-datastore.
+        datastore_display_name (str | None): Optional vSphere datastore display name.
+    """
+    pod_context = f"Pod '{pod_name}' (PVC '{pvc_name}'"
+    if datastore_id is not None and datastore_display_name is not None:
+        pod_context += f", datastore '{datastore_id}' / '{datastore_display_name}'"
+    pod_context += ")"
+
+    result_label = "PASS" if expected_value == actual_value else "FAIL"
+    LOGGER.info(
+        f"{pod_context}: xcopyUsed expected={expected_value} actual={actual_value} "
+        f"({result_label}); log: {xcopy_log_line}"
+    )
+
+
 def verify_xcopy_used(
     ocp_admin_client: DynamicClient,
     plan: Plan,
@@ -382,7 +415,13 @@ def verify_xcopy_used(
             pod_name=pod.name,
             log_content=log_content,
         )
-        LOGGER.info(f"Pod '{pod.name}' (PVC '{pvc_name}'): xcopyUsed={xcopy_used}; log: {xcopy_log_line}")
+        _log_xcopy_verification_result(
+            pod_name=pod.name,
+            pvc_name=pvc_name,
+            expected_value=expected_value,
+            actual_value=xcopy_used,
+            xcopy_log_line=xcopy_log_line,
+        )
 
         assert xcopy_used == expected_value, (
             f"Pod '{pod.name}' (PVC '{pvc_name}'): expected xcopyUsed={expected_value}, "
@@ -497,9 +536,14 @@ def verify_xcopy_used_per_datastore(
         )
 
         verified_datastore_ids.add(source_datastore_id)
-        LOGGER.info(
-            f"Pod '{pod.name}' (PVC '{pvc_name}', datastore '{source_datastore_id}' / "
-            f"'{source_datastore_name}'): xcopyUsed={xcopy_used}; log: {xcopy_log_line}"
+        _log_xcopy_verification_result(
+            pod_name=pod.name,
+            pvc_name=pvc_name,
+            expected_value=expected_value,
+            actual_value=xcopy_used,
+            xcopy_log_line=xcopy_log_line,
+            datastore_id=source_datastore_id,
+            datastore_display_name=source_datastore_name,
         )
 
         assert xcopy_used == expected_value, (


### PR DESCRIPTION
## Summary

- Adds `test_check_xcopy_used` to `TestCopyoffloadMixedDatastoreMigration` (MTV-565) using a new `verify_xcopy_used_per_datastore()` utility for migrations where disks on different vSphere datastores have different expected XCOPY behavior.
- Maps provider-configured MoRef IDs (`datastore_id` → expect `xcopyUsed=1`, `non_xcopy_datastore_id` → expect `xcopyUsed=0`) to populate pod log display names for per-pod verification.
- Improves populate pod log parsing: single log read per pod, clearer errors when copy-offload fails before `xcopyUsed` is logged, and INFO logs with expected vs actual values plus PASS/FAIL.

## Test plan

- [x] Run `TestCopyoffloadMixedDatastoreMigration` on vSphere with mixed XCOPY and non-XCOPY datastores configured in provider JSON
- [x] Confirm both populate pods log `expected=` / `actual=` with `(PASS)` for XCOPY and fallback disks
- [x] Confirm existing copy-offload tests using `verify_xcopy_used()` are unchanged

Jira: [MTV-4803](https://redhat.atlassian.net/browse/MTV-4803)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced XCOPY validation test to check per-datastore behavior, verifying XCOPY usage separately for each datastore and ensuring expected outcomes per datastore.

* **Refactor**
  * Improved copy-offload verification with richer log parsing, clearer PASS/FAIL reporting that includes datastore context, and more robust datastore identification and observation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->