### PR TITLE
test: demote negative ClusterRole test from tier0 to tier1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -894,6 +894,7 @@ Class-scoped teardown fixture that cleans up migrated VMs after each test class 
 | Marker                  | Purpose                               |
 | ----------------------- | ------------------------------------- |
 | `tier0`                 | Core functionality (smoke tests)      |
+| `tier1`                 | Extended functionality tests          |
 | `warm`                  | Warm migration tests                  |
 | `remote`                | Remote cluster tests                  |
 | `copyoffload`           | Copy-offload (XCOPY) tests            |

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ The Quick Start runs **tier0** tests (smoke tests). You can run other test categ
 | Marker | What It Tests | When to Use |
 | ------ | ------------- | ----------- |
 | `tier0` | Smoke tests - critical paths | First run, quick validation |
+| `tier1` | Extended functionality tests | Broader coverage beyond smoke |
 | `copyoffload` | Fast migrations via shared storage | Testing storage arrays |
 | `copyoffload_sanity` | Copy-offload sanity subset (see below) | Quick copy-offload validation |
 | `warm` | Warm migrations (VMs stay running) | Specific scenario testing |
@@ -507,7 +508,7 @@ The wizard will:
 2. Connect to vSphere and let you select datastores, a test VM, and an ESXi host
 3. Prompt for storage vendor and credentials
 4. Connect to OpenShift and let you select a storage class
-5. Ask which test category to run (`all`, `copyoffload`, `copyoffload_sanity`, `tier0`, `warm`, `remote`)
+5. Ask which test category to run (`all`, `copyoffload`, `copyoffload_sanity`, `tier0`, `tier1`, `warm`, `remote`)
 6. Write `.providers.json` and `mtv-api-tests-manifests.yaml`
 
 > **Security Note:** The generated `mtv-api-tests-manifests.yaml` contains embedded credentials

--- a/cli/mtv_api_tests/common.py
+++ b/cli/mtv_api_tests/common.py
@@ -69,6 +69,7 @@ TEST_CATEGORIES: dict[str, str] = {
     "all": "All tests (no marker filter)",
     "copyoffload": "Copy-offload (XCOPY) tests",
     "tier0": "Core functionality tests (smoke tests)",
+    "tier1": "Extended functionality tests",
     "warm": "Warm migration tests",
     "remote": "Remote cluster migration tests",
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,6 +15,7 @@ addopts =
 
 markers =
     tier0: Core functionality tests (smoke tests)
+    tier1: Extended functionality tests
     remote: Remote cluster migration tests
     warm: Warm migration tests
     copyoffload: Copy-offload (XCOPY) tests

--- a/tests/warm/test_mtv_warm_clusterrole_migration.py
+++ b/tests/warm/test_mtv_warm_clusterrole_migration.py
@@ -17,7 +17,7 @@ from utilities.utils import get_value_from_py_config, populate_vm_ids
 
 
 @pytest.mark.remote
-@pytest.mark.tier0
+@pytest.mark.tier1
 @pytest.mark.warm
 @pytest.mark.incremental
 @pytest.mark.skipif(


### PR DESCRIPTION
  Move TestClusterroleWarmMtvMigration (without SCC, expects failure) to
  tier1 and keep the positive test (with SCC) as tier0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reclassified the cluster role migration test to a different test tier.
* **Test Configuration / Documentation**
  * Added a new `tier1` test category marker and documented it for the test suite and related test tooling.

Note: This is an internal testing infrastructure update with no user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->