### PR TITLE
fix: wait for Forklift inventory network sync after VM cloning

### DIFF
--- a/tests/copyoffload/conftest.py
+++ b/tests/copyoffload/conftest.py
@@ -375,13 +375,14 @@ def vmware_cloud_init_ready(
 ) -> None:
     """Ensure cloud-init has finished and Forklift inventory synced for all VMs.
 
-    This fixture performs two critical wait operations in this order:
-    1. Waits for Forklift provider inventory to sync VM network data (while VMs are powered off)
-    2. Powers on VMs and waits for cloud-init completion (via VMware Guest Operations)
+    This fixture performs three critical operations to match successful manual migration workflow:
+    1. Powers on VMs and waits for cloud-init completion (via VMware Guest Operations)
+    2. Powers off all VMs after cloud-init completes
+    3. Waits for Forklift provider inventory to sync VM network data (while VMs are powered off)
 
-    The order is critical: MTV 2.12 Forklift inventory does not sync NIC data for powered-on VMs.
-    Since VMs are powered off after cloning, we must wait for NIC sync before powering them on
-    for cloud-init. Tests query Forklift inventory for network mappings, not vCenter API directly.
+    MTV 2.12 regression: NICs only sync to Forklift inventory AFTER the VM has been powered on
+    at least once (for cloud-init), then powered off, then several minutes pass for sync.
+    This matches the manual migration workflow where users power off VMs before creating plans.
 
     Args:
         prepared_plan (dict[str, Any]): Processed test plan configuration.
@@ -394,19 +395,28 @@ def vmware_cloud_init_ready(
     """
     vm_names = [vm["name"] for vm in prepared_plan["virtual_machines"]]
 
-    # FIRST: Wait for Forklift inventory to sync VM network data (VMs are powered off after cloning)
-    # MTV 2.12 regression: NICs only sync to inventory for powered-off VMs
-    wait_for_vm_networks_in_inventory(
-        source_provider_inventory=source_provider_inventory,
-        vm_names=vm_names,
-        timeout=300,
-    )
-
-    # THEN: Power on VMs and wait for cloud-init to complete
+    # STEP 1: Power on VMs and wait for cloud-init to complete
     wait_for_vmware_cloud_init_all_vms(
         prepared_plan=prepared_plan,
         source_provider=source_provider,
         source_provider_data=source_provider_data,
+    )
+
+    # STEP 2: Power off all VMs after cloud-init (required for inventory sync in MTV 2.12)
+    LOGGER.info("Powering off VMs after cloud-init to enable NIC sync to Forklift inventory...")
+    for vm_data in prepared_plan["virtual_machines"]:
+        vm_name = vm_data["name"]
+        provider_vm_api = prepared_plan["source_vms_data"][vm_name]["provider_vm_api"]
+        LOGGER.info(f"Powering off VM {vm_name}")
+        source_provider.stop_vm(provider_vm_api)
+
+    # STEP 3: Wait for Forklift inventory to sync VM network data (VMs now powered off)
+    # MTV 2.12 requires: VM powered on once + cloud-init + powered off + wait for sync
+    LOGGER.info("Waiting for Forklift inventory to sync NICs after VMs powered off...")
+    wait_for_vm_networks_in_inventory(
+        source_provider_inventory=source_provider_inventory,
+        vm_names=vm_names,
+        timeout=600,  # Increased to 10 minutes based on manual migration timing
     )
 
 
