### PR TITLE
feat: add LUKS disk encryption cold migration tests

### DIFF
--- a/.providers.json.example
+++ b/.providers.json.example
@@ -14,7 +14,6 @@
     "luks_passphrase": "LUKS DISK ENCRYPTION PASSPHRASE",  # pragma: allowlist secret
     "vddk_init_image": "<PATH TO VDDK INIT IMAGE>",
     "endpoint_type": "vcenter",
-    "luks_passphrase": "<LUKS DISK ENCRYPTION PASSPHRASE>"
   },
 
   "vsphere-copy-offload": {

--- a/.providers.json.example
+++ b/.providers.json.example
@@ -11,6 +11,7 @@
     "guest_vm_linux_password": "LINUX VMS PASSWORD",  # pragma: allowlist secret
     "guest_vm_win_user": "WINDOWS VMS USERNAME",
     "guest_vm_win_password": "WINDOWS VMS PASSWORD",  # pragma: allowlist secret
+    "luks_passphrase": "LUKS DISK ENCRYPTION PASSPHRASE",  # pragma: allowlist secret
     "vddk_init_image": "<PATH TO VDDK INIT IMAGE>",
     "endpoint_type": "vcenter",
     "luks_passphrase": "<LUKS DISK ENCRYPTION PASSPHRASE>"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -730,7 +730,7 @@ from utilities.post_migration import check_vms
 )
 @pytest.mark.usefixtures("cleanup_migrated_vms")
 @pytest.mark.incremental
-@pytest.mark.tier0  # optional: tier0/warm/remote/copyoffload
+@pytest.mark.tier0  # optional: tier0, tier1, warm, remote, copyoffload
 class TestNameHere:
     """Test description."""
 
