### PR TITLE
feat(copyoffload): add storage_secret_extra for array-specific Secret keys

### DIFF
--- a/.providers.json.example
+++ b/.providers.json.example
@@ -86,6 +86,14 @@
       # Get from ConfigMap in powermax namespace used by CSI driver
       "powermax_symmetrix_id": "000123456789",
 
+      # Optional: extra Kubernetes Secret stringData keys not covered by vendor fields above.
+      # Keys must match Forklift Secret names (uppercase). Example below is for PowerMax only.
+      # Overridden by COPYOFFLOAD_STORAGE_SECRET_EXTRA env var (JSON object).
+      # "storage_secret_extra": {
+      #   "POWERMAX_PORT_GROUP_NAME": "mtv_group_pg",
+      #   "STORAGE_SKIP_SSL_VERIFICATION": "true"
+      # },
+
       # HPE Primera/3PAR, Dell PowerStore, Infinidat InfiniBox, IBM FlashSystem:
       # No additional vendor-specific fields required - use only the common fields above
 

--- a/README.md
+++ b/README.md
@@ -563,6 +563,9 @@ troubleshooting, see:
 
 📖 **[Copy-Offload Testing Guide](guides/copyoffload/how-to-run-copyoffload-tests.md)**
 
+For array-specific Secret keys not covered by built-in vendor fields, use `storage_secret_extra` in the
+`copyoffload` section of `.providers.json` (or `COPYOFFLOAD_STORAGE_SECRET_EXTRA`); see the guide.
+
 For technical implementation details, see the
 [vsphere-xcopy-volume-populator documentation](https://github.com/kubev2v/forklift/tree/main/cmd/vsphere-xcopy-volume-populator).
 

--- a/cli/mtv_api_tests/common.py
+++ b/cli/mtv_api_tests/common.py
@@ -259,7 +259,7 @@ def gather_storage_secret_extra() -> dict[str, str]:
         secret_key = Prompt.ask("  Secret key (empty to finish)")
         if not secret_key.strip():
             break
-        value = Prompt.ask(f"  Value for {secret_key.strip()}")
+        value = Prompt.ask(f"  Value for {secret_key.strip()}", password=True)
         if not value.strip():
             console.print("  [yellow]Skipping empty value[/yellow]")
             continue
@@ -775,7 +775,9 @@ def mask_passwords(config: dict[str, Any]) -> dict[str, Any]:
     """
     masked: dict[str, Any] = {}
     for key, value in config.items():
-        if isinstance(value, dict):
+        if key == "storage_secret_extra" and isinstance(value, dict):
+            masked[key] = {secret_key: "***" for secret_key in value}
+        elif isinstance(value, dict):
             masked[key] = mask_passwords(value)
         elif "password" in key.lower() or "pwd" in key.lower():
             masked[key] = "***"

--- a/cli/mtv_api_tests/common.py
+++ b/cli/mtv_api_tests/common.py
@@ -242,6 +242,33 @@ def gather_vendor_fields(vendor: str) -> dict[str, str]:
     return result
 
 
+def gather_storage_secret_extra() -> dict[str, str]:
+    """Prompt for optional extra Kubernetes Secret keys for copy-offload.
+
+    Keys must match Forklift ``stringData`` names (uppercase, as required by the populator).
+
+    Returns:
+        dict[str, str]: Secret key names mapped to values for ``storage_secret_extra``.
+    """
+    if not Confirm.ask("\n  Add extra storage secret key/value pairs?", default=False):
+        return {}
+
+    console.print("  [dim]Use Kubernetes Secret stringData key names from the populator docs for your array[/dim]")
+    result: dict[str, str] = {}
+    while True:
+        secret_key = Prompt.ask("  Secret key (empty to finish)")
+        if not secret_key.strip():
+            break
+        value = Prompt.ask(f"  Value for {secret_key.strip()}")
+        if not value.strip():
+            console.print("  [yellow]Skipping empty value[/yellow]")
+            continue
+        result[secret_key.strip()] = value.strip()
+        if not Confirm.ask("  Add another secret key?", default=False):
+            break
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Credential gathering
 # ---------------------------------------------------------------------------

--- a/cli/mtv_api_tests/generate.py
+++ b/cli/mtv_api_tests/generate.py
@@ -27,6 +27,7 @@ from cli.mtv_api_tests.common import (
     discover_storage_classes,
     discover_vms,
     disconnect_vsphere,
+    gather_storage_secret_extra,
     gather_vendor_fields,
     generate_job_yaml,
     get_ocp_credentials,
@@ -156,6 +157,7 @@ def _gather_copyoffload_config(
     # Storage vendor and fields
     vendor = select_vendor()
     vendor_fields = gather_vendor_fields(vendor)
+    storage_secret_extra = gather_storage_secret_extra()
 
     # Storage credentials
     storage_host, storage_user, storage_pass = get_storage_credentials()
@@ -192,6 +194,8 @@ def _gather_copyoffload_config(
         config["rdm_lun_uuid"] = rdm_lun_uuid
     if non_xcopy_ds_id:
         config["non_xcopy_datastore_id"] = non_xcopy_ds_id
+    if storage_secret_extra:
+        config["storage_secret_extra"] = storage_secret_extra
 
     return config, guest_linux_user, guest_linux_pass
 

--- a/guides/copyoffload/how-to-run-copyoffload-tests.md
+++ b/guides/copyoffload/how-to-run-copyoffload-tests.md
@@ -217,6 +217,37 @@ Add the `copyoffload` section to your `.providers.json` file:
 
 - No vendor-specific fields required beyond the base storage configuration
 
+### Extra storage secret keys (`storage_secret_extra`)
+
+Use `storage_secret_extra` when the populator needs additional Kubernetes Secret keys that are not
+mapped by the built-in vendor fields (for example Dell PowerMax `POWERMAX_PORT_GROUP_NAME`).
+
+Keys in `storage_secret_extra` must match Forklift **Secret `stringData` names** (uppercase). Values are
+merged into the storage secret the test suite creates for copy-offload. They override vendor-mapped keys
+when the same Secret key is specified.
+
+Use quoted strings for values (for example `"true"`). If you use JSON booleans in
+`COPYOFFLOAD_STORAGE_SECRET_EXTRA` or in `.providers.json`, they are normalized to lowercase `"true"` /
+`"false"` for Secret `stringData`. An empty object or `null` for `storage_secret_extra` is allowed; env-only
+configuration still works.
+
+**Example (PowerMax):**
+
+```json
+"storage_secret_extra": {
+  "POWERMAX_PORT_GROUP_NAME": "mtv_group_pg",
+  "STORAGE_SKIP_SSL_VERIFICATION": "true"
+}
+```
+
+**Environment override** (takes precedence over `.providers.json`):
+
+```bash
+export COPYOFFLOAD_STORAGE_SECRET_EXTRA='{"POWERMAX_PORT_GROUP_NAME":"mtv_group_pg","STORAGE_SKIP_SSL_VERIFICATION":"true"}'
+```
+
+The `mtv-api-tests generate` wizard can prompt for these keys interactively after vendor-specific fields.
+
 ### Multi-Datastore Support (Advanced)
 
 Configuration for VMs with disks distributed across multiple datastores:

--- a/tests/copyoffload/conftest.py
+++ b/tests/copyoffload/conftest.py
@@ -11,7 +11,11 @@ from simple_logger.logger import get_logger
 from libs.base_provider import BaseProvider
 from libs.providers.vmware import VMWareProvider
 from utilities.copyoffload_constants import SUPPORTED_VENDORS
-from utilities.copyoffload_migration import get_copyoffload_credential, wait_for_vmware_cloud_init_all_vms
+from utilities.copyoffload_migration import (
+    get_copyoffload_credential,
+    merge_storage_secret_extra,
+    wait_for_vmware_cloud_init_all_vms,
+)
 from utilities.esxi import install_ssh_key_on_esxi, remove_ssh_key_from_esxi
 from utilities.resources import create_and_store_resource
 from utilities.utils import resolve_providers_json_path
@@ -208,6 +212,10 @@ def copyoffload_storage_secret(
             f"and COPYOFFLOAD_STORAGE_PASSWORD environment variables or include them in {providers_path}"
         )
 
+    assert storage_hostname is not None
+    assert storage_username is not None
+    assert storage_password is not None
+
     # Validate storage vendor product
     storage_vendor = copyoffload_cfg.get("storage_vendor_product")
     if not storage_vendor:
@@ -221,7 +229,7 @@ def copyoffload_storage_secret(
         )
 
     # Base secret data (required for all vendors)
-    secret_data = {
+    secret_data: dict[str, str] = {
         "STORAGE_HOSTNAME": storage_hostname,
         "STORAGE_USERNAME": storage_username,
         "STORAGE_PASSWORD": storage_password,
@@ -269,6 +277,8 @@ def copyoffload_storage_secret(
                     f"Required vendor-specific field '{config_key}' not found for vendor '{storage_vendor}'. "
                     f"Add it to {providers_path} copyoffload section or set environment variable: {env_var_name}"
                 )
+
+    secret_data = merge_storage_secret_extra(secret_data, copyoffload_cfg)
 
     LOGGER.info(f"Creating storage secret for copy-offload with vendor: {storage_vendor}")
 

--- a/utilities/copyoffload_migration.py
+++ b/utilities/copyoffload_migration.py
@@ -61,6 +61,12 @@ def _storage_secret_extra_value_as_string(value: Any) -> str:
     """Convert a config/env value to Kubernetes Secret stringData text.
 
     JSON booleans must become lowercase ``true``/``false``, not Python ``True``/``False``.
+
+    Args:
+        value: Raw value from JSON config or environment.
+
+    Returns:
+        str: Normalized Secret ``stringData`` text.
     """
     if isinstance(value, bool):
         return "true" if value else "false"
@@ -129,6 +135,10 @@ def get_storage_secret_extra(copyoffload_config: dict[str, Any]) -> dict[str, st
 
     Returns:
         dict[str, str]: Kubernetes Secret ``stringData`` keys and values to merge.
+
+    Raises:
+        ValueError: If ``storage_secret_extra`` contains empty keys or invalid env JSON.
+        TypeError: If ``storage_secret_extra`` is not a JSON object mapping.
     """
     extra: dict[str, str] = {}
     if "storage_secret_extra" not in copyoffload_config:
@@ -140,7 +150,7 @@ def get_storage_secret_extra(copyoffload_config: dict[str, Any]) -> dict[str, st
         extra.update(parse_storage_secret_extra_env())
         return extra
     if not isinstance(config_extra, dict):
-        raise ValueError("storage_secret_extra must be a JSON object mapping Secret keys to values")
+        raise TypeError("storage_secret_extra must be a JSON object mapping Secret keys to values")
 
     extra.update(_secret_extra_entries_from_mapping(config_extra))
     extra.update(parse_storage_secret_extra_env())
@@ -162,6 +172,10 @@ def merge_storage_secret_extra(
 
     Returns:
         dict[str, str]: Updated secret data including extra entries.
+
+    Raises:
+        ValueError: If extra entries from config or environment are invalid.
+        TypeError: If ``storage_secret_extra`` is not a JSON object mapping.
     """
     extra = get_storage_secret_extra(copyoffload_config)
     if not extra:

--- a/utilities/copyoffload_migration.py
+++ b/utilities/copyoffload_migration.py
@@ -7,6 +7,7 @@ including credential management, cloud-init readiness checks, and XCOPY validati
 
 from __future__ import annotations
 
+import json
 import os
 import re
 from typing import TYPE_CHECKING, Any
@@ -25,6 +26,8 @@ if TYPE_CHECKING:
     from ocp_resources.plan import Plan
 
 LOGGER = get_logger(__name__)
+
+STORAGE_SECRET_EXTRA_ENV = "COPYOFFLOAD_STORAGE_SECRET_EXTRA"  # pragma: allowlist secret
 
 
 def get_copyoffload_credential(
@@ -52,6 +55,123 @@ def get_copyoffload_credential(
     """
     env_var_name = f"COPYOFFLOAD_{credential_name.upper()}"
     return os.getenv(env_var_name) or copyoffload_config.get(credential_name)
+
+
+def _storage_secret_extra_value_as_string(value: Any) -> str:
+    """Convert a config/env value to Kubernetes Secret stringData text.
+
+    JSON booleans must become lowercase ``true``/``false``, not Python ``True``/``False``.
+    """
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value).strip()
+
+
+def _secret_extra_entries_from_mapping(mapping: dict[Any, Any]) -> dict[str, str]:
+    """Normalize a mapping to non-empty Secret stringData key/value pairs.
+
+    Args:
+        mapping: Raw key/value mapping from JSON config or environment.
+
+    Returns:
+        dict[str, str]: Normalized Secret keys and values.
+
+    Raises:
+        ValueError: If any key is empty after stripping.
+    """
+    result: dict[str, str] = {}
+    for secret_key, value in mapping.items():
+        if value is None:
+            continue
+        text = _storage_secret_extra_value_as_string(value)
+        if not text:
+            continue
+        key = str(secret_key).strip()
+        if not key:
+            raise ValueError("storage_secret_extra keys must be non-empty strings")
+        result[key] = text
+    return result
+
+
+def parse_storage_secret_extra_env() -> dict[str, str]:
+    """Parse COPYOFFLOAD_STORAGE_SECRET_EXTRA as a JSON object of secret key/value pairs.
+
+    Returns:
+        dict[str, str]: Secret keys and values from the environment variable.
+
+    Raises:
+        ValueError: If the variable is set but not valid JSON object, or keys are empty.
+        TypeError: If the parsed JSON value is not an object.
+    """
+    raw = os.getenv(STORAGE_SECRET_EXTRA_ENV, "").strip()
+    if not raw:
+        return {}
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{STORAGE_SECRET_EXTRA_ENV} must be a valid JSON object") from exc
+
+    if not isinstance(parsed, dict):
+        raise TypeError(f"{STORAGE_SECRET_EXTRA_ENV} must be a JSON object")
+
+    return _secret_extra_entries_from_mapping(parsed)
+
+
+def get_storage_secret_extra(copyoffload_config: dict[str, Any]) -> dict[str, str]:
+    """Resolve extra storage secret entries from providers JSON and environment.
+
+    Values from ``storage_secret_extra`` in ``.providers.json`` are applied first.
+    ``COPYOFFLOAD_STORAGE_SECRET_EXTRA`` (JSON object) overrides matching keys.
+
+    Args:
+        copyoffload_config: The provider ``copyoffload`` configuration dictionary.
+
+    Returns:
+        dict[str, str]: Kubernetes Secret ``stringData`` keys and values to merge.
+    """
+    extra: dict[str, str] = {}
+    if "storage_secret_extra" not in copyoffload_config:
+        extra.update(parse_storage_secret_extra_env())
+        return extra
+
+    config_extra = copyoffload_config["storage_secret_extra"]
+    if config_extra is None:
+        extra.update(parse_storage_secret_extra_env())
+        return extra
+    if not isinstance(config_extra, dict):
+        raise ValueError("storage_secret_extra must be a JSON object mapping Secret keys to values")
+
+    extra.update(_secret_extra_entries_from_mapping(config_extra))
+    extra.update(parse_storage_secret_extra_env())
+    return extra
+
+
+def merge_storage_secret_extra(
+    secret_data: dict[str, str],
+    copyoffload_config: dict[str, Any],
+) -> dict[str, str]:
+    """Merge ``storage_secret_extra`` entries into copy-offload storage secret data.
+
+    Extra entries override existing keys (for example vendor-mapped fields) when the
+    same Secret key is specified.
+
+    Args:
+        secret_data: Base and vendor-specific secret ``stringData`` built so far.
+        copyoffload_config: The provider ``copyoffload`` configuration dictionary.
+
+    Returns:
+        dict[str, str]: Updated secret data including extra entries.
+    """
+    extra = get_storage_secret_extra(copyoffload_config)
+    if not extra:
+        return secret_data
+
+    merged = dict(secret_data)
+    for secret_key, value in extra.items():
+        merged[secret_key] = value
+        LOGGER.info(f"✓ Added extra secret field from storage_secret_extra: {secret_key}")
+    return merged
 
 
 def wait_for_plan_secret(ocp_admin_client: DynamicClient, namespace: str, plan_name: str) -> None:


### PR DESCRIPTION
## Summary

- Add optional `storage_secret_extra` in `.providers.json` `copyoffload` block for Forklift Secret `stringData` keys not covered by built-in vendor fields (e.g. PowerMax `POWERMAX_PORT_GROUP_NAME`, `STORAGE_SKIP_SSL_VERIFICATION`).
- Support `COPYOFFLOAD_STORAGE_SECRET_EXTRA` env var (JSON object) to override matching keys at runtime.
- Merge extras in the copy-offload storage secret fixture after base + vendor fields.
- Extend `mtv-api-tests generate` wizard with an optional prompt for extra keys.
- Document usage in the copy-offload guide, README, and `.providers.json.example`.

If `storage_secret_extra` is missing, empty, or `null`, behavior is unchanged.

## Test plan

- [x] `TestCopyoffloadThinMigration` on `ocp-edge97` (ONTAP) — **6/6 passed** (multiple runs)
- [x] Verified storage Secret on cluster includes extra keys from `storage_secret_extra` (`QE_TEST_EXTRA_KEY`, `ANOTHER_NON_VENDOR_KEY`) plus `STORAGE_*` and `ONTAP_SVM`
- [x] `pre-commit run --all-files` passed on changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow configuring extra custom Kubernetes Secret keys for copy‑offload via provider config or the COPYOFFLOAD_STORAGE_SECRET_EXTRA environment variable; interactive wizard may prompt for these.

* **Documentation**
  * Added detailed guidance, examples, quoting/boolean rules, and precedence (env overrides provider) for supplying extra secret fields.

* **Bug Fixes**
  * Extra secret values are now masked in displayed configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->