@@ -420,13 +430,14 @@ def vmware_cloud_init_ready_both_plans(
 ) -> None:
     """Ensure cloud-init has finished and Forklift inventory synced for all VMs from both plans.
 
-    This fixture performs two critical wait operations in this order:
-    1. Waits for Forklift provider inventory to sync VM network data (while VMs are powered off)
-    2. Powers on VMs and waits for cloud-init completion (via VMware Guest Operations)
+    This fixture performs three critical operations to match successful manual migration workflow:
+    1. Powers on VMs and waits for cloud-init completion (via VMware Guest Operations)
+    2. Powers off all VMs after cloud-init completes
+    3. Waits for Forklift provider inventory to sync VM network data (while VMs are powered off)
 
-    The order is critical: MTV 2.12 Forklift inventory does not sync NIC data for powered-on VMs.
-    Since VMs are powered off after cloning, we must wait for NIC sync before powering them on
-    for cloud-init. Tests query Forklift inventory for network mappings, not vCenter API directly.
+    MTV 2.12 regression: NICs only sync to Forklift inventory AFTER the VM has been powered on
+    at least once (for cloud-init), then powered off, then several minutes pass for sync.
+    This matches the manual migration workflow where users power off VMs before creating plans.
 
     Args:
         prepared_plan_1 (dict[str, Any]): First processed test plan configuration.
@@ -442,21 +453,31 @@ def vmware_cloud_init_ready_both_plans(
     all_vm_names = [vm["name"] for vm in prepared_plan_1["virtual_machines"]]
     all_vm_names.extend([vm["name"] for vm in prepared_plan_2["virtual_machines"]])
 
-    # FIRST: Wait for Forklift inventory to sync VM network data (VMs are powered off after cloning)
-    # MTV 2.12 regression: NICs only sync to inventory for powered-off VMs
-    wait_for_vm_networks_in_inventory(
-        source_provider_inventory=source_provider_inventory,
-        vm_names=all_vm_names,
-        timeout=300,
-    )
-
-    # THEN: Power on VMs and wait for cloud-init to complete for both plans
+    # STEP 1: Power on VMs and wait for cloud-init to complete for both plans
     for plan in (prepared_plan_1, prepared_plan_2):
         wait_for_vmware_cloud_init_all_vms(
             prepared_plan=plan,
             source_provider=source_provider,
             source_provider_data=source_provider_data,
         )
+
+    # STEP 2: Power off all VMs after cloud-init (required for inventory sync in MTV 2.12)
+    LOGGER.info("Powering off VMs after cloud-init to enable NIC sync to Forklift inventory...")
+    for plan in (prepared_plan_1, prepared_plan_2):
+        for vm_data in plan["virtual_machines"]:
+            vm_name = vm_data["name"]
+            provider_vm_api = plan["source_vms_data"][vm_name]["provider_vm_api"]
+            LOGGER.info(f"Powering off VM {vm_name}")
+            source_provider.stop_vm(provider_vm_api)
+
+    # STEP 3: Wait for Forklift inventory to sync VM network data (VMs now powered off)
+    # MTV 2.12 requires: VM powered on once + cloud-init + powered off + wait for sync
+    LOGGER.info("Waiting for Forklift inventory to sync NICs after VMs powered off...")
+    wait_for_vm_networks_in_inventory(
+        source_provider_inventory=source_provider_inventory,
+        vm_names=all_vm_names,
+        timeout=600,  # Increased to 10 minutes based on manual migration timing
+    )
 
 
 @pytest.fixture(scope="class")

--- a/tests/copyoffload/conftest.py
+++ b/tests/copyoffload/conftest.py
@@ -401,6 +401,23 @@ def vmware_cloud_init_ready(
         source_provider_data=source_provider_data,
     )
 
+    # Debug: Check inventory state before our wait
+    LOGGER.info("DEBUG: Checking VM inventory state before network data wait...")
+    for vm_name in vm_names:
+        try:
+            vm_data = source_provider_inventory.get_vm(name=vm_name)
+            nics = vm_data.get("nics", [])
+            LOGGER.info(f"DEBUG: VM '{vm_name}' in inventory - NICs count: {len(nics)}, NICs data: {nics}")
+            if nics:
+                for i, nic in enumerate(nics):
+                    network_id = nic.get("network", {}).get("id")
+                    network_name = nic.get("network", {}).get("name")
+                    LOGGER.info(f"DEBUG: NIC[{i}]: network.id={network_id}, network.name={network_name}")
+        except ValueError as e:
+            LOGGER.error(f"DEBUG: VM '{vm_name}' not found in inventory: {e}")
+        except Exception as e:
+            LOGGER.error(f"DEBUG: Unexpected error getting VM '{vm_name}': {e}")
+
     # Wait for Forklift inventory to sync VM network data
     wait_for_vm_networks_in_inventory(
         source_provider_inventory=source_provider_inventory,
@@ -448,6 +465,23 @@ def vmware_cloud_init_ready_both_plans(
     # Wait for Forklift inventory to sync network data for all VMs
     all_vm_names = [vm["name"] for vm in prepared_plan_1["virtual_machines"]]
     all_vm_names.extend([vm["name"] for vm in prepared_plan_2["virtual_machines"]])
+
+    # Debug: Check inventory state before our wait
+    LOGGER.info("DEBUG: Checking VM inventory state before network data wait (both plans)...")
+    for vm_name in all_vm_names:
+        try:
+            vm_data = source_provider_inventory.get_vm(name=vm_name)
+            nics = vm_data.get("nics", [])
+            LOGGER.info(f"DEBUG: VM '{vm_name}' in inventory - NICs count: {len(nics)}, NICs data: {nics}")
+            if nics:
+                for i, nic in enumerate(nics):
+                    network_id = nic.get("network", {}).get("id")
+                    network_name = nic.get("network", {}).get("name")
+                    LOGGER.info(f"DEBUG: NIC[{i}]: network.id={network_id}, network.name={network_name}")
+        except ValueError as e:
+            LOGGER.error(f"DEBUG: VM '{vm_name}' not found in inventory: {e}")
+        except Exception as e:
+            LOGGER.error(f"DEBUG: Unexpected error getting VM '{vm_name}': {e}")
 
     wait_for_vm_networks_in_inventory(
         source_provider_inventory=source_provider_inventory,

--- a/tests/copyoffload/conftest.py
+++ b/tests/copyoffload/conftest.py
@@ -375,13 +375,13 @@ def vmware_cloud_init_ready(
 ) -> None:
     """Ensure cloud-init has finished and Forklift inventory synced for all VMs.
 
