### PR TITLE
fix: validate preserve_static_ips requires source_vm_power='on'

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1076,6 +1076,14 @@ def prepared_plan(
                 "does not implement relink_shared_disks"
             )
 
+        if plan.get("preserve_static_ips"):
+            for vm in virtual_machines:
+                if vm.get("source_vm_power") != "on":
+                    raise ValueError(
+                        f"preserve_static_ips requires source_vm_power='on' for VM '{vm['name']}'. "
+                        "Guest tools must be running to collect static IP and NIC name data."
+                    )
+
         original_source_vm_names: list[str] = [vm["name"] for vm in virtual_machines] if has_shared_disk_config else []
         cloned_vm_objects: list[Any] = []
 


### PR DESCRIPTION
## Summary
- Add early validation in `prepared_plan`: fail fast if `preserve_static_ips` is set but `source_vm_power` is not `"on"`

## Changed Files
| File | Change |
|------|--------|
| `conftest.py` | Add `ValueError` validation before VM processing loop |

## Test plan
- [x] Pre-commit passes
- [x] Warm sanity still passes
- [x] Cold sanity still passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for preserving static IPs: when enabled, the system now checks that each VM is powered on before collecting static IP and NIC name data, and surfaces an error if any VM is not running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->