@@ -826,10 +826,9 @@ tests_params: dict = {
 
 1. Create the test file in the feature subdirectory described in **Test File Location (MUST)** (for example, `tests/<feature>/test_<feature>_migration.py`)
 2. Create a test class with `@pytest.mark.parametrize` using `class_plan_config` and `indirect=True`
-3. Add pytest markers at class level (tier0, warm, remote, copyoffload)
-4. Implement the 5 test methods following the pattern above (6 for copy-offload tests — use the 6-step copy-offload pattern;
-   7 for copy-offload populator throttling tests — use the 7-step copy-offload throttling pattern;
-   6 for LUKS tests — use the 6-step LUKS pattern)
+3. Add pytest markers at class level (tier0, tier1, warm, remote, copyoffload)
+4. Implement the 5 base test methods. Some features need extra validation steps: see **Key Patterns** for the
+   6-step shared-disk, copy-offload, and LUKS patterns, or the 7-step copy-offload throttling pattern
 
 **VM Configuration Options:**
 
@@ -956,6 +955,7 @@ Test classes for marker-gated features must include the feature name in the clas
 - Warm migration → class name must contain `Warm` (e.g., `TestSanityWarmMtvMigration`)
 - Copy-offload snapshots → class name must contain both `Copyoffload` and `Snapshot` (e.g., `TestCopyoffloadThinSnapshotsMigration`)
 - Copy-offload → class name must contain `Copyoffload` (e.g., `TestCopyoffloadThinMigration`)
+- Tier1 features → class name must include the feature name (e.g., `TestLuksColdMigration`)
 
 This ensures discoverability and consistency with the markers applied to the class.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -798,11 +798,16 @@ class TestNameHere:
   `test_check_xcopy_used`. This step calls `verify_populator_throttling()` from `utilities/copyoffload_migration.py`
   to validate per-ESXi-host concurrency limits, `PopulatorThrottled` events, and `sourceHost` labels.
   Requires the `populator_inflight_forkliftcontroller` fixture.
+- **6-step LUKS pattern**: storagemap -> networkmap -> plan -> migrate -> verify_luks_encryption -> check_vms
+  `test_verify_luks_encryption` calls `verify_luks_encryption()` from `utilities/post_migration.py`. LUKS
+  secret setup is handled by the `luks_vm_specs` fixture in `tests/luks/conftest.py`, which resolves
+  passphrases (per-VM override → provider fallback) and creates K8s Secrets.
 
 **Test method naming:** Base tests: `test_create_storagemap`, `test_create_networkmap`, `test_create_plan`,
 `test_migrate_vms`, `test_check_vms`. Copy-offload tests: same through `test_migrate_vms`, then
 `test_check_xcopy_used`, `test_check_vms`. Copy-offload throttling tests: same through `test_migrate_vms`, then
-`test_verify_populator_throttling`, `test_check_xcopy_used`, `test_check_vms`.
+`test_verify_populator_throttling`, `test_check_xcopy_used`, `test_check_vms`. LUKS tests: same through `test_migrate_vms`, then
+`test_verify_luks_encryption`, `test_check_vms`.
 
 **Fixture parameters:** Each test method requests only the fixtures it needs. The example shows typical patterns.
 
@@ -823,7 +828,8 @@ tests_params: dict = {
 2. Create a test class with `@pytest.mark.parametrize` using `class_plan_config` and `indirect=True`
 3. Add pytest markers at class level (tier0, warm, remote, copyoffload)
 4. Implement the 5 test methods following the pattern above (6 for copy-offload tests — use the 6-step copy-offload pattern;
-   7 for copy-offload populator throttling tests — use the 7-step copy-offload throttling pattern)
+   7 for copy-offload populator throttling tests — use the 7-step copy-offload throttling pattern;
+   6 for LUKS tests — use the 6-step LUKS pattern)
 
 **VM Configuration Options:**
 
@@ -834,6 +840,8 @@ tests_params: dict = {
 | `guest_agent`     | No       | True if installed                   |
 | `clone`           | No       | True to clone before migration      |
 | `disk_type`       | No       | "thin", "thick-lazy", "thick-eager" |
+| `luks`            | No       | True if VM has LUKS-encrypted disk  |
+| `luks_passphrase` | No       | Per-VM passphrase override          |
 
 ## Fixture Patterns
 

--- a/README.md
+++ b/README.md
@@ -589,6 +589,40 @@ For technical implementation details, see the
 
 ---
 
+## LUKS Disk Encryption Migration (tier1)
+
+The test suite includes migration tests for VMs with LUKS-encrypted disks. These tests verify that
+LUKS encryption is preserved after cold migration by checking `lsblk` output on the migrated VM.
+
+### Configuration
+
+Add the `luks_passphrase` field to your `.providers.json` provider configuration:
+
+```json
+{
+  "vsphere-8.0.1": {
+    "type": "vsphere",
+    "luks_passphrase": "your-luks-passphrase"
+  }
+}
+```
+
+The passphrase can be configured at two levels:
+
+- **Provider-level** (in `.providers.json`): Used as the default for all LUKS VMs
+- **Per-VM override** (in test config): Set `luks_passphrase` on individual VM entries to override the provider default
+
+### Running LUKS Tests
+
+```bash
+# Run LUKS encryption migration tests
+podman run ... uv run pytest -m tier1 -k luks -v --tc=source_provider:vsphere-8.0.1 ...
+```
+
+See `.providers.json.example` for the complete provider template including the `luks_passphrase` field.
+
+---
+
 ## Target Scheduling Features (MTV 2.10.0+)
 
 Control where and how migrated VMs are scheduled in the target OpenShift cluster.

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ The Quick Start runs **tier0** tests (smoke tests). You can run other test categ
 | `copyoffload` | Fast migrations via shared storage | Testing storage arrays |
 | `copyoffload_sanity` | Copy-offload sanity subset (see below) | Quick copy-offload validation |
 | `warm` | Warm migrations (VMs stay running) | Specific scenario testing |
+| `tier1` | Feature-specific tests (LUKS, etc.) | Extended functionality validation |
 | `upgrade` | Migration across MTV operator upgrades | Validating upgrade compatibility |
 
 ### Copy-Offload Sanity Tests

--- a/README.md
+++ b/README.md
@@ -271,7 +271,6 @@ The Quick Start runs **tier0** tests (smoke tests). You can run other test categ
 | `copyoffload` | Fast migrations via shared storage | Testing storage arrays |
 | `copyoffload_sanity` | Copy-offload sanity subset (see below) | Quick copy-offload validation |
 | `warm` | Warm migrations (VMs stay running) | Specific scenario testing |
-| `tier1` | Feature-specific tests (LUKS, etc.) | Extended functionality validation |
 | `upgrade` | Migration across MTV operator upgrades | Validating upgrade compatibility |
 
 ### Copy-Offload Sanity Tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -30,7 +30,6 @@ markers =
     rhv: RHV provider-specific tests
     openstack: OpenStack provider-specific tests
     openshift: OpenShift provider-specific tests
-    tier1: Extended functionality tests (feature-specific)
     upgrade: MTV operator upgrade tests
 
 junit_logging = all

--- a/pytest.ini
+++ b/pytest.ini
@@ -30,6 +30,7 @@ markers =
     rhv: RHV provider-specific tests
     openstack: OpenStack provider-specific tests
     openshift: OpenShift provider-specific tests
+    tier1: Extended functionality tests (feature-specific)
     upgrade: MTV operator upgrade tests
 
 junit_logging = all

--- a/tests/luks/conftest.py
+++ b/tests/luks/conftest.py
@@ -8,9 +8,11 @@ from ocp_resources.secret import Secret
 from simple_logger.logger import get_logger
 
 from utilities.resources import create_and_store_resource
+from utilities.utils import populate_vm_ids
 
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
+    from libs.forklift_inventory import ForkliftInventory
 
 LOGGER = get_logger(name=__name__)
 
@@ -22,12 +24,13 @@ def luks_vm_specs(
     ocp_admin_client: "DynamicClient",
     target_namespace: str,
     source_provider_data: dict[str, Any],
+    source_provider_inventory: "ForkliftInventory",
 ) -> list[dict[str, Any]]:
     """VM specs with LUKS secrets created and injected.
 
-    Resolves passphrase per-VM (from VM config override or provider-level fallback),
-    creates a Kubernetes Secret for each VM, and returns the VM list with secret
-    references ready for plan creation.
+    Populates VM IDs from inventory, then resolves passphrase per-VM (from VM config
+    override or provider-level fallback), creates a Kubernetes Secret for each VM,
+    and returns the VM list with secret references ready for plan creation.
 
     Args:
         prepared_plan (dict[str, Any]): Test plan configuration with VM details.
@@ -35,20 +38,23 @@ def luks_vm_specs(
         ocp_admin_client (DynamicClient): OpenShift admin client.
         target_namespace (str): Target namespace for migration resources.
         source_provider_data (dict[str, Any]): Provider configuration from providers.json.
+        source_provider_inventory (ForkliftInventory): Source provider inventory for VM ID lookup.
 
     Returns:
-        list[dict[str, Any]]: VM dicts with luks secret references injected.
+        list[dict[str, Any]]: VM dicts with luks secret references and IDs injected.
 
     Raises:
         ValueError: If LUKS passphrase is empty for any VM.
     """
+    populate_vm_ids(prepared_plan, source_provider_inventory)
     vms = [copy.deepcopy(vm) for vm in prepared_plan["virtual_machines"]]
     for vm in vms:
         vm.pop("luks", None)
         luks_passphrase = vm.pop("luks_passphrase", None)
         if luks_passphrase is None:
             luks_passphrase = source_provider_data.get("luks_passphrase")
-            LOGGER.debug(f"Using provider-level LUKS passphrase for VM '{vm['name']}'")
+            if luks_passphrase:
+                LOGGER.debug(f"Using provider-level LUKS passphrase for VM '{vm['name']}'")
         if not luks_passphrase:
             raise ValueError(
                 f"LUKS passphrase not found for VM '{vm['name']}' — "

--- a/tests/luks/conftest.py
+++ b/tests/luks/conftest.py
@@ -50,16 +50,15 @@ def luks_vm_specs(
     vms = [copy.deepcopy(vm) for vm in prepared_plan["virtual_machines"]]
     for vm in vms:
         vm.pop("luks", None)
+        source = "per-VM config"
         luks_passphrase = vm.pop("luks_passphrase", None)
         if luks_passphrase is None:
             luks_passphrase = source_provider_data.get("luks_passphrase")
+            source = "source_provider_data"
             if luks_passphrase:
                 LOGGER.debug(f"Using provider-level LUKS passphrase for VM '{vm['name']}'")
         if not luks_passphrase:
-            raise ValueError(
-                f"LUKS passphrase not found for VM '{vm['name']}' — "
-                "checked per-VM config and source_provider_data['luks_passphrase']"
-            )
+            raise ValueError(f"LUKS passphrase empty/missing for VM '{vm['name']}' (resolved from {source})")
 
         luks_secret = create_and_store_resource(
             client=ocp_admin_client,

--- a/tests/luks/conftest.py
+++ b/tests/luks/conftest.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from ocp_resources.secret import Secret
+from simple_logger.logger import get_logger
+
+from utilities.resources import create_and_store_resource
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+LOGGER = get_logger(name=__name__)
+
+
+@pytest.fixture(scope="class")
+def luks_vm_specs(
+    prepared_plan: dict[str, Any],
+    fixture_store: dict[str, Any],
+    ocp_admin_client: "DynamicClient",
+    target_namespace: str,
+    source_provider_data: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """VM specs with LUKS secrets created and injected.
+
+    Resolves passphrase per-VM (from VM config override or provider-level fallback),
+    creates a Kubernetes Secret for each VM, and returns the VM list with secret
+    references ready for plan creation.
+
+    Args:
+        prepared_plan (dict[str, Any]): Test plan configuration with VM details.
+        fixture_store (dict[str, Any]): Resource tracking dictionary.
+        ocp_admin_client (DynamicClient): OpenShift admin client.
+        target_namespace (str): Target namespace for migration resources.
+        source_provider_data (dict[str, Any]): Provider configuration from providers.json.
+
+    Returns:
+        list[dict[str, Any]]: VM dicts with luks secret references injected.
+
+    Raises:
+        ValueError: If LUKS passphrase is empty for any VM.
+    """
+    vms = [copy.deepcopy(vm) for vm in prepared_plan["virtual_machines"]]
+    for vm in vms:
+        vm.pop("luks", None)
+        luks_passphrase = vm.pop("luks_passphrase", None)
+        if luks_passphrase is None:
+            luks_passphrase = source_provider_data.get("luks_passphrase")
+            LOGGER.debug(f"Using provider-level LUKS passphrase for VM '{vm['name']}'")
+        if not luks_passphrase:
+            raise ValueError(
+                f"LUKS passphrase not found for VM '{vm['name']}' — "
+                "checked per-VM config and source_provider_data['luks_passphrase']"
+            )
+
+        luks_secret = create_and_store_resource(
+            client=ocp_admin_client,
+            fixture_store=fixture_store,
+            resource=Secret,
+            namespace=target_namespace,
+            string_data={"key": luks_passphrase},
+        )
+        vm["luks"] = {"name": luks_secret.name}
+
+    return vms

--- a/tests/luks/test_luks_cold_migration.py
+++ b/tests/luks/test_luks_cold_migration.py
@@ -1,0 +1,444 @@
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from ocp_resources.network_map import NetworkMap
+from ocp_resources.plan import Plan
+from ocp_resources.secret import Secret
+from ocp_resources.storage_map import StorageMap
+from pytest_testconfig import config as py_config
+
+from exceptions.exceptions import MigrationPlanExecError
+from utilities.mtv_migration import (
+    create_plan_resource,
+    execute_migration,
+    get_network_migration_map,
+    get_storage_migration_map,
+)
+from utilities.post_migration import check_vms, verify_luks_encryption
+from utilities.resources import create_and_store_resource
+from utilities.utils import populate_vm_ids
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+    from libs.base_provider import BaseProvider
+    from libs.forklift_inventory import ForkliftInventory
+    from libs.providers.openshift import OCPProvider
+    from utilities.ssh_utils import SSHConnectionManager
+
+
+@pytest.mark.vsphere
+@pytest.mark.tier1
+@pytest.mark.parametrize(
+    "class_plan_config",
+    [pytest.param(py_config["tests_params"]["test_luks_cold_migration"])],
+    indirect=True,
+    ids=["luks-cold-correct-key"],
+)
+@pytest.mark.usefixtures("cleanup_migrated_vms")
+@pytest.mark.incremental
+class TestLuksColdMigration:
+    """Cold migration with correct LUKS disk decryption passphrase.
+
+    Validates that LUKS-encrypted VMs migrate successfully when the correct
+    passphrase is provided, and that disk encryption remains active post-migration.
+    """
+
+    storage_map: StorageMap
+    network_map: NetworkMap
+    plan_resource: Plan
+
+    def test_create_storagemap(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        source_provider: "BaseProvider",
+        destination_provider: "BaseProvider",
+        ocp_admin_client: "DynamicClient",
+        target_namespace: str,
+        source_provider_inventory: "ForkliftInventory",
+    ) -> None:
+        """Create StorageMap resource.
+
+        Args:
+            prepared_plan (dict[str, Any]): Test plan configuration with VM details.
+            fixture_store (dict[str, Any]): Resource tracking dictionary.
+            source_provider (BaseProvider): Source provider connection.
+            destination_provider (BaseProvider): Destination provider connection.
+            ocp_admin_client (DynamicClient): OpenShift admin client.
+            target_namespace (str): Target namespace for migration resources.
+            source_provider_inventory (ForkliftInventory): Source provider inventory.
+
+        Raises:
+            AssertionError: If StorageMap creation fails.
+        """
+        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.storage_map = get_storage_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            vms=vms,
+        )
+        assert self.storage_map, "StorageMap creation failed"
+
+    def test_create_networkmap(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        source_provider: "BaseProvider",
+        destination_provider: "BaseProvider",
+        ocp_admin_client: "DynamicClient",
+        target_namespace: str,
+        source_provider_inventory: "ForkliftInventory",
+        multus_network_name: dict[str, str],
+    ) -> None:
+        """Create NetworkMap resource.
+
+        Args:
+            prepared_plan (dict[str, Any]): Test plan configuration with VM details.
+            fixture_store (dict[str, Any]): Resource tracking dictionary.
+            source_provider (BaseProvider): Source provider connection.
+            destination_provider (BaseProvider): Destination provider connection.
+            ocp_admin_client (DynamicClient): OpenShift admin client.
+            target_namespace (str): Target namespace for migration resources.
+            source_provider_inventory (ForkliftInventory): Source provider inventory.
+            multus_network_name (dict[str, str]): Multus network name for network mapping.
+
+        Raises:
+            AssertionError: If NetworkMap creation fails.
+        """
+        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.network_map = get_network_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            multus_network_name=multus_network_name,
+            target_namespace=target_namespace,
+            vms=vms,
+        )
+        assert self.network_map, "NetworkMap creation failed"
+
+    def test_create_plan(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        source_provider: "BaseProvider",
+        destination_provider: "OCPProvider",
+        ocp_admin_client: "DynamicClient",
+        target_namespace: str,
+        source_provider_inventory: "ForkliftInventory",
+        source_provider_data: dict[str, Any],
+    ) -> None:
+        """Create MTV Plan with LUKS decryption secret.
+
+        Creates a Kubernetes Secret containing the LUKS passphrase and references
+        it in the VM spec so forklift mounts it for virt-v2v during conversion.
+        The passphrase is resolved from per-VM config override first, then from
+        the provider configuration (providers.json).
+
+        Args:
+            prepared_plan (dict[str, Any]): Test plan configuration with VM details.
+            fixture_store (dict[str, Any]): Resource tracking dictionary.
+            source_provider (BaseProvider): Source provider connection.
+            destination_provider (OCPProvider): Destination provider connection.
+            ocp_admin_client (DynamicClient): OpenShift admin client.
+            target_namespace (str): Target namespace for migration resources.
+            source_provider_inventory (ForkliftInventory): Source provider inventory.
+            source_provider_data (dict[str, Any]): Provider configuration from providers.json.
+
+        Raises:
+            AssertionError: If Plan creation fails.
+        """
+        populate_vm_ids(prepared_plan, source_provider_inventory)
+
+        vms = [dict(vm) for vm in prepared_plan["virtual_machines"]]
+        for vm in vms:
+            vm.pop("luks", None)
+            luks_passphrase = vm.pop("luks_passphrase", None) or source_provider_data["luks_passphrase"]
+            luks_secret = create_and_store_resource(
+                client=ocp_admin_client,
+                fixture_store=fixture_store,
+                resource=Secret,
+                namespace=target_namespace,
+                string_data={"key": luks_passphrase},
+            )
+            vm["luks"] = {"name": luks_secret.name}
+
+        self.__class__.plan_resource = create_plan_resource(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            storage_map=self.storage_map,
+            network_map=self.network_map,
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            virtual_machines_list=vms,
+            warm_migration=prepared_plan["warm_migration"],
+        )
+        assert self.plan_resource, "Plan creation failed"
+
+    def test_migrate_vms(
+        self,
+        fixture_store: dict[str, Any],
+        ocp_admin_client: "DynamicClient",
+        target_namespace: str,
+    ) -> None:
+        """Execute cold migration with LUKS decryption.
+
+        Args:
+            fixture_store (dict[str, Any]): Resource tracking dictionary.
+            ocp_admin_client (DynamicClient): OpenShift admin client.
+            target_namespace (str): Target namespace for migration resources.
+
+        Raises:
+            MigrationTimeoutError: If migration fails to complete within timeout.
+        """
+        execute_migration(
+            fixture_store=fixture_store,
+            ocp_admin_client=ocp_admin_client,
+            plan=self.plan_resource,
+            target_namespace=target_namespace,
+        )
+
+    def test_check_vms(
+        self,
+        prepared_plan: dict[str, Any],
+        source_provider: "BaseProvider",
+        destination_provider: "OCPProvider",
+        source_provider_data: dict[str, Any],
+        source_vms_namespace: str,
+        source_provider_inventory: "ForkliftInventory",
+        vm_ssh_connections: "SSHConnectionManager | None",
+    ) -> None:
+        """Validate migrated VMs.
+
+        Args:
+            prepared_plan (dict[str, Any]): Test plan configuration with VM details.
+            source_provider (BaseProvider): Source provider connection.
+            destination_provider (OCPProvider): Destination provider connection.
+            source_provider_data (dict[str, Any]): Source provider configuration.
+            source_vms_namespace (str): Source VMs namespace.
+            source_provider_inventory (ForkliftInventory): Source provider inventory.
+            vm_ssh_connections (SSHConnectionManager | None): SSH connections for connectivity testing.
+
+        Raises:
+            AssertionError: If any VM validation checks fail.
+        """
+        check_vms(
+            plan=prepared_plan,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            source_provider_data=source_provider_data,
+            network_map_resource=self.network_map,
+            storage_map_resource=self.storage_map,
+            source_vms_namespace=source_vms_namespace,
+            source_provider_inventory=source_provider_inventory,
+            vm_ssh_connections=vm_ssh_connections,
+        )
+
+    def test_verify_luks_encryption(
+        self,
+        prepared_plan: dict[str, Any],
+        vm_ssh_connections: "SSHConnectionManager",
+        source_provider_data: dict[str, Any],
+    ) -> None:
+        """Verify LUKS encryption is active on migrated VM.
+
+        SSHs into the migrated VM and checks lsblk JSON output for crypto_LUKS
+        filesystem type, confirming encryption survived the migration.
+
+        Args:
+            prepared_plan (dict[str, Any]): Test plan configuration with VM details.
+            vm_ssh_connections (SSHConnectionManager): SSH connection manager.
+            source_provider_data (dict[str, Any]): Provider configuration with guest credentials.
+
+        Raises:
+            AssertionError: If no LUKS-encrypted devices are found.
+        """
+        for vm in prepared_plan["virtual_machines"]:
+            vm_name = vm["name"]
+            source_vm_info = prepared_plan["source_vms_data"][vm_name]
+            verify_luks_encryption(
+                vm_name=vm_name,
+                vm_ssh_connections=vm_ssh_connections,
+                source_provider_data=source_provider_data,
+                source_vm_info=source_vm_info,
+            )
+
+
+@pytest.mark.vsphere
+@pytest.mark.tier1
+@pytest.mark.parametrize(
+    "class_plan_config",
+    [pytest.param(py_config["tests_params"]["test_luks_cold_migration_wrong_key"])],
+    indirect=True,
+    ids=["luks-cold-wrong-key"],
+)
+@pytest.mark.usefixtures("cleanup_migrated_vms")
+@pytest.mark.incremental
+class TestLuksColdMigrationWrongKey:
+    """Cold migration with incorrect LUKS passphrase — expects failure at ImageConversion."""
+
+    storage_map: StorageMap
+    network_map: NetworkMap
+    plan_resource: Plan
+
+    def test_create_storagemap(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        source_provider: "BaseProvider",
+        destination_provider: "BaseProvider",
+        ocp_admin_client: "DynamicClient",
+        target_namespace: str,
+        source_provider_inventory: "ForkliftInventory",
+    ) -> None:
+        """Create StorageMap resource.
+
+        Args:
+            prepared_plan (dict[str, Any]): Test plan configuration with VM details.
+            fixture_store (dict[str, Any]): Resource tracking dictionary.
+            source_provider (BaseProvider): Source provider connection.
+            destination_provider (BaseProvider): Destination provider connection.
+            ocp_admin_client (DynamicClient): OpenShift admin client.
+            target_namespace (str): Target namespace for migration resources.
+            source_provider_inventory (ForkliftInventory): Source provider inventory.
+
+        Raises:
+            AssertionError: If StorageMap creation fails.
+        """
+        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.storage_map = get_storage_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            vms=vms,
+        )
+        assert self.storage_map, "StorageMap creation failed"
+
+    def test_create_networkmap(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        source_provider: "BaseProvider",
+        destination_provider: "BaseProvider",
+        ocp_admin_client: "DynamicClient",
+        target_namespace: str,
+        source_provider_inventory: "ForkliftInventory",
+        multus_network_name: dict[str, str],
+    ) -> None:
+        """Create NetworkMap resource.
+
+        Args:
+            prepared_plan (dict[str, Any]): Test plan configuration with VM details.
+            fixture_store (dict[str, Any]): Resource tracking dictionary.
+            source_provider (BaseProvider): Source provider connection.
+            destination_provider (BaseProvider): Destination provider connection.
+            ocp_admin_client (DynamicClient): OpenShift admin client.
+            target_namespace (str): Target namespace for migration resources.
+            source_provider_inventory (ForkliftInventory): Source provider inventory.
+            multus_network_name (dict[str, str]): Multus network name for network mapping.
+
+        Raises:
+            AssertionError: If NetworkMap creation fails.
+        """
+        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.network_map = get_network_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            multus_network_name=multus_network_name,
+            target_namespace=target_namespace,
+            vms=vms,
+        )
+        assert self.network_map, "NetworkMap creation failed"
+
+    def test_create_plan(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        source_provider: "BaseProvider",
+        destination_provider: "OCPProvider",
+        ocp_admin_client: "DynamicClient",
+        target_namespace: str,
+        source_provider_inventory: "ForkliftInventory",
+        source_provider_data: dict[str, Any],
+    ) -> None:
+        """Create MTV Plan with incorrect LUKS decryption secret.
+
+        The wrong passphrase is specified in config.py as an override, which
+        takes precedence over the real passphrase in providers.json.
+
+        Args:
+            prepared_plan (dict[str, Any]): Test plan configuration with VM details.
+            fixture_store (dict[str, Any]): Resource tracking dictionary.
+            source_provider (BaseProvider): Source provider connection.
+            destination_provider (OCPProvider): Destination provider connection.
+            ocp_admin_client (DynamicClient): OpenShift admin client.
+            target_namespace (str): Target namespace for migration resources.
+            source_provider_inventory (ForkliftInventory): Source provider inventory.
+            source_provider_data (dict[str, Any]): Provider configuration from providers.json.
+
+        Raises:
+            AssertionError: If Plan creation fails.
+        """
+        populate_vm_ids(prepared_plan, source_provider_inventory)
+
+        vms = [dict(vm) for vm in prepared_plan["virtual_machines"]]
+        for vm in vms:
+            vm.pop("luks", None)
+            luks_passphrase = vm.pop("luks_passphrase", None) or source_provider_data["luks_passphrase"]
+            luks_secret = create_and_store_resource(
+                client=ocp_admin_client,
+                fixture_store=fixture_store,
+                resource=Secret,
+                namespace=target_namespace,
+                string_data={"key": luks_passphrase},
+            )
+            vm["luks"] = {"name": luks_secret.name}
+
+        self.__class__.plan_resource = create_plan_resource(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            storage_map=self.storage_map,
+            network_map=self.network_map,
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            virtual_machines_list=vms,
+            warm_migration=prepared_plan["warm_migration"],
+        )
+        assert self.plan_resource, "Plan creation failed"
+
+    def test_migrate_vms(
+        self,
+        fixture_store: dict[str, Any],
+        ocp_admin_client: "DynamicClient",
+        target_namespace: str,
+    ) -> None:
+        """Execute migration — expects failure due to wrong LUKS passphrase.
+
+        Args:
+            fixture_store (dict[str, Any]): Resource tracking dictionary.
+            ocp_admin_client (DynamicClient): OpenShift admin client.
+            target_namespace (str): Target namespace for migration resources.
+
+        Raises:
+            AssertionError: If migration does not raise MigrationPlanExecError.
+        """
+        with pytest.raises(MigrationPlanExecError):
+            execute_migration(
+                fixture_store=fixture_store,
+                ocp_admin_client=ocp_admin_client,
+                plan=self.plan_resource,
+                target_namespace=target_namespace,
+            )

--- a/tests/luks/test_luks_cold_migration.py
+++ b/tests/luks/test_luks_cold_migration.py
@@ -289,7 +289,6 @@ class TestLuksColdMigrationWrongKey(LuksColdMigrationBase):
             fixture_store (dict[str, Any]): Resource tracking dictionary.
             ocp_admin_client (DynamicClient): OpenShift admin client.
             target_namespace (str): Target namespace for migration resources.
-
         """
         # ImageConversion is the pipeline step name in plan.instance.status — update if upstream renames it
         with pytest.raises(MigrationPlanExecError, match="ImageConversion"):

--- a/tests/luks/test_luks_cold_migration.py
+++ b/tests/luks/test_luks_cold_migration.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from utilities.ssh_utils import SSHConnectionManager
 
 
-class _LuksColdMigrationBase:
+class LuksColdMigrationBase:
     """Shared setup for LUKS cold migration tests.
 
     Provides common storagemap, networkmap, and plan creation methods.
@@ -155,7 +155,7 @@ class _LuksColdMigrationBase:
 
         vms = [copy.deepcopy(vm) for vm in prepared_plan["virtual_machines"]]
         for vm in vms:
-            vm.pop("luks", None)
+            vm.pop("luks", None)  # Remove config-only marker; all VMs in LUKS tests get secrets
             luks_passphrase = vm.pop("luks_passphrase", None)
             if luks_passphrase is None:
                 luks_passphrase = source_provider_data.get("luks_passphrase")
@@ -198,7 +198,7 @@ class _LuksColdMigrationBase:
 )
 @pytest.mark.usefixtures("cleanup_migrated_vms")
 @pytest.mark.incremental
-class TestLuksColdMigration(_LuksColdMigrationBase):
+class TestLuksColdMigration(LuksColdMigrationBase):
     """Cold migration with correct LUKS disk decryption passphrase.
 
     Validates that LUKS-encrypted VMs migrate successfully when the correct
@@ -304,7 +304,7 @@ class TestLuksColdMigration(_LuksColdMigrationBase):
 )
 @pytest.mark.usefixtures("cleanup_migrated_vms")
 @pytest.mark.incremental
-class TestLuksColdMigrationWrongKey(_LuksColdMigrationBase):
+class TestLuksColdMigrationWrongKey(LuksColdMigrationBase):
     """Cold migration with incorrect LUKS passphrase — expects failure at ImageConversion."""
 
     def test_migrate_vms(
@@ -323,6 +323,7 @@ class TestLuksColdMigrationWrongKey(_LuksColdMigrationBase):
         Raises:
             AssertionError: If migration does not raise MigrationPlanExecError.
         """
+        # ImageConversion is the pipeline step name in plan.instance.status — update if upstream renames it
         with pytest.raises(MigrationPlanExecError, match="ImageConversion"):
             execute_migration(
                 fixture_store=fixture_store,

--- a/tests/luks/test_luks_cold_migration.py
+++ b/tests/luks/test_luks_cold_migration.py
@@ -1,3 +1,4 @@
+import copy
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -152,14 +153,17 @@ class _LuksColdMigrationBase:
         """
         populate_vm_ids(prepared_plan, source_provider_inventory)
 
-        vms = [dict(vm) for vm in prepared_plan["virtual_machines"]]
+        vms = [copy.deepcopy(vm) for vm in prepared_plan["virtual_machines"]]
         for vm in vms:
             vm.pop("luks", None)
             luks_passphrase = vm.pop("luks_passphrase", None)
             if luks_passphrase is None:
-                luks_passphrase = source_provider_data["luks_passphrase"]
+                luks_passphrase = source_provider_data.get("luks_passphrase")
             if not luks_passphrase:
-                raise ValueError(f"LUKS passphrase is empty for VM '{vm['name']}'")
+                raise ValueError(
+                    f"LUKS passphrase not found for VM '{vm['name']}' — "
+                    "checked per-VM config and source_provider_data['luks_passphrase']"
+                )
 
             luks_secret = create_and_store_resource(
                 client=ocp_admin_client,
@@ -179,7 +183,7 @@ class _LuksColdMigrationBase:
             ocp_admin_client=ocp_admin_client,
             target_namespace=target_namespace,
             virtual_machines_list=vms,
-            warm_migration=prepared_plan["warm_migration"],
+            warm_migration=prepared_plan.get("warm_migration", False),
         )
         assert self.plan_resource, "Plan creation failed"
 
@@ -224,6 +228,35 @@ class TestLuksColdMigration(_LuksColdMigrationBase):
             target_namespace=target_namespace,
         )
 
+    def test_verify_luks_encryption(
+        self,
+        prepared_plan: dict[str, Any],
+        vm_ssh_connections: "SSHConnectionManager",
+        source_provider_data: dict[str, Any],
+    ) -> None:
+        """Verify LUKS encryption is active on migrated VM.
+
+        SSHs into the migrated VM and checks lsblk JSON output for crypto_LUKS
+        filesystem type, confirming encryption survived the migration.
+
+        Args:
+            prepared_plan (dict[str, Any]): Test plan configuration with VM details.
+            vm_ssh_connections (SSHConnectionManager): SSH connection manager.
+            source_provider_data (dict[str, Any]): Provider configuration with guest credentials.
+
+        Raises:
+            AssertionError: If no LUKS-encrypted devices are found.
+        """
+        for vm in prepared_plan["virtual_machines"]:
+            vm_name = vm["name"]
+            source_vm_info = prepared_plan["source_vms_data"][vm_name]
+            verify_luks_encryption(
+                vm_name=vm_name,
+                vm_ssh_connections=vm_ssh_connections,
+                source_provider_data=source_provider_data,
+                source_vm_info=source_vm_info,
+            )
+
     def test_check_vms(
         self,
         prepared_plan: dict[str, Any],
@@ -259,35 +292,6 @@ class TestLuksColdMigration(_LuksColdMigrationBase):
             source_provider_inventory=source_provider_inventory,
             vm_ssh_connections=vm_ssh_connections,
         )
-
-    def test_verify_luks_encryption(
-        self,
-        prepared_plan: dict[str, Any],
-        vm_ssh_connections: "SSHConnectionManager",
-        source_provider_data: dict[str, Any],
-    ) -> None:
-        """Verify LUKS encryption is active on migrated VM.
-
-        SSHs into the migrated VM and checks lsblk JSON output for crypto_LUKS
-        filesystem type, confirming encryption survived the migration.
-
-        Args:
-            prepared_plan (dict[str, Any]): Test plan configuration with VM details.
-            vm_ssh_connections (SSHConnectionManager): SSH connection manager.
-            source_provider_data (dict[str, Any]): Provider configuration with guest credentials.
-
-        Raises:
-            AssertionError: If no LUKS-encrypted devices are found.
-        """
-        for vm in prepared_plan["virtual_machines"]:
-            vm_name = vm["name"]
-            source_vm_info = prepared_plan["source_vms_data"][vm_name]
-            verify_luks_encryption(
-                vm_name=vm_name,
-                vm_ssh_connections=vm_ssh_connections,
-                source_provider_data=source_provider_data,
-                source_vm_info=source_vm_info,
-            )
 
 
 @pytest.mark.vsphere

--- a/tests/luks/test_luks_cold_migration.py
+++ b/tests/luks/test_luks_cold_migration.py
@@ -189,7 +189,7 @@ class TestLuksColdMigration(LuksColdMigrationBase):
             target_namespace (str): Target namespace for migration resources.
 
         Raises:
-            MigrationTimeoutError: If migration fails to complete within timeout.
+            MigrationPlanExecError: If migration execution fails.
         """
         execute_migration(
             fixture_store=fixture_store,
@@ -290,8 +290,6 @@ class TestLuksColdMigrationWrongKey(LuksColdMigrationBase):
             ocp_admin_client (DynamicClient): OpenShift admin client.
             target_namespace (str): Target namespace for migration resources.
 
-        Raises:
-            AssertionError: If migration does not raise MigrationPlanExecError.
         """
         # ImageConversion is the pipeline step name in plan.instance.status — update if upstream renames it
         with pytest.raises(MigrationPlanExecError, match="ImageConversion"):

--- a/tests/luks/test_luks_cold_migration.py
+++ b/tests/luks/test_luks_cold_migration.py
@@ -31,6 +31,12 @@ class _LuksColdMigrationBase:
 
     Provides common storagemap, networkmap, and plan creation methods.
     Subclasses define scenario-specific migration execution and validation.
+
+    VM requirements:
+        The source VM must have a LUKS-encrypted partition (e.g. sda3 with crypto_LUKS)
+        and a key file (e.g. /etc/luks-key) configured in /etc/crypttab for unattended
+        boot. Without a key file, the VM prompts for the passphrase interactively on
+        boot, which blocks SSH access after migration.
     """
 
     storage_map: StorageMap

--- a/tests/luks/test_luks_cold_migration.py
+++ b/tests/luks/test_luks_cold_migration.py
@@ -147,6 +147,7 @@ class _LuksColdMigrationBase:
             source_provider_data (dict[str, Any]): Provider configuration from providers.json.
 
         Raises:
+            ValueError: If LUKS passphrase is empty.
             AssertionError: If Plan creation fails.
         """
         populate_vm_ids(prepared_plan, source_provider_inventory)
@@ -154,7 +155,12 @@ class _LuksColdMigrationBase:
         vms = [dict(vm) for vm in prepared_plan["virtual_machines"]]
         for vm in vms:
             vm.pop("luks", None)
-            luks_passphrase = vm.pop("luks_passphrase", None) or source_provider_data["luks_passphrase"]
+            luks_passphrase = vm.pop("luks_passphrase", None)
+            if luks_passphrase is None:
+                luks_passphrase = source_provider_data["luks_passphrase"]
+            if not luks_passphrase:
+                raise ValueError(f"LUKS passphrase is empty for VM '{vm['name']}'")
+
             luks_secret = create_and_store_resource(
                 client=ocp_admin_client,
                 fixture_store=fixture_store,

--- a/tests/luks/test_luks_cold_migration.py
+++ b/tests/luks/test_luks_cold_migration.py
@@ -1,10 +1,8 @@
-import copy
 from typing import TYPE_CHECKING, Any
 
 import pytest
 from ocp_resources.network_map import NetworkMap
 from ocp_resources.plan import Plan
-from ocp_resources.secret import Secret
 from ocp_resources.storage_map import StorageMap
 from pytest_testconfig import config as py_config
 
@@ -16,7 +14,6 @@ from utilities.mtv_migration import (
     get_storage_migration_map,
 )
 from utilities.post_migration import check_vms, verify_luks_encryption
-from utilities.resources import create_and_store_resource
 from utilities.utils import populate_vm_ids
 
 if TYPE_CHECKING:
@@ -128,14 +125,12 @@ class LuksColdMigrationBase:
         ocp_admin_client: "DynamicClient",
         target_namespace: str,
         source_provider_inventory: "ForkliftInventory",
-        source_provider_data: dict[str, Any],
+        luks_vm_specs: list[dict[str, Any]],
     ) -> None:
-        """Create MTV Plan with LUKS decryption secret.
+        """Create MTV Plan with LUKS decryption secrets.
 
-        Creates a Kubernetes Secret containing the LUKS passphrase and references
-        it in the VM spec so forklift mounts it for virt-v2v during conversion.
-        The passphrase is resolved from per-VM config override first, then from
-        the provider configuration (providers.json).
+        Uses the luks_vm_specs fixture which resolves passphrases and creates
+        K8s Secrets per-VM. This method only handles plan creation.
 
         Args:
             prepared_plan (dict[str, Any]): Test plan configuration with VM details.
@@ -145,34 +140,12 @@ class LuksColdMigrationBase:
             ocp_admin_client (DynamicClient): OpenShift admin client.
             target_namespace (str): Target namespace for migration resources.
             source_provider_inventory (ForkliftInventory): Source provider inventory.
-            source_provider_data (dict[str, Any]): Provider configuration from providers.json.
+            luks_vm_specs (list[dict[str, Any]]): VM specs with LUKS secrets injected.
 
         Raises:
-            ValueError: If LUKS passphrase is empty.
             AssertionError: If Plan creation fails.
         """
         populate_vm_ids(prepared_plan, source_provider_inventory)
-
-        vms = [copy.deepcopy(vm) for vm in prepared_plan["virtual_machines"]]
-        for vm in vms:
-            vm.pop("luks", None)  # Remove config-only marker; all VMs in LUKS tests get secrets
-            luks_passphrase = vm.pop("luks_passphrase", None)
-            if luks_passphrase is None:
-                luks_passphrase = source_provider_data.get("luks_passphrase")
-            if not luks_passphrase:
-                raise ValueError(
-                    f"LUKS passphrase not found for VM '{vm['name']}' — "
-                    "checked per-VM config and source_provider_data['luks_passphrase']"
-                )
-
-            luks_secret = create_and_store_resource(
-                client=ocp_admin_client,
-                fixture_store=fixture_store,
-                resource=Secret,
-                namespace=target_namespace,
-                string_data={"key": luks_passphrase},
-            )
-            vm["luks"] = {"name": luks_secret.name}
 
         self.__class__.plan_resource = create_plan_resource(
             fixture_store=fixture_store,
@@ -182,7 +155,7 @@ class LuksColdMigrationBase:
             network_map=self.network_map,
             ocp_admin_client=ocp_admin_client,
             target_namespace=target_namespace,
-            virtual_machines_list=vms,
+            virtual_machines_list=luks_vm_specs,
             warm_migration=prepared_plan.get("warm_migration", False),
         )
         assert self.plan_resource, "Plan creation failed"

--- a/tests/luks/test_luks_cold_migration.py
+++ b/tests/luks/test_luks_cold_migration.py
@@ -26,21 +26,11 @@ if TYPE_CHECKING:
     from utilities.ssh_utils import SSHConnectionManager
 
 
-@pytest.mark.vsphere
-@pytest.mark.tier1
-@pytest.mark.parametrize(
-    "class_plan_config",
-    [pytest.param(py_config["tests_params"]["test_luks_cold_migration"])],
-    indirect=True,
-    ids=["luks-cold-correct-key"],
-)
-@pytest.mark.usefixtures("cleanup_migrated_vms")
-@pytest.mark.incremental
-class TestLuksColdMigration:
-    """Cold migration with correct LUKS disk decryption passphrase.
+class _LuksColdMigrationBase:
+    """Shared setup for LUKS cold migration tests.
 
-    Validates that LUKS-encrypted VMs migrate successfully when the correct
-    passphrase is provided, and that disk encryption remains active post-migration.
+    Provides common storagemap, networkmap, and plan creation methods.
+    Subclasses define scenario-specific migration execution and validation.
     """
 
     storage_map: StorageMap
@@ -181,6 +171,24 @@ class TestLuksColdMigration:
         )
         assert self.plan_resource, "Plan creation failed"
 
+
+@pytest.mark.vsphere
+@pytest.mark.tier1
+@pytest.mark.parametrize(
+    "class_plan_config",
+    [pytest.param(py_config["tests_params"]["test_luks_cold_migration"])],
+    indirect=True,
+    ids=["luks-cold-correct-key"],
+)
+@pytest.mark.usefixtures("cleanup_migrated_vms")
+@pytest.mark.incremental
+class TestLuksColdMigration(_LuksColdMigrationBase):
+    """Cold migration with correct LUKS disk decryption passphrase.
+
+    Validates that LUKS-encrypted VMs migrate successfully when the correct
+    passphrase is provided, and that disk encryption remains active post-migration.
+    """
+
     def test_migrate_vms(
         self,
         fixture_store: dict[str, Any],
@@ -280,144 +288,8 @@ class TestLuksColdMigration:
 )
 @pytest.mark.usefixtures("cleanup_migrated_vms")
 @pytest.mark.incremental
-class TestLuksColdMigrationWrongKey:
+class TestLuksColdMigrationWrongKey(_LuksColdMigrationBase):
     """Cold migration with incorrect LUKS passphrase — expects failure at ImageConversion."""
-
-    storage_map: StorageMap
-    network_map: NetworkMap
-    plan_resource: Plan
-
-    def test_create_storagemap(
-        self,
-        prepared_plan: dict[str, Any],
-        fixture_store: dict[str, Any],
-        source_provider: "BaseProvider",
-        destination_provider: "BaseProvider",
-        ocp_admin_client: "DynamicClient",
-        target_namespace: str,
-        source_provider_inventory: "ForkliftInventory",
-    ) -> None:
-        """Create StorageMap resource.
-
-        Args:
-            prepared_plan (dict[str, Any]): Test plan configuration with VM details.
-            fixture_store (dict[str, Any]): Resource tracking dictionary.
-            source_provider (BaseProvider): Source provider connection.
-            destination_provider (BaseProvider): Destination provider connection.
-            ocp_admin_client (DynamicClient): OpenShift admin client.
-            target_namespace (str): Target namespace for migration resources.
-            source_provider_inventory (ForkliftInventory): Source provider inventory.
-
-        Raises:
-            AssertionError: If StorageMap creation fails.
-        """
-        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
-        self.__class__.storage_map = get_storage_migration_map(
-            fixture_store=fixture_store,
-            source_provider=source_provider,
-            destination_provider=destination_provider,
-            source_provider_inventory=source_provider_inventory,
-            ocp_admin_client=ocp_admin_client,
-            target_namespace=target_namespace,
-            vms=vms,
-        )
-        assert self.storage_map, "StorageMap creation failed"
-
-    def test_create_networkmap(
-        self,
-        prepared_plan: dict[str, Any],
-        fixture_store: dict[str, Any],
-        source_provider: "BaseProvider",
-        destination_provider: "BaseProvider",
-        ocp_admin_client: "DynamicClient",
-        target_namespace: str,
-        source_provider_inventory: "ForkliftInventory",
-        multus_network_name: dict[str, str],
-    ) -> None:
-        """Create NetworkMap resource.
-
-        Args:
-            prepared_plan (dict[str, Any]): Test plan configuration with VM details.
-            fixture_store (dict[str, Any]): Resource tracking dictionary.
-            source_provider (BaseProvider): Source provider connection.
-            destination_provider (BaseProvider): Destination provider connection.
-            ocp_admin_client (DynamicClient): OpenShift admin client.
-            target_namespace (str): Target namespace for migration resources.
-            source_provider_inventory (ForkliftInventory): Source provider inventory.
-            multus_network_name (dict[str, str]): Multus network name for network mapping.
-
-        Raises:
-            AssertionError: If NetworkMap creation fails.
-        """
-        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
-        self.__class__.network_map = get_network_migration_map(
-            fixture_store=fixture_store,
-            source_provider=source_provider,
-            destination_provider=destination_provider,
-            source_provider_inventory=source_provider_inventory,
-            ocp_admin_client=ocp_admin_client,
-            multus_network_name=multus_network_name,
-            target_namespace=target_namespace,
-            vms=vms,
-        )
-        assert self.network_map, "NetworkMap creation failed"
-
-    def test_create_plan(
-        self,
-        prepared_plan: dict[str, Any],
-        fixture_store: dict[str, Any],
-        source_provider: "BaseProvider",
-        destination_provider: "OCPProvider",
-        ocp_admin_client: "DynamicClient",
-        target_namespace: str,
-        source_provider_inventory: "ForkliftInventory",
-        source_provider_data: dict[str, Any],
-    ) -> None:
-        """Create MTV Plan with incorrect LUKS decryption secret.
-
-        The wrong passphrase is specified in config.py as an override, which
-        takes precedence over the real passphrase in providers.json.
-
-        Args:
-            prepared_plan (dict[str, Any]): Test plan configuration with VM details.
-            fixture_store (dict[str, Any]): Resource tracking dictionary.
-            source_provider (BaseProvider): Source provider connection.
-            destination_provider (OCPProvider): Destination provider connection.
-            ocp_admin_client (DynamicClient): OpenShift admin client.
-            target_namespace (str): Target namespace for migration resources.
-            source_provider_inventory (ForkliftInventory): Source provider inventory.
-            source_provider_data (dict[str, Any]): Provider configuration from providers.json.
-
-        Raises:
-            AssertionError: If Plan creation fails.
-        """
-        populate_vm_ids(prepared_plan, source_provider_inventory)
-
-        vms = [dict(vm) for vm in prepared_plan["virtual_machines"]]
-        for vm in vms:
-            vm.pop("luks", None)
-            luks_passphrase = vm.pop("luks_passphrase", None) or source_provider_data["luks_passphrase"]
-            luks_secret = create_and_store_resource(
-                client=ocp_admin_client,
-                fixture_store=fixture_store,
-                resource=Secret,
-                namespace=target_namespace,
-                string_data={"key": luks_passphrase},
-            )
-            vm["luks"] = {"name": luks_secret.name}
-
-        self.__class__.plan_resource = create_plan_resource(
-            fixture_store=fixture_store,
-            source_provider=source_provider,
-            destination_provider=destination_provider,
-            storage_map=self.storage_map,
-            network_map=self.network_map,
-            ocp_admin_client=ocp_admin_client,
-            target_namespace=target_namespace,
-            virtual_machines_list=vms,
-            warm_migration=prepared_plan["warm_migration"],
-        )
-        assert self.plan_resource, "Plan creation failed"
 
     def test_migrate_vms(
         self,
@@ -435,7 +307,7 @@ class TestLuksColdMigrationWrongKey:
         Raises:
             AssertionError: If migration does not raise MigrationPlanExecError.
         """
-        with pytest.raises(MigrationPlanExecError):
+        with pytest.raises(MigrationPlanExecError, match="ImageConversion"):
             execute_migration(
                 fixture_store=fixture_store,
                 ocp_admin_client=ocp_admin_client,

--- a/tests/luks/test_luks_cold_migration.py
+++ b/tests/luks/test_luks_cold_migration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -14,7 +16,6 @@ from utilities.mtv_migration import (
     get_storage_migration_map,
 )
 from utilities.post_migration import check_vms, verify_luks_encryption
-from utilities.utils import populate_vm_ids
 
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
@@ -124,13 +125,12 @@ class LuksColdMigrationBase:
         destination_provider: "OCPProvider",
         ocp_admin_client: "DynamicClient",
         target_namespace: str,
-        source_provider_inventory: "ForkliftInventory",
         luks_vm_specs: list[dict[str, Any]],
     ) -> None:
         """Create MTV Plan with LUKS decryption secrets.
 
-        Uses the luks_vm_specs fixture which resolves passphrases and creates
-        K8s Secrets per-VM. This method only handles plan creation.
+        Uses the luks_vm_specs fixture which resolves passphrases, populates VM IDs,
+        and creates K8s Secrets per-VM. This method only handles plan creation.
 
         Args:
             prepared_plan (dict[str, Any]): Test plan configuration with VM details.
@@ -139,14 +139,11 @@ class LuksColdMigrationBase:
             destination_provider (OCPProvider): Destination provider connection.
             ocp_admin_client (DynamicClient): OpenShift admin client.
             target_namespace (str): Target namespace for migration resources.
-            source_provider_inventory (ForkliftInventory): Source provider inventory.
-            luks_vm_specs (list[dict[str, Any]]): VM specs with LUKS secrets injected.
+            luks_vm_specs (list[dict[str, Any]]): VM specs with LUKS secrets and IDs injected.
 
         Raises:
             AssertionError: If Plan creation fails.
         """
-        populate_vm_ids(prepared_plan, source_provider_inventory)
-
         self.__class__.plan_resource = create_plan_resource(
             fixture_store=fixture_store,
             source_provider=source_provider,

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -684,6 +684,7 @@ tests_params: dict = {
                 "source_vm_power": "on",
                 "guest_agent": True,
                 "luks": True,
+                "clone": True,
             },
         ],
         "warm_migration": False,
@@ -693,6 +694,7 @@ tests_params: dict = {
             {
                 "name": "mtv-tests-rhel9-luks",
                 "luks_passphrase": "WRONGPASSWORD",
+                "clone": True,
             },
         ],
         "warm_migration": False,

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -696,7 +696,6 @@ tests_params: dict = {
             },
         ],
         "warm_migration": False,
-        "expected_migration_result": "fail",
     },
     "test_upgrade_cold_migration": {
         "virtual_machines": [

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -693,6 +693,7 @@ tests_params: dict = {
         "virtual_machines": [
             {
                 "name": "mtv-tests-rhel9-luks",
+                "luks": True,
                 "luks_passphrase": "WRONGPASSWORD",
                 "clone": True,
             },

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -677,6 +677,27 @@ tests_params: dict = {
         "migrate_shared_disks": True,
         "target_power_state": "on",
     },
+    "test_luks_cold_migration": {
+        "virtual_machines": [
+            {
+                "name": "mtv-tests-rhel9-luks",
+                "source_vm_power": "on",
+                "guest_agent": True,
+                "luks": True,
+            },
+        ],
+        "warm_migration": False,
+    },
+    "test_luks_cold_migration_wrong_key": {
+        "virtual_machines": [
+            {
+                "name": "mtv-tests-rhel9-luks",
+                "luks_passphrase": "WRONGPASSWORD",
+            },
+        ],
+        "warm_migration": False,
+        "expected_migration_result": "fail",
+    },
     "test_upgrade_cold_migration": {
         "virtual_machines": [
             {"name": "mtv-tests-rhel8", "guest_agent": True},

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -35,6 +35,8 @@ LOGGER = get_logger(name=__name__)
 KUBERNETES_MAX_NAME_LENGTH: int = 63
 KUBERNETES_MAX_GENERATE_NAME_PREFIX_LENGTH: int = 58
 
+_LUKS_FSTYPE = "crypto_LUKS"  # lsblk filesystem-type identifier for LUKS partitions
+
 
 def get_ssh_credentials_from_provider_config(
     source_provider_data: dict[str, Any], source_vm_info: dict[str, Any]
@@ -228,7 +230,7 @@ def _find_luks_devices(devices: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for dev in devices:
         if not isinstance(dev, dict):
             continue
-        if dev.get("fstype") == "crypto_LUKS":
+        if dev.get("fstype") == _LUKS_FSTYPE:
             found.append(dev)
         children = dev.get("children") or []
         if isinstance(children, list):

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -274,8 +274,18 @@ def verify_luks_encryption(
                 if rc != 0:
                     LOGGER.warning(f"lsblk failed on VM {vm_name}: {err} - retrying...")
                     return None
-                lsblk_data: dict[str, Any] = json.loads(stdout)
-                return _find_luks_devices(lsblk_data["blockdevices"])
+                try:
+                    lsblk_data: dict[str, Any] = json.loads(stdout)
+                except json.JSONDecodeError as e:
+                    LOGGER.warning(f"Invalid lsblk JSON on VM {vm_name}: {e} - retrying...")
+                    return None
+
+                blockdevices = lsblk_data.get("blockdevices")
+                if not isinstance(blockdevices, list):
+                    LOGGER.warning(f"lsblk output missing/invalid 'blockdevices' on VM {vm_name} - retrying...")
+                    return None
+
+                return _find_luks_devices(blockdevices)
         except (SSHException, AuthenticationException, NoValidConnectionsError, ChannelException) as e:
             LOGGER.warning(f"SSH failed for VM {vm_name}: {type(e).__name__}: {e} - retrying...")
             return None
@@ -283,7 +293,7 @@ def verify_luks_encryption(
     luks_devices: list[dict[str, Any]] | None = None
     try:
         for sample in TimeoutSampler(wait_timeout=timeout, sleep=retry_delay, func=_check_luks):
-            if sample is not None:
+            if sample:
                 luks_devices = sample
                 break
     except TimeoutExpiredError as e:

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -228,13 +228,9 @@ def _find_luks_devices(devices: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """
     found: list[dict[str, Any]] = []
     for dev in devices:
-        if not isinstance(dev, dict):
-            continue
         if dev.get("fstype") == _LUKS_FSTYPE:
             found.append(dev)
-        children = dev.get("children") or []
-        if isinstance(children, list):
-            found.extend(_find_luks_devices(children))
+        found.extend(_find_luks_devices(dev.get("children") or []))
     return found
 
 
@@ -286,16 +282,7 @@ def verify_luks_encryption(
                     LOGGER.warning(f"Invalid lsblk JSON on VM {vm_name}: {e} - retrying...")
                     return None
 
-                if not isinstance(lsblk_data, dict):
-                    LOGGER.warning(f"lsblk JSON root is not an object on VM {vm_name} - retrying...")
-                    return None
-
-                blockdevices = lsblk_data.get("blockdevices")
-                if not isinstance(blockdevices, list):
-                    LOGGER.warning(f"lsblk output missing/invalid 'blockdevices' on VM {vm_name} - retrying...")
-                    return None
-
-                return _find_luks_devices(blockdevices)
+                return _find_luks_devices(lsblk_data["blockdevices"])
         except (SSHException, AuthenticationException, NoValidConnectionsError, ChannelException) as e:
             LOGGER.warning(f"SSH failed for VM {vm_name}: {type(e).__name__}: {e} - retrying...")
             return None

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -226,9 +226,13 @@ def _find_luks_devices(devices: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """
     found: list[dict[str, Any]] = []
     for dev in devices:
+        if not isinstance(dev, dict):
+            continue
         if dev.get("fstype") == "crypto_LUKS":
             found.append(dev)
-        found.extend(_find_luks_devices(dev.get("children", [])))
+        children = dev.get("children") or []
+        if isinstance(children, list):
+            found.extend(_find_luks_devices(children))
     return found
 
 

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -275,9 +275,13 @@ def verify_luks_encryption(
                     LOGGER.warning(f"lsblk failed on VM {vm_name}: {err} - retrying...")
                     return None
                 try:
-                    lsblk_data: dict[str, Any] = json.loads(stdout)
+                    lsblk_data = json.loads(stdout)
                 except json.JSONDecodeError as e:
                     LOGGER.warning(f"Invalid lsblk JSON on VM {vm_name}: {e} - retrying...")
+                    return None
+
+                if not isinstance(lsblk_data, dict):
+                    LOGGER.warning(f"lsblk JSON root is not an object on VM {vm_name} - retrying...")
                     return None
 
                 blockdevices = lsblk_data.get("blockdevices")

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -298,6 +298,7 @@ def verify_luks_encryption(
             LOGGER.warning(f"SSH failed for VM {vm_name}: {type(e).__name__}: {e} - retrying...")
             return None
 
+    # None = transient failure (retry); empty list = no LUKS devices (definitive → assert)
     luks_devices: list[dict[str, Any]] | None = None
     try:
         for sample in TimeoutSampler(wait_timeout=timeout, sleep=retry_delay, func=_check_luks):

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -297,7 +297,7 @@ def verify_luks_encryption(
     luks_devices: list[dict[str, Any]] | None = None
     try:
         for sample in TimeoutSampler(wait_timeout=timeout, sleep=retry_delay, func=_check_luks):
-            if sample:
+            if sample is not None:
                 luks_devices = sample
                 break
     except TimeoutExpiredError as e:

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import ipaddress
+import json
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -212,6 +213,84 @@ def verify_data_integrity(
         f"marker file {DATA_INTEGRITY_FILE} exists with expected content {marker_content!r}. "
         f"Pre-migration data survived the migration process."
     )
+
+
+def _find_luks_devices(devices: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Recursively search lsblk blockdevice tree for LUKS-encrypted devices.
+
+    Args:
+        devices (list[dict[str, Any]]): List of blockdevice dicts from lsblk -J -f output.
+
+    Returns:
+        list[dict[str, Any]]: Blockdevice entries with fstype == "crypto_LUKS".
+    """
+    found: list[dict[str, Any]] = []
+    for dev in devices:
+        if dev.get("fstype") == "crypto_LUKS":
+            found.append(dev)
+        found.extend(_find_luks_devices(dev.get("children", [])))
+    return found
+
+
+def verify_luks_encryption(
+    vm_name: str,
+    vm_ssh_connections: SSHConnectionManager,
+    source_provider_data: dict[str, Any],
+    source_vm_info: dict[str, Any],
+    timeout: int = 300,
+    retry_delay: int = 15,
+) -> None:
+    """Verify that LUKS disk encryption is active on the migrated VM.
+
+    SSHs into the migrated VM, runs lsblk -J -f for structured JSON output,
+    and searches the blockdevice tree for crypto_LUKS entries.
+
+    Args:
+        vm_name (str): Name of the migrated VM.
+        vm_ssh_connections (SSHConnectionManager): SSH connection manager.
+        source_provider_data (dict[str, Any]): Provider configuration with guest credentials.
+        source_vm_info (dict[str, Any]): VM information including OS type.
+        timeout (int): Maximum seconds to wait for SSH connectivity.
+        retry_delay (int): Seconds between SSH retry attempts.
+
+    Raises:
+        AssertionError: If no LUKS-encrypted devices are found.
+        TimeoutExpiredError: If SSH connectivity cannot be established.
+    """
+    LOGGER.info(f"Verifying LUKS encryption on migrated VM {vm_name}")
+
+    ssh_username, ssh_password = get_ssh_credentials_from_provider_config(source_provider_data, source_vm_info)
+    ssh_conn = vm_ssh_connections.create(vm_name=vm_name, username=ssh_username, password=ssh_password)
+
+    def _check_luks() -> list[dict[str, Any]] | None:
+        try:
+            with ssh_conn:
+                if not ssh_conn.rrmngmnt_host:
+                    LOGGER.warning(f"SSH connection not established for VM {vm_name} - retrying...")
+                    return None
+                executor = ssh_conn.rrmngmnt_host.executor(user=ssh_conn.rrmngmnt_user)
+                executor.port = ssh_conn.local_port
+                rc, stdout, err = executor.run_cmd(["lsblk", "-J", "-f"])
+                if rc != 0:
+                    LOGGER.warning(f"lsblk failed on VM {vm_name}: {err} - retrying...")
+                    return None
+                lsblk_data: dict[str, Any] = json.loads(stdout)
+                return _find_luks_devices(lsblk_data["blockdevices"])
+        except (SSHException, AuthenticationException, NoValidConnectionsError, ChannelException) as e:
+            LOGGER.warning(f"SSH failed for VM {vm_name}: {type(e).__name__}: {e} - retrying...")
+            return None
+
+    luks_devices: list[dict[str, Any]] | None = None
+    try:
+        for sample in TimeoutSampler(wait_timeout=timeout, sleep=retry_delay, func=_check_luks):
+            if sample is not None:
+                luks_devices = sample
+                break
+    except TimeoutExpiredError as e:
+        raise TimeoutExpiredError(f"Could not verify LUKS encryption on VM {vm_name} after {timeout}s") from e
+
+    assert luks_devices, f"No LUKS-encrypted devices found on migrated VM {vm_name}"
+    LOGGER.info(f"LUKS encryption verified on VM {vm_name}: {len(luks_devices)} encrypted device(s) found")
 
 
 def _parse_windows_network_config(ipconfig_output: str) -> dict[str, dict[str, Any]]:


### PR DESCRIPTION
## Summary
- Add positive and negative cold migration tests for LUKS-encrypted VMs (vSphere, tier1)
- Positive test: cold migrate with correct passphrase, verify migration succeeds and LUKS encryption remains active post-migration (`lsblk -J -f` parsed for `crypto_LUKS`)
- Negative test: cold migrate with wrong passphrase, verify migration fails at ImageConversion (`MigrationPlanExecError`)
- Add `verify_luks_encryption` helper in `utilities/post_migration.py`
- LUKS passphrase read from `providers.json` (real key, gitignored); negative test overrides with `"WRONGPASSWORD"` in config
- VM (`mtv-tests-rhel9-luks`): RHEL 9, single LUKS-encrypted disk, single NIC (DHCP), key file at `/etc/luks-key` embedded in initramfs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end LUKS-encrypted cold-migration coverage, including post-migration verification by checking disk encryption.
  * Added a negative test path to confirm the migration fails when an incorrect LUKS passphrase is used.
* **Tests**
  * Introduced new LUKS cold-migration test cases, shared setup helpers, and VM LUKS secret preparation for plan execution and validation.
* **Documentation**
  * Updated LUKS test-pattern guidance and VM configuration options, including the new verification step.
  * Added a README section for running and configuring tier1 LUKS tests.
* **Chores**
  * Updated the example vSphere provider configuration ordering/placeholder text for the LUKS passphrase field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->