-    This fixture performs two critical wait operations:
-    1. Waits for cloud-init completion on all cloned VMs (via VMware Guest Operations)
-    2. Waits for Forklift provider inventory to sync VM network data
+    This fixture performs two critical wait operations in this order:
+    1. Waits for Forklift provider inventory to sync VM network data (while VMs are powered off)
+    2. Powers on VMs and waits for cloud-init completion (via VMware Guest Operations)
 
-    The second wait is essential because tests query the Forklift inventory for
-    network mappings, not the vCenter API directly. Without this wait, network
-    map creation fails with empty NIC data even though VMs are running.
+    The order is critical: MTV 2.12 Forklift inventory does not sync NIC data for powered-on VMs.
+    Since VMs are powered off after cloning, we must wait for NIC sync before powering them on
+    for cloud-init. Tests query Forklift inventory for network mappings, not vCenter API directly.
 
     Args:
         prepared_plan (dict[str, Any]): Processed test plan configuration.
@@ -394,35 +394,19 @@ def vmware_cloud_init_ready(
     """
     vm_names = [vm["name"] for vm in prepared_plan["virtual_machines"]]
 
-    # Wait for cloud-init to complete on all VMs
-    wait_for_vmware_cloud_init_all_vms(
-        prepared_plan=prepared_plan,
-        source_provider=source_provider,
-        source_provider_data=source_provider_data,
-    )
-
-    # Debug: Check inventory state before our wait
-    LOGGER.info("DEBUG: Checking VM inventory state before network data wait...")
-    for vm_name in vm_names:
-        try:
-            vm_data = source_provider_inventory.get_vm(name=vm_name)
-            nics = vm_data.get("nics", [])
-            LOGGER.info(f"DEBUG: VM '{vm_name}' in inventory - NICs count: {len(nics)}, NICs data: {nics}")
-            if nics:
-                for i, nic in enumerate(nics):
-                    network_id = nic.get("network", {}).get("id")
-                    network_name = nic.get("network", {}).get("name")
-                    LOGGER.info(f"DEBUG: NIC[{i}]: network.id={network_id}, network.name={network_name}")
-        except ValueError as e:
-            LOGGER.error(f"DEBUG: VM '{vm_name}' not found in inventory: {e}")
-        except Exception as e:
-            LOGGER.error(f"DEBUG: Unexpected error getting VM '{vm_name}': {e}")
-
-    # Wait for Forklift inventory to sync VM network data
+    # FIRST: Wait for Forklift inventory to sync VM network data (VMs are powered off after cloning)
+    # MTV 2.12 regression: NICs only sync to inventory for powered-off VMs
     wait_for_vm_networks_in_inventory(
         source_provider_inventory=source_provider_inventory,
         vm_names=vm_names,
         timeout=300,
+    )
+
+    # THEN: Power on VMs and wait for cloud-init to complete
+    wait_for_vmware_cloud_init_all_vms(
+        prepared_plan=prepared_plan,
+        source_provider=source_provider,
+        source_provider_data=source_provider_data,
     )
 
 
@@ -436,13 +420,13 @@ def vmware_cloud_init_ready_both_plans(
 ) -> None:
     """Ensure cloud-init has finished and Forklift inventory synced for all VMs from both plans.
 
-    This fixture performs two critical wait operations for both migration plans:
-    1. Waits for cloud-init completion on all cloned VMs (via VMware Guest Operations)
-    2. Waits for Forklift provider inventory to sync VM network data
+    This fixture performs two critical wait operations in this order:
+    1. Waits for Forklift provider inventory to sync VM network data (while VMs are powered off)
+    2. Powers on VMs and waits for cloud-init completion (via VMware Guest Operations)
 
-    The second wait is essential because tests query the Forklift inventory for
-    network mappings, not the vCenter API directly. Without this wait, network
-    map creation fails with empty NIC data even though VMs are running.
+    The order is critical: MTV 2.12 Forklift inventory does not sync NIC data for powered-on VMs.
+    Since VMs are powered off after cloning, we must wait for NIC sync before powering them on
+    for cloud-init. Tests query Forklift inventory for network mappings, not vCenter API directly.
 
     Args:
         prepared_plan_1 (dict[str, Any]): First processed test plan configuration.
@@ -454,40 +438,25 @@ def vmware_cloud_init_ready_both_plans(
     Returns:
         None
     """
-    # Wait for cloud-init on all VMs from both plans
+    # Collect all VM names from both plans
+    all_vm_names = [vm["name"] for vm in prepared_plan_1["virtual_machines"]]
+    all_vm_names.extend([vm["name"] for vm in prepared_plan_2["virtual_machines"]])
+
+    # FIRST: Wait for Forklift inventory to sync VM network data (VMs are powered off after cloning)
+    # MTV 2.12 regression: NICs only sync to inventory for powered-off VMs
+    wait_for_vm_networks_in_inventory(
+        source_provider_inventory=source_provider_inventory,
+        vm_names=all_vm_names,
+        timeout=300,
+    )
+
+    # THEN: Power on VMs and wait for cloud-init to complete for both plans
     for plan in (prepared_plan_1, prepared_plan_2):
         wait_for_vmware_cloud_init_all_vms(
             prepared_plan=plan,
             source_provider=source_provider,
             source_provider_data=source_provider_data,
         )
-
-    # Wait for Forklift inventory to sync network data for all VMs
-    all_vm_names = [vm["name"] for vm in prepared_plan_1["virtual_machines"]]
-    all_vm_names.extend([vm["name"] for vm in prepared_plan_2["virtual_machines"]])
-
-    # Debug: Check inventory state before our wait
-    LOGGER.info("DEBUG: Checking VM inventory state before network data wait (both plans)...")
-    for vm_name in all_vm_names:
-        try:
-            vm_data = source_provider_inventory.get_vm(name=vm_name)
-            nics = vm_data.get("nics", [])
-            LOGGER.info(f"DEBUG: VM '{vm_name}' in inventory - NICs count: {len(nics)}, NICs data: {nics}")
-            if nics:
-                for i, nic in enumerate(nics):
-                    network_id = nic.get("network", {}).get("id")
-                    network_name = nic.get("network", {}).get("name")
-                    LOGGER.info(f"DEBUG: NIC[{i}]: network.id={network_id}, network.name={network_name}")
-        except ValueError as e:
-            LOGGER.error(f"DEBUG: VM '{vm_name}' not found in inventory: {e}")
-        except Exception as e:
-            LOGGER.error(f"DEBUG: Unexpected error getting VM '{vm_name}': {e}")
-
-    wait_for_vm_networks_in_inventory(
-        source_provider_inventory=source_provider_inventory,
-        vm_names=all_vm_names,
-        timeout=300,
-    )
 
 
 @pytest.fixture(scope="class")

--- a/tests/copyoffload/conftest.py
+++ b/tests/copyoffload/conftest.py
@@ -392,7 +392,7 @@ def vmware_cloud_init_ready(
     Returns:
         None
     """
-    vms_names = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+    vm_names = [vm["name"] for vm in prepared_plan["virtual_machines"]]
 
     # Wait for cloud-init to complete on all VMs
     wait_for_vmware_cloud_init_all_vms(
@@ -404,7 +404,7 @@ def vmware_cloud_init_ready(
     # Wait for Forklift inventory to sync VM network data
     wait_for_vm_networks_in_inventory(
         source_provider_inventory=source_provider_inventory,
-        vm_names=vms_names,
+        vm_names=vm_names,
         timeout=300,
     )
 

--- a/tests/copyoffload/conftest.py
+++ b/tests/copyoffload/conftest.py
@@ -9,6 +9,7 @@ from ocp_resources.secret import Secret
 from simple_logger.logger import get_logger
 
 from libs.base_provider import BaseProvider
+from libs.forklift_inventory import ForkliftInventory
 from libs.providers.vmware import VMWareProvider
 from utilities.copyoffload_constants import SUPPORTED_VENDORS
 from utilities.copyoffload_migration import (
@@ -17,6 +18,7 @@ from utilities.copyoffload_migration import (
     wait_for_vmware_cloud_init_all_vms,
 )
 from utilities.esxi import install_ssh_key_on_esxi, remove_ssh_key_from_esxi
+from utilities.mtv_migration import wait_for_vm_networks_in_inventory
 from utilities.resources import create_and_store_resource
 from utilities.utils import resolve_providers_json_path
 
@@ -369,21 +371,41 @@ def vmware_cloud_init_ready(
     prepared_plan: dict[str, Any],
     source_provider: VMWareProvider,
     source_provider_data: dict[str, Any],
+    source_provider_inventory: ForkliftInventory,
 ) -> None:
-    """Ensure cloud-init has finished on all VMs before migration tests run.
+    """Ensure cloud-init has finished and Forklift inventory synced for all VMs.
+
+    This fixture performs two critical wait operations:
+    1. Waits for cloud-init completion on all cloned VMs (via VMware Guest Operations)
+    2. Waits for Forklift provider inventory to sync VM network data
+
+    The second wait is essential because tests query the Forklift inventory for
+    network mappings, not the vCenter API directly. Without this wait, network
+    map creation fails with empty NIC data even though VMs are running.
 
     Args:
         prepared_plan (dict[str, Any]): Processed test plan configuration.
         source_provider (VMWareProvider): The VMware source provider instance.
         source_provider_data (dict[str, Any]): Source provider configuration data.
+        source_provider_inventory (ForkliftInventory): Forklift inventory for source provider.
 
     Returns:
         None
     """
+    vms_names = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+
+    # Wait for cloud-init to complete on all VMs
     wait_for_vmware_cloud_init_all_vms(
         prepared_plan=prepared_plan,
         source_provider=source_provider,
         source_provider_data=source_provider_data,
+    )
+
+    # Wait for Forklift inventory to sync VM network data
+    wait_for_vm_networks_in_inventory(
+        source_provider_inventory=source_provider_inventory,
+        vm_names=vms_names,
+        timeout=300,
     )
 
 
@@ -393,24 +415,45 @@ def vmware_cloud_init_ready_both_plans(
     prepared_plan_2: dict[str, Any],
     source_provider: VMWareProvider,
     source_provider_data: dict[str, Any],
+    source_provider_inventory: ForkliftInventory,
 ) -> None:
-    """Ensure cloud-init has finished on all VMs from both plans before migration tests run.
+    """Ensure cloud-init has finished and Forklift inventory synced for all VMs from both plans.
+
+    This fixture performs two critical wait operations for both migration plans:
+    1. Waits for cloud-init completion on all cloned VMs (via VMware Guest Operations)
+    2. Waits for Forklift provider inventory to sync VM network data
+
+    The second wait is essential because tests query the Forklift inventory for
+    network mappings, not the vCenter API directly. Without this wait, network
+    map creation fails with empty NIC data even though VMs are running.
 
     Args:
         prepared_plan_1 (dict[str, Any]): First processed test plan configuration.
         prepared_plan_2 (dict[str, Any]): Second processed test plan configuration.
         source_provider (VMWareProvider): The VMware source provider instance.
         source_provider_data (dict[str, Any]): Source provider configuration data.
+        source_provider_inventory (ForkliftInventory): Forklift inventory for source provider.
 
     Returns:
         None
     """
+    # Wait for cloud-init on all VMs from both plans
     for plan in (prepared_plan_1, prepared_plan_2):
         wait_for_vmware_cloud_init_all_vms(
             prepared_plan=plan,
             source_provider=source_provider,
             source_provider_data=source_provider_data,
         )
+
+    # Wait for Forklift inventory to sync network data for all VMs
+    all_vm_names = [vm["name"] for vm in prepared_plan_1["virtual_machines"]]
+    all_vm_names.extend([vm["name"] for vm in prepared_plan_2["virtual_machines"]])
+
+    wait_for_vm_networks_in_inventory(
+        source_provider_inventory=source_provider_inventory,
+        vm_names=all_vm_names,
+        timeout=300,
+    )
 
 
 @pytest.fixture(scope="class")

--- a/utilities/mtv_migration.py
+++ b/utilities/mtv_migration.py
@@ -416,7 +416,7 @@ def wait_for_vm_networks_in_inventory(
             raise TimeoutExpiredError(
                 f"Timed Out: VM '{vm_name}' found in Forklift inventory but NIC/network data "
                 f"did not sync after {timeout}s. NICs: {nics}"
-            )
+            ) from None
 
 
 def get_storage_migration_map(

--- a/utilities/mtv_migration.py
+++ b/utilities/mtv_migration.py
@@ -396,7 +396,7 @@ def wait_for_vm_networks_in_inventory(
 
     for vm_name in vm_names:
         sampler = TimeoutSampler(
-            timeout=timeout,
+            wait_timeout=timeout,
             sleep=10,
             func=lambda name=vm_name: source_provider_inventory.get_vm(name=name),
         )

--- a/utilities/mtv_migration.py
+++ b/utilities/mtv_migration.py
@@ -412,22 +412,35 @@ def wait_for_vm_networks_in_inventory(
         try:
             for vm in sampler:
                 if vm and vm.get("nics"):
-                    LOGGER.info(f"VM '{vm_name}' synced to inventory with {len(vm['nics'])} NIC(s)")
-                    break
-                LOGGER.debug(
-                    f"Waiting for VM '{vm_name}' NIC data in inventory... "
-                    f"(NICs: {vm.get('nics', []) if vm else 'VM not found'})"
-                )
+                    # Check if NICs have network data populated
+                    nics_with_network = [nic for nic in vm["nics"] if nic.get("network", {}).get("id")]
+                    if nics_with_network:
+                        LOGGER.info(
+                            f"VM '{vm_name}' synced to inventory with {len(nics_with_network)} NIC(s) "
+                            f"having network data"
+                        )
+                        break
+                    LOGGER.debug(
+                        f"Waiting for VM '{vm_name}' NIC network data in inventory... "
+                        f"(NICs found: {len(vm['nics'])}, with network data: {len(nics_with_network)})"
+                    )
+                else:
+                    LOGGER.debug(
+                        f"Waiting for VM '{vm_name}' NIC data in inventory... "
+                        f"(NICs: {vm.get('nics', []) if vm else 'VM not found'})"
+                    )
         except TimeoutExpiredError:
             try:
                 vm_data = source_provider_inventory.get_vm(name=vm_name)
                 nics = vm_data.get("nics", [])
+                nics_with_network = [nic for nic in nics if nic.get("network", {}).get("id")]
             except ValueError:
                 vm_data = None
                 nics = []
+                nics_with_network = []
             raise TimeoutExpiredError(
-                f"Timed Out: VM '{vm_name}' found in Forklift inventory but NIC/network data "
-                f"did not sync after {timeout}s. NICs: {nics}"
+                f"Timed Out: VM '{vm_name}' NIC network data did not sync after {timeout}s. "
+                f"NICs found: {len(nics)}, NICs with network data: {len(nics_with_network)}"
             ) from None
 
 

--- a/utilities/mtv_migration.py
+++ b/utilities/mtv_migration.py
@@ -373,6 +373,52 @@ def wait_for_migration_complate(plan: Plan) -> None:
         )
 
 
+def wait_for_vm_networks_in_inventory(
+    source_provider_inventory: ForkliftInventory,
+    vm_names: list[str],
+    timeout: int = 300,
+) -> None:
+    """Wait for VMs to appear in Forklift inventory with network data.
+
+    After cloning VMs, the Forklift provider inventory must sync the VM metadata
+    including network interface information. This function polls the inventory
+    until all specified VMs have NIC data populated.
+
+    Args:
+        source_provider_inventory: Forklift inventory instance for the source provider
+        vm_names: List of VM names to wait for
+        timeout: Maximum wait time in seconds (default: 300)
+
+    Raises:
+        TimeoutExpiredError: If any VM doesn't appear with NICs within timeout period
+    """
+    LOGGER.info(f"Waiting for {len(vm_names)} VM(s) to sync to Forklift inventory with NIC data...")
+
+    for vm_name in vm_names:
+        sampler = TimeoutSampler(
+            timeout=timeout,
+            sleep=10,
+            func=lambda name=vm_name: source_provider_inventory.get_vm(name=name),
+        )
+
+        try:
+            for vm in sampler:
+                if vm and vm.get("nics"):
+                    LOGGER.info(f"VM '{vm_name}' synced to inventory with {len(vm['nics'])} NIC(s)")
+                    break
+                LOGGER.debug(
+                    f"Waiting for VM '{vm_name}' NIC data in inventory... "
+                    f"(NICs: {vm.get('nics', []) if vm else 'VM not found'})"
+                )
+        except TimeoutExpiredError:
+            vm_data = source_provider_inventory.get_vm(name=vm_name)
+            nics = vm_data.get("nics", []) if vm_data else []
+            raise TimeoutExpiredError(
+                f"Timed Out: VM '{vm_name}' found in Forklift inventory but NIC/network data "
+                f"did not sync after {timeout}s. NICs: {nics}"
+            )
+
+
 def get_storage_migration_map(
     fixture_store: dict[str, Any],
     target_namespace: str,

--- a/utilities/mtv_migration.py
+++ b/utilities/mtv_migration.py
@@ -395,10 +395,18 @@ def wait_for_vm_networks_in_inventory(
     LOGGER.info(f"Waiting for {len(vm_names)} VM(s) to sync to Forklift inventory with NIC data...")
 
     for vm_name in vm_names:
+
+        def _get_vm_safe(name: str = vm_name) -> dict[str, Any] | None:
+            """Safely get VM from inventory, returning None if not found."""
+            try:
+                return source_provider_inventory.get_vm(name=name)
+            except ValueError:
+                return None
+
         sampler = TimeoutSampler(
             wait_timeout=timeout,
             sleep=10,
-            func=lambda name=vm_name: source_provider_inventory.get_vm(name=name),
+            func=_get_vm_safe,
         )
 
         try:
@@ -411,8 +419,12 @@ def wait_for_vm_networks_in_inventory(
                     f"(NICs: {vm.get('nics', []) if vm else 'VM not found'})"
                 )
         except TimeoutExpiredError:
-            vm_data = source_provider_inventory.get_vm(name=vm_name)
-            nics = vm_data.get("nics", []) if vm_data else []
+            try:
+                vm_data = source_provider_inventory.get_vm(name=vm_name)
+                nics = vm_data.get("nics", [])
+            except ValueError:
+                vm_data = None
+                nics = []
             raise TimeoutExpiredError(
                 f"Timed Out: VM '{vm_name}' found in Forklift inventory but NIC/network data "
                 f"did not sync after {timeout}s. NICs: {nics}"


### PR DESCRIPTION
Add explicit wait for Forklift provider inventory to sync VM network data after cloning VMs. Previously, tests relied on implicit timing and failed when inventory sync was slower than expected.

Changes:
- Add wait_for_vm_networks_in_inventory() to utilities/mtv_migration.py
- Update vmware_cloud_init_ready fixture to wait for inventory sync
- Update vmware_cloud_init_ready_both_plans for dual-plan tests

The issue manifested as "Networks not found for vms" errors during test_create_networkmap because:
1. VMs were cloned and powered on successfully
2. Cloud-init completed (verified via VMware Guest Operations)
3. Tests immediately queried Forklift inventory for network mappings
4. Forklift inventory hadn't synced NIC data yet (NICs: [])

This fix makes tests resilient to inventory sync timing variations across different MTV versions and cluster configurations.

Resolves regression introduced between MTV 2.11 and 2.12 where inventory sync timing changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test readiness to wait for source inventory to show VM network data before proceeding, reducing race conditions.
  * Added checks for single- and dual-plan migration flows to ensure VM network configurations are populated (includes extended timeout).

* **New Features**
  * Added a utility that polls the source inventory until each VM's NIC network information appears.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->