### PR TITLE
feat: add Windows shared disk migration test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -845,15 +845,16 @@ tests_params: dict = {
 
 **VM Configuration Options:**
 
-| Option            | Required | Values                              |
-| ----------------- | -------- | ----------------------------------- |
-| `name`            | Yes      | VM name in source provider          |
-| `source_vm_power` | No       | "on" or "off"                       |
-| `guest_agent`     | No       | True if installed                   |
-| `clone`           | No       | True to clone before migration      |
-| `disk_type`       | No       | "thin", "thick-lazy", "thick-eager" |
-| `luks`            | No       | True if VM has LUKS-encrypted disk  |
-| `luks_passphrase` | No       | Per-VM passphrase override          |
+| Option                 | Required | Values                                   |
+| ---------------------- | -------- | ---------------------------------------- |
+| `name`                 | Yes      | VM name in source provider               |
+| `source_vm_power`      | No       | "on" or "off"                            |
+| `guest_agent`          | No       | True if installed                        |
+| `clone`                | No       | True to clone before migration           |
+| `disk_type`            | No       | "thin", "thick-lazy", "thick-eager"      |
+| `luks`                 | No       | True if VM has LUKS-encrypted disk       |
+| `luks_passphrase`      | No       | Per-VM passphrase override               |
+| `migrate_shared_disks` | No       | True for owner VM in shared disk tests   |
 
 **Plan Configuration Options:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -818,7 +818,7 @@ class TestNameHere:
 **Test method naming:** Base tests: `test_create_storagemap`, `test_create_networkmap`, `test_create_plan`,
 `test_migrate_vms`, `test_check_vms`. Shared-disk Linux tests: same through `test_migrate_vms`, then
 `test_verify_shared_disk_data`, `test_check_vms`. Shared-disk Windows tests: `test_label_shared_disk`,
-then the base five, then `test_verify_shared_disk_data`, `test_check_vms`. Copy-offload tests: same through `test_migrate_vms`, then
+then the base five through `test_migrate_vms`, then `test_verify_shared_disk_data`, `test_check_vms`. Copy-offload tests: same through `test_migrate_vms`, then
 `test_check_xcopy_used`, `test_check_vms`. Copy-offload throttling tests: same through `test_migrate_vms`, then
 `test_verify_populator_throttling`, `test_check_xcopy_used`, `test_check_vms`. LUKS tests: same through `test_migrate_vms`, then
 `test_verify_luks_encryption`, `test_check_vms`. XFS tests: same through `test_migrate_vms`, then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -866,6 +866,7 @@ tests_params: dict = {
 | `preserve_static_ips` | No       | True to preserve static IP addresses after migration  |
 | `copyoffload`         | No       | True to enable copy-offload (XCOPY) migration         |
 | `xfs_compatibility`   | No       | True to enable XFS v4 filesystem compatibility        |
+| `migrate_shared_disks`| No       | True to enable shared disk migration at plan level    |
 
 **Test Verification Configuration:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -788,7 +788,7 @@ class TestNameHere:
 - **6-step shared-disk pattern**: storagemap -> networkmap -> plan -> migrate -> verify_shared_disk_data -> check_vms
   Shared disk tests insert `test_verify_shared_disk_data` before `test_check_vms`. This step mounts,
   writes, and reads a shared disk from both VMs to verify bidirectional access after migration.
-  Uses `verify_shared_disk_data()` from `utilities/shared_disk.py`.
+  Uses `verify_shared_disk_data()` (Linux) or `verify_shared_disk_data_windows()` (Windows) from `utilities/shared_disk.py`.
 - **6-step copy-offload pattern**: storagemap -> networkmap -> plan -> migrate -> check_xcopy_used -> check_vms
   `test_check_xcopy_used` calls `verify_xcopy_used()` from `utilities/copyoffload_migration.py`. This step
   validates the transfer mechanism (infrastructure), not the migrated VM (application), and provides
@@ -966,6 +966,7 @@ Class-scoped teardown fixture that cleans up migrated VMs after each test class 
 | `copyoffload_sanity`    | Copy-offload sanity subset             |
 | `copyoffload_snapshots` | Copy-offload snapshot tests (vSphere)  |
 | `vsphere`               | VMware vSphere provider-specific tests |
+| `shared_disk`           | Shared disk migration tests            |
 
 **Marker requirements for collection-time skipping (MUST):**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -785,10 +785,14 @@ class TestNameHere:
 - **Shared state**: Store resources on class with `self.__class__.attribute`
 - **Test ordering**: Use `@pytest.mark.incremental` at class level for sequential test dependencies
 - **5-step pattern**: storagemap -> networkmap -> plan -> migrate -> check_vms
-- **6-step shared-disk pattern**: storagemap -> networkmap -> plan -> migrate -> verify_shared_disk_data -> check_vms
+- **6-step shared-disk pattern (Linux)**: storagemap -> networkmap -> plan -> migrate -> verify_shared_disk_data -> check_vms
   Shared disk tests insert `test_verify_shared_disk_data` before `test_check_vms`. This step mounts,
   writes, and reads a shared disk from both VMs to verify bidirectional access after migration.
-  Uses `verify_shared_disk_data()` (Linux) or `verify_shared_disk_data_windows()` (Windows) from `utilities/shared_disk.py`.
+  Uses `verify_shared_disk_data()` from `utilities/shared_disk.py`.
+- **7-step shared-disk pattern (Windows)**: label_shared_disk -> storagemap -> networkmap -> plan -> migrate -> verify_shared_disk_data -> check_vms
+  Windows shared disk tests prepend `test_label_shared_disk` which dynamically labels the shared NTFS
+  volume on the source VM via VMware Guest Operations API before migration. Post-migration verification
+  uses `verify_shared_disk_data_windows()` from `utilities/shared_disk.py`.
 - **6-step copy-offload pattern**: storagemap -> networkmap -> plan -> migrate -> check_xcopy_used -> check_vms
   `test_check_xcopy_used` calls `verify_xcopy_used()` from `utilities/copyoffload_migration.py`. This step
   validates the transfer mechanism (infrastructure), not the migrated VM (application), and provides
@@ -837,7 +841,7 @@ tests_params: dict = {
 2. Create a test class with `@pytest.mark.parametrize` using `class_plan_config` and `indirect=True`
 3. Add pytest markers at class level (tier0, tier1, warm, remote, copyoffload)
 4. Implement the 5 base test methods. Some features need extra validation steps: see **Key Patterns** for the
-   6-step shared-disk, copy-offload, and LUKS patterns, or the 7-step copy-offload throttling pattern
+   6-step shared-disk (Linux), 7-step shared-disk (Windows), copy-offload, and LUKS patterns, or the 7-step copy-offload throttling pattern
 
 **VM Configuration Options:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -816,7 +816,9 @@ class TestNameHere:
   Requires `xfs_compatibility: True` in plan config and `xfs_check` config dict.
 
 **Test method naming:** Base tests: `test_create_storagemap`, `test_create_networkmap`, `test_create_plan`,
-`test_migrate_vms`, `test_check_vms`. Copy-offload tests: same through `test_migrate_vms`, then
+`test_migrate_vms`, `test_check_vms`. Shared-disk Linux tests: same through `test_migrate_vms`, then
+`test_verify_shared_disk_data`, `test_check_vms`. Shared-disk Windows tests: `test_label_shared_disk`,
+then the base five, then `test_verify_shared_disk_data`, `test_check_vms`. Copy-offload tests: same through `test_migrate_vms`, then
 `test_check_xcopy_used`, `test_check_vms`. Copy-offload throttling tests: same through `test_migrate_vms`, then
 `test_verify_populator_throttling`, `test_check_xcopy_used`, `test_check_vms`. LUKS tests: same through `test_migrate_vms`, then
 `test_verify_luks_encryption`, `test_check_vms`. XFS tests: same through `test_migrate_vms`, then

--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ The Quick Start runs **tier0** tests (smoke tests). You can run other test categ
 | `copyoffload` | Fast migrations via shared storage | Testing storage arrays |
 | `copyoffload_sanity` | Copy-offload sanity subset (see below) | Quick copy-offload validation |
 | `warm` | Warm migrations (VMs stay running) | Specific scenario testing |
+| `shared_disk` | Shared disk migration tests | Testing shared disk between VMs |
+| `vsphere` | vSphere-only tests | Tests specific to vSphere provider |
 | `upgrade` | Migration across MTV operator upgrades | Validating upgrade compatibility |
 | `vsphere` | vSphere-specific tests (XFS, etc.) | Testing vSphere specific scenarios |
 

--- a/README.md
+++ b/README.md
@@ -272,9 +272,8 @@ The Quick Start runs **tier0** tests (smoke tests). You can run other test categ
 | `copyoffload_sanity` | Copy-offload sanity subset (see below) | Quick copy-offload validation |
 | `warm` | Warm migrations (VMs stay running) | Specific scenario testing |
 | `shared_disk` | Shared disk migration tests | Testing shared disk between VMs |
-| `vsphere` | vSphere-only tests | Tests specific to vSphere provider |
+| `vsphere` | VMware vSphere provider-specific tests | Tests specific to vSphere provider |
 | `upgrade` | Migration across MTV operator upgrades | Validating upgrade compatibility |
-| `vsphere` | vSphere-specific tests (XFS, etc.) | Testing vSphere specific scenarios |
 
 ### Copy-Offload Sanity Tests
 

--- a/exceptions/exceptions.py
+++ b/exceptions/exceptions.py
@@ -129,3 +129,7 @@ class GuestCommandError(Exception):
 
 class MtvUpgradeError(Exception):
     """Raised when MTV operator upgrade fails."""
+
+
+class SSHConnectionSetupError(Exception):
+    """Raised when SSH connection setup fails (e.g., missing virtctl, port-forward failure)."""

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -1599,6 +1599,17 @@ class VMWareProvider(BaseProvider):
 
         return None
 
+    def find_shared_vmdk_paths(self, vm_names: list[str]) -> dict[str, list[tuple[int, int, int]]]:
+        """Find VMDKs shared across multiple VMs.
+
+        Args:
+            vm_names: Source VM names to scan.
+
+        Returns:
+            dict mapping shared VMDK paths to their SCSI positions per VM.
+        """
+        return self._find_shared_vmdks(self._build_vmdk_position_map(vm_names))
+
     def _build_vmdk_position_map(
         self,
         source_vm_names: list[str],

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -1606,7 +1606,10 @@ class VMWareProvider(BaseProvider):
             vm_names (list[str]): Source VM names to scan.
 
         Returns:
-            dict mapping shared VMDK paths to their SCSI positions per VM.
+            dict[str, list[tuple[int, int, int]]]: Mapping of shared VMDK backing-file
+                paths to their SCSI positions. Each tuple is ``(vm_index, bus_number,
+                unit_number)`` where ``vm_index`` is the index into the caller-supplied
+                ``vm_names`` list.
         """
         return self._find_shared_vmdks(self._build_vmdk_position_map(vm_names))
 

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -1603,7 +1603,7 @@ class VMWareProvider(BaseProvider):
         """Find VMDKs shared across multiple VMs.
 
         Args:
-            vm_names: Source VM names to scan.
+            vm_names (list[str]): Source VM names to scan.
 
         Returns:
             dict mapping shared VMDK paths to their SCSI positions per VM.

--- a/tests/shared_disk/test_shared_disk_windows_migration.py
+++ b/tests/shared_disk/test_shared_disk_windows_migration.py
@@ -22,7 +22,7 @@ from utilities.mtv_migration import (
     get_storage_migration_map,
 )
 from utilities.post_migration import check_vms
-from utilities.shared_disk import verify_shared_disk_data_windows
+from utilities.shared_disk import label_shared_disk_on_source_windows, verify_shared_disk_data_windows
 from utilities.utils import populate_vm_ids
 
 if TYPE_CHECKING:
@@ -55,6 +55,21 @@ class TestSharedDiskWindowsMigration:
     storage_map: StorageMap
     network_map: NetworkMap
     plan_resource: Plan
+
+    def test_label_shared_disk(
+        self,
+        prepared_plan: dict[str, Any],
+        source_provider: "BaseProvider",
+        source_provider_data: dict[str, Any],
+        fixture_store: dict[str, Any],
+    ) -> None:
+        """Label the shared disk on source VM via SCSI position before migration."""
+        label_shared_disk_on_source_windows(
+            source_provider=source_provider,  # type: ignore[arg-type]
+            prepared_plan=prepared_plan,
+            source_provider_data=source_provider_data,
+            session_uuid=fixture_store["session_uuid"],
+        )
 
     def test_create_storagemap(
         self,

--- a/tests/shared_disk/test_shared_disk_windows_migration.py
+++ b/tests/shared_disk/test_shared_disk_windows_migration.py
@@ -1,0 +1,185 @@
+"""Shared disk migration tests for Windows VMs.
+
+Tests VM-level migrateSharedDisks overrides for Windows Server VMs in a single
+migration plan. The owner VM (migrateSharedDisks=true) migrates the shared disk
+PVC, while the consumer VM (migrateSharedDisks=false) skips it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from ocp_resources.network_map import NetworkMap
+from ocp_resources.plan import Plan
+from ocp_resources.storage_map import StorageMap
+from pytest_testconfig import config as py_config
+
+from utilities.mtv_migration import (
+    create_plan_resource,
+    execute_migration,
+    get_network_migration_map,
+    get_storage_migration_map,
+)
+from utilities.post_migration import check_vms
+from utilities.shared_disk import verify_shared_disk_data_windows
+from utilities.utils import populate_vm_ids
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from libs.base_provider import BaseProvider
+    from libs.forklift_inventory import ForkliftInventory
+    from libs.providers.openshift import OCPProvider
+    from utilities.ssh_utils import SSHConnectionManager
+
+
+@pytest.mark.vsphere
+@pytest.mark.shared_disk
+@pytest.mark.tier1
+@pytest.mark.incremental
+@pytest.mark.parametrize(
+    "class_plan_config",
+    [
+        pytest.param(
+            py_config["tests_params"]["test_shared_disk_windows_migration"],
+        )
+    ],
+    indirect=True,
+    ids=["shared-disk-windows"],
+)
+@pytest.mark.usefixtures("cleanup_migrated_vms")
+class TestSharedDiskWindowsMigration:
+    """Cold migrate Windows VMs with VM-level migrateSharedDisks overrides."""
+
+    storage_map: StorageMap
+    network_map: NetworkMap
+    plan_resource: Plan
+
+    def test_create_storagemap(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: "DynamicClient",
+        source_provider: "BaseProvider",
+        destination_provider: "OCPProvider",
+        source_provider_inventory: "ForkliftInventory",
+        target_namespace: str,
+    ) -> None:
+        """Create StorageMap resource for both VMs."""
+        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.storage_map = get_storage_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            vms=vms,
+        )
+        assert self.storage_map, "StorageMap creation failed"
+
+    def test_create_networkmap(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: "DynamicClient",
+        source_provider: "BaseProvider",
+        destination_provider: "OCPProvider",
+        source_provider_inventory: "ForkliftInventory",
+        target_namespace: str,
+        multus_network_name: dict[str, str],
+    ) -> None:
+        """Create NetworkMap resource for both VMs."""
+        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.network_map = get_network_migration_map(
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            source_provider_inventory=source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            multus_network_name=multus_network_name,
+            vms=vms,
+        )
+        assert self.network_map, "NetworkMap creation failed"
+
+    def test_create_plan(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: "DynamicClient",
+        source_provider: "BaseProvider",
+        destination_provider: "OCPProvider",
+        target_namespace: str,
+        source_provider_inventory: "ForkliftInventory",
+    ) -> None:
+        """Create MTV Plan CR with VM-level migrateSharedDisks overrides."""
+        populate_vm_ids(prepared_plan, source_provider_inventory)
+
+        self.__class__.plan_resource = create_plan_resource(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            storage_map=self.storage_map,
+            network_map=self.network_map,
+            virtual_machines_list=prepared_plan["virtual_machines"],
+            target_namespace=target_namespace,
+            warm_migration=prepared_plan["warm_migration"],
+            migrate_shared_disks=prepared_plan["migrate_shared_disks"],
+            target_power_state=prepared_plan["target_power_state"],
+        )
+        assert self.plan_resource, "Plan creation failed"
+
+    def test_migrate_vms(
+        self,
+        fixture_store: dict[str, Any],
+        ocp_admin_client: "DynamicClient",
+        target_namespace: str,
+    ) -> None:
+        """Execute migration for both VMs in a single plan."""
+        execute_migration(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            plan=self.plan_resource,
+            target_namespace=target_namespace,
+        )
+
+    def test_verify_shared_disk_data(
+        self,
+        prepared_plan: dict[str, Any],
+        vm_ssh_connections: "SSHConnectionManager",
+        source_provider_data: dict[str, Any],
+        ocp_admin_client: "DynamicClient",
+    ) -> None:
+        """Verify shared disk read/write access from both Windows VMs."""
+        verify_shared_disk_data_windows(
+            prepared_plan=prepared_plan,
+            vm_ssh_connections=vm_ssh_connections,
+            source_provider_data=source_provider_data,
+            ocp_admin_client=ocp_admin_client,
+        )
+
+    def test_check_vms(
+        self,
+        prepared_plan: dict[str, Any],
+        source_provider: "BaseProvider",
+        destination_provider: "OCPProvider",
+        source_provider_data: dict[str, Any],
+        source_vms_namespace: str,
+        source_provider_inventory: "ForkliftInventory",
+        vm_ssh_connections: "SSHConnectionManager",
+    ) -> None:
+        """Validate both migrated VMs."""
+        check_vms(
+            plan=prepared_plan,
+            source_provider=source_provider,
+            destination_provider=destination_provider,
+            network_map_resource=self.network_map,
+            storage_map_resource=self.storage_map,
+            source_provider_data=source_provider_data,
+            source_vms_namespace=source_vms_namespace,
+            source_provider_inventory=source_provider_inventory,
+            vm_ssh_connections=vm_ssh_connections,
+        )

--- a/tests/shared_disk/test_shared_disk_windows_migration.py
+++ b/tests/shared_disk/test_shared_disk_windows_migration.py
@@ -141,7 +141,7 @@ class TestSharedDiskWindowsMigration:
             network_map=self.network_map,
             virtual_machines_list=prepared_plan["virtual_machines"],
             target_namespace=target_namespace,
-            warm_migration=prepared_plan.get("warm_migration", False),
+            warm_migration=prepared_plan["warm_migration"],
             migrate_shared_disks=prepared_plan["migrate_shared_disks"],
             target_power_state=prepared_plan["target_power_state"],
         )

--- a/tests/shared_disk/test_shared_disk_windows_migration.py
+++ b/tests/shared_disk/test_shared_disk_windows_migration.py
@@ -58,14 +58,14 @@ class TestSharedDiskWindowsMigration:
 
     def test_label_shared_disk(
         self,
-        prepared_plan: dict[str, Any],
+        prepared_plan: dict[str, Any],  # Heterogeneous: VM specs, flags, runtime data
         source_provider: "BaseProvider",
-        source_provider_data: dict[str, Any],
-        fixture_store: dict[str, Any],
+        source_provider_data: dict[str, Any],  # Provider config: credentials, endpoints, settings
+        fixture_store: dict[str, Any],  # Session state: UUIDs, teardown tracking
     ) -> None:
         """Label the shared disk on source VM via SCSI position before migration."""
         label_shared_disk_on_source_windows(
-            source_provider=source_provider,  # type: ignore[arg-type]
+            source_provider=source_provider,  # type: ignore[arg-type]  # vsphere marker guarantees VMWareProvider
             prepared_plan=prepared_plan,
             source_provider_data=source_provider_data,
             session_uuid=fixture_store["session_uuid"],
@@ -141,7 +141,7 @@ class TestSharedDiskWindowsMigration:
             network_map=self.network_map,
             virtual_machines_list=prepared_plan["virtual_machines"],
             target_namespace=target_namespace,
-            warm_migration=prepared_plan["warm_migration"],
+            warm_migration=prepared_plan.get("warm_migration", False),
             migrate_shared_disks=prepared_plan["migrate_shared_disks"],
             target_power_state=prepared_plan["target_power_state"],
         )

--- a/tests/shared_disk/test_shared_disk_windows_migration.py
+++ b/tests/shared_disk/test_shared_disk_windows_migration.py
@@ -63,7 +63,7 @@ class TestSharedDiskWindowsMigration:
         source_provider_data: dict[str, Any],  # Provider config: credentials, endpoints, settings
         fixture_store: dict[str, Any],  # Session state: UUIDs, teardown tracking
     ) -> None:
-        """Label the shared disk on source VM via SCSI position before migration."""
+        """Label the shared disk on source VM via VMware Guest Operations before migration."""
         label_shared_disk_on_source_windows(
             source_provider=source_provider,  # type: ignore[arg-type]  # vsphere marker guarantees VMWareProvider
             prepared_plan=prepared_plan,

--- a/tests/shared_disk/test_shared_disk_windows_migration.py
+++ b/tests/shared_disk/test_shared_disk_windows_migration.py
@@ -59,7 +59,7 @@ class TestSharedDiskWindowsMigration:
     def test_label_shared_disk(
         self,
         prepared_plan: dict[str, Any],  # Heterogeneous: VM specs, flags, runtime data
-        source_provider: "BaseProvider",
+        source_provider: BaseProvider,
         source_provider_data: dict[str, Any],  # Provider config: credentials, endpoints, settings
         fixture_store: dict[str, Any],  # Session state: UUIDs, teardown tracking
     ) -> None:
@@ -75,10 +75,10 @@ class TestSharedDiskWindowsMigration:
         self,
         prepared_plan: dict[str, Any],
         fixture_store: dict[str, Any],
-        ocp_admin_client: "DynamicClient",
-        source_provider: "BaseProvider",
-        destination_provider: "OCPProvider",
-        source_provider_inventory: "ForkliftInventory",
+        ocp_admin_client: DynamicClient,
+        source_provider: BaseProvider,
+        destination_provider: OCPProvider,
+        source_provider_inventory: ForkliftInventory,
         target_namespace: str,
     ) -> None:
         """Create StorageMap resource for both VMs."""
@@ -98,10 +98,10 @@ class TestSharedDiskWindowsMigration:
         self,
         prepared_plan: dict[str, Any],
         fixture_store: dict[str, Any],
-        ocp_admin_client: "DynamicClient",
-        source_provider: "BaseProvider",
-        destination_provider: "OCPProvider",
-        source_provider_inventory: "ForkliftInventory",
+        ocp_admin_client: DynamicClient,
+        source_provider: BaseProvider,
+        destination_provider: OCPProvider,
+        source_provider_inventory: ForkliftInventory,
         target_namespace: str,
         multus_network_name: dict[str, str],
     ) -> None:
@@ -123,11 +123,11 @@ class TestSharedDiskWindowsMigration:
         self,
         prepared_plan: dict[str, Any],
         fixture_store: dict[str, Any],
-        ocp_admin_client: "DynamicClient",
-        source_provider: "BaseProvider",
-        destination_provider: "OCPProvider",
+        ocp_admin_client: DynamicClient,
+        source_provider: BaseProvider,
+        destination_provider: OCPProvider,
         target_namespace: str,
-        source_provider_inventory: "ForkliftInventory",
+        source_provider_inventory: ForkliftInventory,
     ) -> None:
         """Create MTV Plan CR with VM-level migrateSharedDisks overrides."""
         populate_vm_ids(prepared_plan, source_provider_inventory)
@@ -150,7 +150,7 @@ class TestSharedDiskWindowsMigration:
     def test_migrate_vms(
         self,
         fixture_store: dict[str, Any],
-        ocp_admin_client: "DynamicClient",
+        ocp_admin_client: DynamicClient,
         target_namespace: str,
     ) -> None:
         """Execute migration for both VMs in a single plan."""
@@ -164,9 +164,9 @@ class TestSharedDiskWindowsMigration:
     def test_verify_shared_disk_data(
         self,
         prepared_plan: dict[str, Any],
-        vm_ssh_connections: "SSHConnectionManager",
+        vm_ssh_connections: SSHConnectionManager,
         source_provider_data: dict[str, Any],
-        ocp_admin_client: "DynamicClient",
+        ocp_admin_client: DynamicClient,
     ) -> None:
         """Verify shared disk read/write access from both Windows VMs."""
         verify_shared_disk_data_windows(
@@ -179,12 +179,12 @@ class TestSharedDiskWindowsMigration:
     def test_check_vms(
         self,
         prepared_plan: dict[str, Any],
-        source_provider: "BaseProvider",
-        destination_provider: "OCPProvider",
+        source_provider: BaseProvider,
+        destination_provider: OCPProvider,
         source_provider_data: dict[str, Any],
         source_vms_namespace: str,
-        source_provider_inventory: "ForkliftInventory",
-        vm_ssh_connections: "SSHConnectionManager",
+        source_provider_inventory: ForkliftInventory,
+        vm_ssh_connections: SSHConnectionManager,
     ) -> None:
         """Validate both migrated VMs."""
         check_vms(

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -702,6 +702,25 @@ tests_params: dict = {
         ],
         "warm_migration": False,
     },
+    "test_shared_disk_windows_migration": {
+        "virtual_machines": [
+            {
+                "name": "mtv-tests-shared-win1",
+                "source_vm_power": "off",
+                "guest_agent": True,
+                "migrate_shared_disks": True,
+            },
+            {
+                "name": "mtv-tests-shared-win2",
+                "source_vm_power": "off",
+                "guest_agent": True,
+                "migrate_shared_disks": False,
+            },
+        ],
+        "warm_migration": False,
+        "migrate_shared_disks": True,
+        "target_power_state": "on",
+    },
     "test_upgrade_cold_migration": {
         "virtual_machines": [
             {"name": "mtv-tests-rhel8", "guest_agent": True},

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -369,6 +369,7 @@ def _win_get_shared_drive_letter(ssh_conn: VMSSHConnection, vm_label: str) -> st
         except GuestCommandError:
             return None
 
+    drive_letter = ""
     try:
         for sample in TimeoutSampler(
             wait_timeout=_WIN_VOLUME_DISCOVERY_TIMEOUT,
@@ -377,14 +378,15 @@ def _win_get_shared_drive_letter(ssh_conn: VMSSHConnection, vm_label: str) -> st
         ):
             if sample and len(sample) == 1:
                 LOGGER.info(f"{vm_label}: SHARED volume is drive {sample}:")
-                return sample
+                drive_letter = sample
+                break
     except TimeoutExpiredError as exc:
         raise GuestCommandError(
             f"{vm_label}: Volume with label '{_SHARED_VOLUME_LABEL}' not found after "
             f"{_WIN_VOLUME_DISCOVERY_TIMEOUT}s. Ensure the shared disk on the source VM "
             f"has an NTFS volume labeled '{_SHARED_VOLUME_LABEL}'."
         ) from exc
-    raise GuestCommandError(f"{vm_label}: SHARED volume not found")
+    return drive_letter
 
 
 def _win_refresh_shared_disk(ssh_conn: VMSSHConnection, vm_label: str) -> None:

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -706,7 +706,7 @@ def _win_get_shared_drive_letter(ssh_conn: VMSSHConnection, vm_label: str, volum
             sleep=_WIN_VOLUME_DISCOVERY_POLL_INTERVAL,
             func=_try_get_drive_letter,
         ):
-            if sample and len(sample) == 1:
+            if sample:
                 drive_letter = sample
                 break
     except TimeoutExpiredError as exc:
@@ -868,6 +868,8 @@ def verify_shared_disk_data_windows(
         GuestCommandError: If SSH or PowerShell commands fail.
     """
     volume_label = prepared_plan["_shared_disk_label"]
+    if not _SAFE_LABEL_RE.fullmatch(volume_label):
+        raise ValueError(f"Invalid volume label: {volume_label}")
 
     # Shared PVC validated by helper (device paths unused — Windows uses volume labels)
     ctx = _prepare_shared_disk_verification(prepared_plan, vm_ssh_connections, source_provider_data, ocp_admin_client)

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -542,9 +542,11 @@ def verify_shared_disk_data_windows(
     4. VM1: refresh disk (invalidate cache), read VM2's data
 
     Args:
-        prepared_plan (dict[str, Any]): Plan config with virtual_machines, source_vms_data, and _vm_target_namespace.
+        prepared_plan (dict[str, Any]): Heterogeneous pytest fixture dict — schema varies by
+            test scenario (uses virtual_machines, source_vms_data, _vm_target_namespace).
         vm_ssh_connections (SSHConnectionManager): SSH connection manager.
-        source_provider_data (dict[str, Any]): Provider configuration from .providers.json.
+        source_provider_data (dict[str, Any]): Heterogeneous provider config from .providers.json —
+            schema varies by provider type (uses guest credentials keys).
         ocp_admin_client (DynamicClient): OpenShift admin client for destination VM lookup.
 
     Raises:
@@ -584,6 +586,9 @@ def verify_shared_disk_data_windows(
             AuthenticationException,
             NoValidConnectionsError,
             ChannelException,
+            RuntimeError,
+            OSError,
+            ConnectionError,
             GuestCommandError,
             AssertionError,
         ) as e:

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -382,7 +382,8 @@ def _find_shared_disk_serial(
         raise ValueError(f"No shared VMDKs found between VMs: {vm_names}")
     if len(shared_vmdks) > 1:
         raise ValueError(
-            f"Multiple shared VMDKs found between VMs: {list(shared_vmdks)}. Only single shared disk is supported."
+            f"Multiple shared VMDKs found between VMs {vm_names}: {list(shared_vmdks)}. "
+            "Only single shared disk is supported."
         )
 
     shared_vmdk_path = next(iter(shared_vmdks))

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -60,8 +60,8 @@ _WIN_VERIFICATION_RETRY_TIMEOUT = 300
 _WIN_VERIFICATION_RETRY_INTERVAL = 15
 _GUEST_TOOLS_READY_TIMEOUT = 300
 
-_HEX_SERIAL_RE = re.compile(r"^[a-fA-F0-9]+$")
-_SAFE_LABEL_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+_HEX_SERIAL_RE = re.compile(r"[a-fA-F0-9]+")
+_SAFE_LABEL_RE = re.compile(r"[a-zA-Z0-9_-]+")
 
 
 def _mount_shared_partition(ssh_conn: VMSSHConnection, partition: str, mount_point: str, vm_label: str) -> None:
@@ -359,7 +359,7 @@ def verify_shared_disk_data(
 
 
 def _find_shared_disk_serial(
-    source_provider: "VMWareProvider",
+    source_provider: VMWareProvider,
     owner_vm: vim.VirtualMachine,
     owner_name: str,
     vm_names: list[str],
@@ -411,7 +411,7 @@ def _find_shared_disk_serial(
 
 
 def _disable_fast_startup(
-    source_provider: "VMWareProvider",
+    source_provider: VMWareProvider,
     owner_vm: vim.VirtualMachine,
     owner_name: str,
     auth: vim.vm.guest.NamePasswordAuthentication,
@@ -439,14 +439,17 @@ def _disable_fast_startup(
             timeout=_WIN_LABEL_GUEST_OPS_TIMEOUT,
         )
         LOGGER.info(f"Disabled Fast Startup on '{owner_name}' to ensure clean shutdown")
-    except GuestCommandError as e:
+    except Exception as e:
         # Intentional best-effort (no-fallbacks exception): Fast Startup disable is
         # non-critical — migration can succeed without it, but may produce warnings.
+        # Broad catch because run_command_in_vmware_guest can raise GuestCommandError,
+        # vim.fault.* (GuestOperationsFault, InvalidGuestLogin), timeouts, and
+        # connection errors — none should abort the critical labeling flow.
         LOGGER.warning(f"Failed to disable Fast Startup on '{owner_name}' (best-effort): {e}")
 
 
 def _execute_guest_label_command(
-    source_provider: "VMWareProvider",
+    source_provider: VMWareProvider,
     owner_vm: vim.VirtualMachine,
     owner_name: str,
     disk_serial: str,
@@ -467,9 +470,11 @@ def _execute_guest_label_command(
         ValueError: If credentials, vCenter host unavailable, or inputs invalid.
         GuestCommandError: If the labeling PowerShell command fails.
     """
-    if not _HEX_SERIAL_RE.match(disk_serial):
+    disk_serial = disk_serial.strip()
+    volume_label = volume_label.strip()
+    if not _HEX_SERIAL_RE.fullmatch(disk_serial):
         raise ValueError(f"Invalid disk serial (hex expected): {disk_serial}")
-    if not _SAFE_LABEL_RE.match(volume_label):
+    if not _SAFE_LABEL_RE.fullmatch(volume_label):
         raise ValueError(f"Invalid volume label (alphanumeric expected): {volume_label}")
 
     if not source_provider.wait_for_vmware_guest_info(owner_vm, timeout=_GUEST_TOOLS_READY_TIMEOUT):
@@ -513,7 +518,7 @@ def _execute_guest_label_command(
 
 
 def label_shared_disk_on_source_windows(
-    source_provider: "VMWareProvider",
+    source_provider: VMWareProvider,
     prepared_plan: dict[str, Any],
     source_provider_data: dict[str, Any],
     session_uuid: str,

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -120,7 +120,7 @@ def _write_marker(ssh_conn: VMSSHConnection, file_path: str, content: str, vm_la
 
 
 def _get_pvc_device_targets(
-    ocp_admin_client: "DynamicClient",
+    ocp_admin_client: DynamicClient,
     target_namespace: str,
     vm_name: str,
 ) -> dict[str, str]:
@@ -184,7 +184,7 @@ def _get_pvc_device_targets(
 
 
 def _get_shared_disk_devices(
-    ocp_admin_client: "DynamicClient",
+    ocp_admin_client: DynamicClient,
     target_namespace: str,
     vm1_dest_name: str,
     vm2_dest_name: str,
@@ -248,7 +248,7 @@ def _prepare_shared_disk_verification(
     prepared_plan: dict[str, Any],
     vm_ssh_connections: SSHConnectionManager,
     source_provider_data: dict[str, Any],
-    ocp_admin_client: "DynamicClient",
+    ocp_admin_client: DynamicClient,
 ) -> _SharedDiskContext:
     """Extract common setup for shared disk verification (Linux and Windows).
 
@@ -264,6 +264,9 @@ def _prepare_shared_disk_verification(
 
     Returns:
         _SharedDiskContext: Common context for shared disk verification.
+
+    Raises:
+        ValueError: If no shared PVC (or more than one) is found between the two VMs.
     """
     vm1_config = prepared_plan["virtual_machines"][0]
     vm2_config = prepared_plan["virtual_machines"][1]
@@ -296,7 +299,7 @@ def verify_shared_disk_data(
     prepared_plan: dict[str, Any],
     vm_ssh_connections: SSHConnectionManager,
     source_provider_data: dict[str, Any],
-    ocp_admin_client: "DynamicClient",
+    ocp_admin_client: DynamicClient,
 ) -> None:
     """Verify shared disk is accessible from both VMs by writing and reading data.
 
@@ -635,7 +638,7 @@ def _win_run_powershell(
     Raises:
         GuestCommandError: If the command fails (non-zero return code).
     """
-    return _run_cmd_on_vm(ssh_conn, ["powershell", "-Command", script], description)
+    return run_cmd_in_vm(ssh_conn, ["powershell", "-Command", script], description)
 
 
 def _win_ensure_shared_volume_online(ssh_conn: VMSSHConnection, vm_label: str, volume_label: str) -> str:
@@ -856,7 +859,7 @@ def verify_shared_disk_data_windows(
     prepared_plan: dict[str, Any],
     vm_ssh_connections: SSHConnectionManager,
     source_provider_data: dict[str, Any],
-    ocp_admin_client: "DynamicClient",
+    ocp_admin_client: DynamicClient,
 ) -> None:
     """Verify shared disk is accessible from both Windows VMs after migration.
 

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -18,7 +18,7 @@ from simple_logger.logger import get_logger
 
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from exceptions.exceptions import GuestCommandError
+from exceptions.exceptions import GuestCommandError, SSHConnectionSetupError
 from utilities.naming import resolve_destination_vm_name
 from utilities.post_migration import get_ssh_credentials_from_provider_config
 from utilities.ssh_utils import SSHConnectionManager, VMSSHConnection, run_cmd_in_vm
@@ -402,6 +402,76 @@ def _find_shared_disk_serial(
     return serial
 
 
+def _execute_guest_label_command(
+    source_provider: "VMWareProvider",
+    owner_vm: Any,
+    owner_name: str,
+    disk_serial: str,
+    volume_label: str,
+    source_provider_data: dict[str, Any],
+) -> None:
+    """Authenticate via Guest Ops, label the shared disk, and disable Fast Startup.
+
+    Args:
+        source_provider: VMWare provider instance.
+        owner_vm: PyVmomi VM object for the owner VM.
+        owner_name: Display name of the owner VM.
+        disk_serial: Disk serial number to match inside the guest.
+        volume_label: NTFS volume label to set.
+        source_provider_data: Provider config (uses guest_vm_win_user/password).
+
+    Raises:
+        ValueError: If credentials or vCenter host unavailable.
+        GuestCommandError: If the labeling PowerShell command fails.
+    """
+    if not source_provider.wait_for_vmware_guest_info(owner_vm, timeout=300):
+        raise ValueError(f"VMware Tools not available on '{owner_name}' after power-on, cannot label shared disk")
+
+    try:
+        win_user = source_provider_data["guest_vm_win_user"]
+        win_pass = source_provider_data["guest_vm_win_password"]
+    except KeyError as e:
+        raise ValueError(
+            f"Windows VM credentials not found in provider config: {e}. "
+            "Required: guest_vm_win_user, guest_vm_win_password"
+        ) from e
+
+    auth = vim.vm.guest.NamePasswordAuthentication(username=win_user, password=win_pass, interactiveSession=False)
+
+    ps_script = _WIN_LABEL_PS_TEMPLATE.format(serial=disk_serial, label=volume_label)
+    encoded_cmd = base64.b64encode(ps_script.encode("utf-16-le")).decode("ascii")
+
+    vcenter_host = source_provider.host
+    if vcenter_host is None:
+        raise ValueError(f"vCenter host not available for provider used by VM '{owner_name}'")
+
+    output = run_command_in_vmware_guest(
+        content=source_provider.content,
+        vm=owner_vm,
+        auth=auth,
+        command=f"powershell -EncodedCommand {encoded_cmd}",
+        vcenter_host=vcenter_host,
+        timeout=_WIN_LABEL_GUEST_OPS_TIMEOUT,
+    )
+    LOGGER.info(f"Shared disk labeling on '{owner_name}': {output.strip()}")
+
+    # Disable Fast Startup before graceful shutdown to prevent hiberfile.sys creation.
+    # Windows hybrid shutdown writes a hibernation file that causes virt-customize to fail
+    # during migration (ConversionHasWarnings / CustomizationFailed).
+    try:
+        run_command_in_vmware_guest(
+            content=source_provider.content,
+            vm=owner_vm,
+            auth=auth,
+            command="powershell -Command powercfg /h off",
+            vcenter_host=vcenter_host,
+            timeout=_WIN_LABEL_GUEST_OPS_TIMEOUT,
+        )
+        LOGGER.info(f"Disabled Fast Startup on '{owner_name}' to ensure clean shutdown")
+    except GuestCommandError as e:
+        LOGGER.warning(f"Failed to disable Fast Startup on '{owner_name}' (best-effort): {e}")
+
+
 def label_shared_disk_on_source_windows(
     source_provider: "VMWareProvider",
     prepared_plan: dict[str, Any],
@@ -446,52 +516,14 @@ def label_shared_disk_on_source_windows(
     LOGGER.info(f"Powering on '{owner_name}' for shared disk labeling")
     source_provider.start_vm(owner_vm)
     try:
-        if not source_provider.wait_for_vmware_guest_info(owner_vm, timeout=300):
-            raise ValueError(f"VMware Tools not available on '{owner_name}' after power-on, cannot label shared disk")
-
-        try:
-            win_user = source_provider_data["guest_vm_win_user"]
-            win_pass = source_provider_data["guest_vm_win_password"]
-        except KeyError as e:
-            raise ValueError(
-                f"Windows VM credentials not found in provider config: {e}. "
-                "Required: guest_vm_win_user, guest_vm_win_password"
-            ) from e
-
-        auth = vim.vm.guest.NamePasswordAuthentication(username=win_user, password=win_pass, interactiveSession=False)
-
-        ps_script = _WIN_LABEL_PS_TEMPLATE.format(serial=disk_serial, label=volume_label)
-        encoded_cmd = base64.b64encode(ps_script.encode("utf-16-le")).decode("ascii")
-
-        vcenter_host = source_provider.host
-        if vcenter_host is None:
-            raise ValueError(f"vCenter host not available for provider used by VM '{owner_name}'")
-
-        output = run_command_in_vmware_guest(
-            content=source_provider.content,
-            vm=owner_vm,
-            auth=auth,
-            command=f"powershell -EncodedCommand {encoded_cmd}",
-            vcenter_host=vcenter_host,
-            timeout=_WIN_LABEL_GUEST_OPS_TIMEOUT,
+        _execute_guest_label_command(
+            source_provider=source_provider,
+            owner_vm=owner_vm,
+            owner_name=owner_name,
+            disk_serial=disk_serial,
+            volume_label=volume_label,
+            source_provider_data=source_provider_data,
         )
-        LOGGER.info(f"Shared disk labeling on '{owner_name}': {output.strip()}")
-
-        # Disable Fast Startup before graceful shutdown to prevent hiberfile.sys creation.
-        # Windows hybrid shutdown writes a hibernation file that causes virt-customize to fail
-        # during migration (ConversionHasWarnings / CustomizationFailed).
-        try:
-            run_command_in_vmware_guest(
-                content=source_provider.content,
-                vm=owner_vm,
-                auth=auth,
-                command="powershell -Command powercfg /h off",
-                vcenter_host=vcenter_host,
-                timeout=_WIN_LABEL_GUEST_OPS_TIMEOUT,
-            )
-            LOGGER.info(f"Disabled Fast Startup on '{owner_name}' to ensure clean shutdown")
-        except GuestCommandError:
-            LOGGER.warning(f"Failed to disable Fast Startup on '{owner_name}' (best-effort)")
     finally:
         LOGGER.info(f"Gracefully shutting down '{owner_name}' after shared disk labeling")
         source_provider.shutdown_vm_guest(owner_vm)
@@ -539,9 +571,9 @@ def _win_ensure_shared_volume_online(ssh_conn: VMSSHConnection, vm_label: str, v
     Raises:
         GuestCommandError: If shared volume not found after bringing disks online.
     """
-    # Best-effort: piped Set-Disk fails on some vSphere versions due to a Windows SSH
-    # console buffer bug. The targeted Set-Disk -Number <N> in _win_refresh_shared_disk
-    # is the reliable path; this is just an initial attempt to bring disks online.
+    # Intentional best-effort (no-fallbacks exception): piped Set-Disk fails on some vSphere
+    # versions due to a Windows SSH console buffer bug. _win_refresh_shared_disk uses targeted
+    # Set-Disk -Number <N> as the reliable path; these are just optimistic first attempts.
     try:
         _win_run_powershell(
             ssh_conn,
@@ -698,6 +730,43 @@ def _win_read_marker(ssh_conn: VMSSHConnection, drive_letter: str, filename: str
     LOGGER.info(f"{vm_label}: Successfully read {filename}")
 
 
+def _win_do_bidirectional_verification(
+    ctx: _SharedDiskContext,
+    volume_label: str,
+    test_file_vm1: str,
+    test_file_vm2: str,
+) -> bool:
+    """Run bidirectional read/write verification between both Windows VMs.
+
+    Args:
+        ctx: Shared disk verification context (SSH connections, VM names).
+        volume_label: NTFS volume label to locate the shared disk.
+        test_file_vm1: Marker filename written by VM1.
+        test_file_vm2: Marker filename written by VM2.
+
+    Returns:
+        True if both VMs can read each other's marker files.
+    """
+    with ctx.ssh_vm1:
+        drive1 = _win_ensure_shared_volume_online(ctx.ssh_vm1, "VM1", volume_label)
+        _win_write_marker(ctx.ssh_vm1, drive1, test_file_vm1, "Data from VM1", "VM1")
+
+        with ctx.ssh_vm2:
+            drive2 = _win_ensure_shared_volume_online(ctx.ssh_vm2, "VM2", volume_label)
+            _win_refresh_shared_disk(ctx.ssh_vm2, "VM2", volume_label)
+            drive2 = _win_get_shared_drive_letter(ctx.ssh_vm2, "VM2", volume_label)
+            _win_read_marker(ctx.ssh_vm2, drive2, test_file_vm1, "Data from VM1", "VM2")
+
+            _win_write_marker(ctx.ssh_vm2, drive2, test_file_vm2, "Data from VM2", "VM2")
+            _win_refresh_shared_disk(ctx.ssh_vm2, "VM2", volume_label)
+
+        _win_refresh_shared_disk(ctx.ssh_vm1, "VM1", volume_label)
+        drive1 = _win_get_shared_drive_letter(ctx.ssh_vm1, "VM1", volume_label)
+        _win_read_marker(ctx.ssh_vm1, drive1, test_file_vm2, "Data from VM2", "VM1")
+
+    return True
+
+
 def verify_shared_disk_data_windows(
     prepared_plan: dict[str, Any],
     vm_ssh_connections: SSHConnectionManager,
@@ -744,42 +813,20 @@ def verify_shared_disk_data_windows(
 
     last_exc: Exception | None = None
 
-    def _do_verification() -> bool | None:
-        """Run bidirectional read/write verification between both Windows VMs.
-
-        Returns:
-            True if both VMs can read each other's marker files, None on transient failure (triggers retry).
-        """
+    def _attempt() -> bool | None:
+        nonlocal last_exc
         try:
-            with ctx.ssh_vm1:
-                drive1 = _win_ensure_shared_volume_online(ctx.ssh_vm1, "VM1", volume_label)
-                _win_write_marker(ctx.ssh_vm1, drive1, test_file_vm1, "Data from VM1", "VM1")
-
-                with ctx.ssh_vm2:
-                    drive2 = _win_ensure_shared_volume_online(ctx.ssh_vm2, "VM2", volume_label)
-                    _win_refresh_shared_disk(ctx.ssh_vm2, "VM2", volume_label)
-                    drive2 = _win_get_shared_drive_letter(ctx.ssh_vm2, "VM2", volume_label)
-                    _win_read_marker(ctx.ssh_vm2, drive2, test_file_vm1, "Data from VM1", "VM2")
-
-                    _win_write_marker(ctx.ssh_vm2, drive2, test_file_vm2, "Data from VM2", "VM2")
-                    _win_refresh_shared_disk(ctx.ssh_vm2, "VM2", volume_label)
-
-                _win_refresh_shared_disk(ctx.ssh_vm1, "VM1", volume_label)
-                drive1 = _win_get_shared_drive_letter(ctx.ssh_vm1, "VM1", volume_label)
-                _win_read_marker(ctx.ssh_vm1, drive1, test_file_vm2, "Data from VM2", "VM1")
-
-                return True
+            return _win_do_bidirectional_verification(ctx, volume_label, test_file_vm1, test_file_vm2)
         except (
             SSHException,
             AuthenticationException,
             NoValidConnectionsError,
             ChannelException,
-            RuntimeError,
+            SSHConnectionSetupError,
             OSError,
             ConnectionError,
             GuestCommandError,
         ) as e:
-            nonlocal last_exc
             last_exc = e
             LOGGER.warning(f"Shared disk verification failed: {type(e).__name__}: {e} - retrying...")
             return None
@@ -788,7 +835,7 @@ def verify_shared_disk_data_windows(
         for sample in TimeoutSampler(
             wait_timeout=_WIN_VERIFICATION_RETRY_TIMEOUT,
             sleep=_WIN_VERIFICATION_RETRY_INTERVAL,
-            func=_do_verification,
+            func=_attempt,
         ):
             if sample:
                 break

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -445,15 +445,50 @@ def _disable_fast_startup(
         LOGGER.warning(f"Failed to disable Fast Startup on '{owner_name}' (best-effort): {e}")
 
 
+def _get_guest_auth(
+    source_provider: VMWareProvider,
+    owner_vm: vim.VirtualMachine,
+    owner_name: str,
+    source_provider_data: dict[str, Any],
+) -> tuple["vim.vm.guest.NamePasswordAuthentication", str]:
+    """Wait for VMware Tools and return guest auth + vCenter host.
+
+    Args:
+        source_provider: VMWare provider instance.
+        owner_vm: PyVmomi VM object for the owner VM.
+        owner_name: Display name of the owner VM.
+        source_provider_data: Provider config (uses guest_vm_win_user/password).
+
+    Returns:
+        Tuple of (NamePasswordAuthentication, vcenter_host).
+
+    Raises:
+        ValueError: If Tools not ready or vCenter host unavailable.
+    """
+    if not source_provider.wait_for_vmware_guest_info(owner_vm, timeout=_GUEST_TOOLS_READY_TIMEOUT):
+        raise ValueError(f"VMware Tools not available on '{owner_name}' after power-on, cannot label shared disk")
+
+    win_user = source_provider_data["guest_vm_win_user"]
+    win_pass = source_provider_data["guest_vm_win_password"]
+    auth = vim.vm.guest.NamePasswordAuthentication(username=win_user, password=win_pass, interactiveSession=False)
+
+    vcenter_host = source_provider.host
+    if vcenter_host is None:
+        raise ValueError(f"vCenter host not available for provider used by VM '{owner_name}'")
+
+    return auth, vcenter_host
+
+
 def _execute_guest_label_command(
     source_provider: VMWareProvider,
     owner_vm: vim.VirtualMachine,
     owner_name: str,
     disk_serial: str,
     volume_label: str,
-    source_provider_data: dict[str, Any],
+    auth: "vim.vm.guest.NamePasswordAuthentication",
+    vcenter_host: str,
 ) -> None:
-    """Authenticate via Guest Ops and label the shared disk on the source Windows VM.
+    """Label the shared disk on the source Windows VM via Guest Ops.
 
     Args:
         source_provider: VMWare provider instance.
@@ -461,10 +496,11 @@ def _execute_guest_label_command(
         owner_name: Display name of the owner VM.
         disk_serial: Hex disk serial number to match inside the guest.
         volume_label: Alphanumeric NTFS volume label to set.
-        source_provider_data: Provider config (uses guest_vm_win_user/password).
+        auth: Guest authentication credentials.
+        vcenter_host: vCenter hostname.
 
     Raises:
-        ValueError: If credentials, vCenter host unavailable, or inputs invalid.
+        ValueError: If disk_serial or volume_label format is invalid.
         GuestCommandError: If the labeling PowerShell command fails.
     """
     disk_serial = disk_serial.strip()
@@ -474,26 +510,8 @@ def _execute_guest_label_command(
     if not _SAFE_LABEL_RE.fullmatch(volume_label):
         raise ValueError(f"Invalid volume label (alphanumeric expected): {volume_label}")
 
-    if not source_provider.wait_for_vmware_guest_info(owner_vm, timeout=_GUEST_TOOLS_READY_TIMEOUT):
-        raise ValueError(f"VMware Tools not available on '{owner_name}' after power-on, cannot label shared disk")
-
-    try:
-        win_user = source_provider_data["guest_vm_win_user"]
-        win_pass = source_provider_data["guest_vm_win_password"]
-    except KeyError as e:
-        raise ValueError(
-            f"Windows VM credentials not found in provider config: {e}. "
-            "Required: guest_vm_win_user, guest_vm_win_password"
-        ) from e
-
-    auth = vim.vm.guest.NamePasswordAuthentication(username=win_user, password=win_pass, interactiveSession=False)
-
     ps_script = _WIN_LABEL_PS_TEMPLATE.format(serial=disk_serial, label=volume_label)
     encoded_cmd = base64.b64encode(ps_script.encode("utf-16-le")).decode("ascii")
-
-    vcenter_host = source_provider.host
-    if vcenter_host is None:
-        raise ValueError(f"vCenter host not available for provider used by VM '{owner_name}'")
 
     output = run_command_in_vmware_guest(
         content=source_provider.content,
@@ -504,14 +522,6 @@ def _execute_guest_label_command(
         timeout=_WIN_LABEL_GUEST_OPS_TIMEOUT,
     )
     LOGGER.info(f"Shared disk labeling on '{owner_name}': {output.strip()}")
-
-    _disable_fast_startup(
-        source_provider=source_provider,
-        owner_vm=owner_vm,
-        owner_name=owner_name,
-        auth=auth,
-        vcenter_host=vcenter_host,
-    )
 
 
 def label_shared_disk_on_source_windows(
@@ -558,13 +568,27 @@ def label_shared_disk_on_source_windows(
     LOGGER.info(f"Powering on '{owner_name}' for shared disk labeling")
     source_provider.start_vm(owner_vm)
     try:
+        auth, vcenter_host = _get_guest_auth(
+            source_provider=source_provider,
+            owner_vm=owner_vm,
+            owner_name=owner_name,
+            source_provider_data=source_provider_data,
+        )
         _execute_guest_label_command(
             source_provider=source_provider,
             owner_vm=owner_vm,
             owner_name=owner_name,
             disk_serial=disk_serial,
             volume_label=volume_label,
-            source_provider_data=source_provider_data,
+            auth=auth,
+            vcenter_host=vcenter_host,
+        )
+        _disable_fast_startup(
+            source_provider=source_provider,
+            owner_vm=owner_vm,
+            owner_name=owner_name,
+            auth=auth,
+            vcenter_host=vcenter_host,
         )
     finally:
         LOGGER.info(f"Gracefully shutting down '{owner_name}' after shared disk labeling")
@@ -838,11 +862,7 @@ def verify_shared_disk_data_windows(
         AssertionError: If shared disk data verification fails.
         GuestCommandError: If SSH or PowerShell commands fail.
     """
-    volume_label = prepared_plan.get("_shared_disk_label")
-    if not volume_label:
-        raise ValueError(
-            "No shared disk label found in prepared_plan. Ensure test_label_shared_disk ran before migration."
-        )
+    volume_label = prepared_plan["_shared_disk_label"]
 
     # Shared PVC validated by helper (device paths unused — Windows uses volume labels)
     ctx = _prepare_shared_disk_verification(prepared_plan, vm_ssh_connections, source_provider_data, ocp_admin_client)
@@ -868,7 +888,6 @@ def verify_shared_disk_data_windows(
             OSError,
             ConnectionError,
             GuestCommandError,
-            AssertionError,
         ) as e:
             last_exc = e
             LOGGER.warning(f"Shared disk verification failed: {type(e).__name__}: {e} - retrying...")

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -465,9 +465,6 @@ def _get_guest_auth(
     Raises:
         ValueError: If Tools not ready, credentials missing, or vCenter host unavailable.
     """
-    if not source_provider.wait_for_vmware_guest_info(owner_vm, timeout=_GUEST_TOOLS_READY_TIMEOUT):
-        raise ValueError(f"VMware Tools not available on '{owner_name}' after power-on, cannot label shared disk")
-
     win_user = source_provider_data.get("guest_vm_win_user")
     win_pass = source_provider_data.get("guest_vm_win_password")
     if not win_user or not win_pass:
@@ -475,11 +472,15 @@ def _get_guest_auth(
             f"Windows Guest Operations requires 'guest_vm_win_user' and "
             f"'guest_vm_win_password' in provider config for '{owner_name}'"
         )
-    auth = vim.vm.guest.NamePasswordAuthentication(username=win_user, password=win_pass, interactiveSession=False)
 
     vcenter_host = source_provider.host
     if vcenter_host is None:
         raise ValueError(f"vCenter host not available for provider used by VM '{owner_name}'")
+
+    if not source_provider.wait_for_vmware_guest_info(owner_vm, timeout=_GUEST_TOOLS_READY_TIMEOUT):
+        raise ValueError(f"VMware Tools not available on '{owner_name}' after power-on, cannot label shared disk")
+
+    auth = vim.vm.guest.NamePasswordAuthentication(username=win_user, password=win_pass, interactiveSession=False)
 
     return auth, vcenter_host
 

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -353,6 +353,50 @@ def verify_shared_disk_data(
     LOGGER.info("Shared disk verification successful - bidirectional access confirmed")
 
 
+def _find_shared_disk_serial(
+    source_provider: "VMWareProvider",
+    owner_vm: vim.VirtualMachine,
+    owner_name: str,
+    vm_names: list[str],
+) -> str:
+    """Find the disk serial of the shared VMDK on the owner VM.
+
+    Detects shared VMDKs by comparing backing files across VMs, then
+    extracts the VMware backing UUID (which forklift maps to the Windows
+    disk serial via ``Win32_DiskDrive.SerialNumber``).
+
+    Args:
+        source_provider: VMWare provider instance.
+        owner_vm: Owner VM pyvmomi object.
+        owner_name: Owner VM name (for error messages).
+        vm_names: All VM names in the plan.
+
+    Returns:
+        Disk serial string (backing UUID without dashes, lowercase).
+
+    Raises:
+        ValueError: If no shared VMDK found or backing UUID unavailable.
+    """
+    shared_vmdks = source_provider.find_shared_vmdk_paths(vm_names)
+    if not shared_vmdks:
+        raise ValueError(f"No shared VMDKs found between VMs: {vm_names}")
+
+    shared_vmdk_path = next(iter(shared_vmdks))
+    backing_uuid = None
+    for device in owner_vm.config.hardware.device:
+        if not isinstance(device, vim.vm.device.VirtualDisk):
+            continue
+        if hasattr(device.backing, "fileName") and device.backing.fileName == shared_vmdk_path:
+            backing_uuid = getattr(device.backing, "uuid", None)
+            break
+    if not backing_uuid:
+        raise ValueError(f"Cannot find backing UUID for shared VMDK '{shared_vmdk_path}' on VM '{owner_name}'")
+
+    serial = backing_uuid.replace("-", "").lower()
+    LOGGER.info(f"Shared disk on '{owner_name}': backing.uuid={backing_uuid}, serial={serial}")
+    return serial
+
+
 def label_shared_disk_on_source_windows(
     source_provider: "VMWareProvider",
     prepared_plan: dict[str, Any],
@@ -361,17 +405,10 @@ def label_shared_disk_on_source_windows(
 ) -> None:
     """Label the shared disk on the source Windows VM before migration.
 
-    Dynamically detects the shared VMDK by comparing disk backing files
-    across VMs, retrieves the VMware backing UUID (which forklift maps to
-    the disk serial number), and matches it to the Windows disk via WMI
-    ``Win32_DiskDrive.SerialNumber``. Sets a unique NTFS volume label
-    via VMware Guest Operations (no SSH needed).
-
-    The generated label (``SHARED-<session_uuid>``) is stored in
-    ``prepared_plan["_shared_disk_label"]`` so post-migration verification
-    can find the volume by the same label.
-
-    Must be called after cloning + relinking and before migration.
+    Sets a unique NTFS volume label via VMware Guest Operations by matching
+    the shared VMDK's backing UUID to the Windows disk serial number.
+    The generated label is stored in ``prepared_plan["_shared_disk_label"]``
+    for post-migration verification.
 
     Args:
         source_provider: VMWare provider instance.
@@ -399,26 +436,7 @@ def label_shared_disk_on_source_windows(
     owner_name = vm_names[owner_idx]
     owner_vm = prepared_plan["source_vms_data"][owner_name]["provider_vm_api"]
 
-    vmdk_positions = source_provider._build_vmdk_position_map(vm_names)
-    shared_vmdks = source_provider._find_shared_vmdks(vmdk_positions)
-
-    if not shared_vmdks:
-        raise ValueError(f"No shared VMDKs found between VMs: {vm_names}")
-
-    shared_vmdk_path = next(iter(shared_vmdks))
-
-    backing_uuid = None
-    for device in owner_vm.config.hardware.device:
-        if not isinstance(device, vim.vm.device.VirtualDisk):
-            continue
-        if hasattr(device.backing, "fileName") and device.backing.fileName == shared_vmdk_path:
-            backing_uuid = getattr(device.backing, "uuid", None)
-            break
-    if not backing_uuid:
-        raise ValueError(f"Cannot find backing UUID for shared VMDK '{shared_vmdk_path}' on VM '{owner_name}'")
-
-    disk_serial = backing_uuid.replace("-", "").lower()
-    LOGGER.info(f"Shared disk on '{owner_name}': backing.uuid={backing_uuid}, serial={disk_serial}")
+    disk_serial = _find_shared_disk_serial(source_provider, owner_vm, owner_name, vm_names)
 
     LOGGER.info(f"Powering on '{owner_name}' for shared disk labeling")
     source_provider.start_vm(owner_vm)
@@ -755,7 +773,6 @@ def verify_shared_disk_data_windows(
             OSError,
             ConnectionError,
             GuestCommandError,
-            AssertionError,
         ) as e:
             nonlocal last_exc
             last_exc = e

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -868,6 +868,7 @@ def verify_shared_disk_data_windows(
             OSError,
             ConnectionError,
             GuestCommandError,
+            AssertionError,
         ) as e:
             last_exc = e
             LOGGER.warning(f"Shared disk verification failed: {type(e).__name__}: {e} - retrying...")

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -380,6 +380,10 @@ def _find_shared_disk_serial(
     shared_vmdks = source_provider.find_shared_vmdk_paths(vm_names)
     if not shared_vmdks:
         raise ValueError(f"No shared VMDKs found between VMs: {vm_names}")
+    if len(shared_vmdks) > 1:
+        raise ValueError(
+            f"Multiple shared VMDKs found between VMs: {list(shared_vmdks)}. Only single shared disk is supported."
+        )
 
     shared_vmdk_path = next(iter(shared_vmdks))
     backing_uuid = None

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -468,8 +468,13 @@ def _get_guest_auth(
     if not source_provider.wait_for_vmware_guest_info(owner_vm, timeout=_GUEST_TOOLS_READY_TIMEOUT):
         raise ValueError(f"VMware Tools not available on '{owner_name}' after power-on, cannot label shared disk")
 
-    win_user = source_provider_data["guest_vm_win_user"]
-    win_pass = source_provider_data["guest_vm_win_password"]
+    win_user = source_provider_data.get("guest_vm_win_user")
+    win_pass = source_provider_data.get("guest_vm_win_password")
+    if not win_user or not win_pass:
+        raise ValueError(
+            f"Windows Guest Operations requires 'guest_vm_win_user' and "
+            f"'guest_vm_win_password' in provider config for '{owner_name}'"
+        )
     auth = vim.vm.guest.NamePasswordAuthentication(username=win_user, password=win_pass, interactiveSession=False)
 
     vcenter_host = source_provider.host
@@ -819,7 +824,7 @@ def _win_do_bidirectional_verification(
         _win_write_marker(ctx.ssh_vm1, drive1, test_file_vm1, "Data from VM1", "VM1")
 
         with ctx.ssh_vm2:
-            drive2 = _win_ensure_shared_volume_online(ctx.ssh_vm2, "VM2", volume_label)
+            _win_ensure_shared_volume_online(ctx.ssh_vm2, "VM2", volume_label)
             _win_refresh_shared_disk(ctx.ssh_vm2, "VM2", volume_label)
             drive2 = _win_get_shared_drive_letter(ctx.ssh_vm2, "VM2", volume_label)
             _win_read_marker(ctx.ssh_vm2, drive2, test_file_vm1, "Data from VM1", "VM2")

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -310,7 +310,8 @@ def verify_shared_disk_data(
         ocp_admin_client (DynamicClient): OpenShift admin client for destination VM lookup.
 
     Raises:
-        GuestCommandError: If SSH commands or data verification fails.
+        GuestCommandError: If SSH commands fail.
+        AssertionError: If shared-disk marker content does not match.
     """
     ctx = _prepare_shared_disk_verification(prepared_plan, vm_ssh_connections, source_provider_data, ocp_admin_client)
     vm1_device = ctx.shared_devices[ctx.vm1_dest_name]
@@ -794,9 +795,10 @@ def _win_read_marker(ssh_conn: VMSSHConnection, drive_letter: str, filename: str
     Raises:
         GuestCommandError: If the read command fails or content does not match.
     """
+    ps_path = f"{drive_letter}:\\{filename}".replace("'", "''")
     content = _win_run_powershell(
         ssh_conn,
-        f"Get-Content -Path '{drive_letter}:\\{filename}'",
+        f"Get-Content -Path '{ps_path}'",
         f"{vm_label} read {filename}",
     )
     if expected not in content.strip():
@@ -866,7 +868,9 @@ def verify_shared_disk_data_windows(
         ocp_admin_client (DynamicClient): OpenShift admin client for destination VM lookup.
 
     Raises:
-        GuestCommandError: If SSH, PowerShell commands, or data verification fails.
+        KeyError: If ``prepared_plan`` does not contain ``"_shared_disk_label"``.
+        ValueError: If the stored volume label is not safe for PowerShell usage.
+        TimeoutExpiredError: If SSH, PowerShell, or data verification keeps failing until retry timeout.
     """
     volume_label = prepared_plan["_shared_disk_label"]
     if not _SAFE_LABEL_RE.fullmatch(volume_label):

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -450,7 +450,7 @@ def _get_guest_auth(
     owner_vm: vim.VirtualMachine,
     owner_name: str,
     source_provider_data: dict[str, Any],
-) -> tuple["vim.vm.guest.NamePasswordAuthentication", str]:
+) -> tuple[vim.vm.guest.NamePasswordAuthentication, str]:
     """Wait for VMware Tools and return guest auth + vCenter host.
 
     Args:
@@ -485,7 +485,7 @@ def _execute_guest_label_command(
     owner_name: str,
     disk_serial: str,
     volume_label: str,
-    auth: "vim.vm.guest.NamePasswordAuthentication",
+    auth: vim.vm.guest.NamePasswordAuthentication,
     vcenter_host: str,
 ) -> None:
     """Label the shared disk on the source Windows VM via Guest Ops.

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -31,6 +31,33 @@ if TYPE_CHECKING:
 
 LOGGER = get_logger(name=__name__)
 
+_VMI_VOLUME_STATUS_TIMEOUT = 300
+_VMI_VOLUME_STATUS_POLL_INTERVAL = 5
+
+_SHARED_LABEL_PREFIX = "SHARED"
+
+_WIN_LABEL_PS_TEMPLATE = """\
+$ErrorActionPreference = 'Stop'
+$wmiDisk = Get-CimInstance Win32_DiskDrive | Where-Object {{ $_.SerialNumber -eq '{serial}' }}
+if (-not $wmiDisk) {{ throw 'No disk with serial {serial}' }}
+$n = $wmiDisk.Index
+Set-Disk -Number $n -IsOffline $false -ErrorAction SilentlyContinue
+Set-Disk -Number $n -IsReadOnly $false -ErrorAction SilentlyContinue
+Start-Sleep -Seconds 2
+$vol = Get-Partition -DiskNumber $n | Get-Volume | Where-Object {{ $_.FileSystemType -eq 'NTFS' -and $_.DriveLetter }}
+if (-not $vol) {{ throw ('No NTFS volume with drive letter on disk ' + $n) }}
+$vol | ForEach-Object {{ Set-Volume -DriveLetter $_.DriveLetter -NewFileSystemLabel '{label}' }}
+$check = Get-Volume -FileSystemLabel '{label}' -ErrorAction SilentlyContinue
+if (-not $check) {{ throw 'Label verification failed' }}
+Write-Output ('Labeled disk ' + $n + ' drive ' + $check.DriveLetter + ': as {label}')
+"""
+
+_WIN_LABEL_GUEST_OPS_TIMEOUT = 60
+_WIN_VOLUME_DISCOVERY_TIMEOUT = 60
+_WIN_VOLUME_DISCOVERY_POLL_INTERVAL = 5
+_WIN_VERIFICATION_RETRY_TIMEOUT = 300
+_WIN_VERIFICATION_RETRY_INTERVAL = 15
+
 
 def _mount_shared_partition(ssh_conn: VMSSHConnection, partition: str, mount_point: str, vm_label: str) -> None:
     """Mount a shared disk partition on a VM.
@@ -80,10 +107,6 @@ def _write_marker(ssh_conn: VMSSHConnection, file_path: str, content: str, vm_la
         f"{vm_label} write test data",
     )
     run_cmd_in_vm(ssh_conn, ["sudo", "sync"], f"{vm_label} sync")
-
-
-_VMI_VOLUME_STATUS_TIMEOUT = 300
-_VMI_VOLUME_STATUS_POLL_INTERVAL = 5
 
 
 def _get_pvc_device_targets(
@@ -330,27 +353,6 @@ def verify_shared_disk_data(
     LOGGER.info("Shared disk verification successful - bidirectional access confirmed")
 
 
-_SHARED_LABEL_PREFIX = "SHARED"
-
-_WIN_LABEL_PS_TEMPLATE = """\
-$ErrorActionPreference = 'Stop'
-$wmiDisk = Get-CimInstance Win32_DiskDrive | Where-Object {{ $_.SerialNumber -eq '{serial}' }}
-if (-not $wmiDisk) {{ throw 'No disk with serial {serial}' }}
-$n = $wmiDisk.Index
-Set-Disk -Number $n -IsOffline $false -ErrorAction SilentlyContinue
-Set-Disk -Number $n -IsReadOnly $false -ErrorAction SilentlyContinue
-Start-Sleep -Seconds 2
-$vol = Get-Partition -DiskNumber $n | Get-Volume | Where-Object {{ $_.FileSystemType -eq 'NTFS' -and $_.DriveLetter }}
-if (-not $vol) {{ throw ('No NTFS volume with drive letter on disk ' + $n) }}
-$vol | ForEach-Object {{ Set-Volume -DriveLetter $_.DriveLetter -NewFileSystemLabel '{label}' }}
-$check = Get-Volume -FileSystemLabel '{label}' -ErrorAction SilentlyContinue
-if (-not $check) {{ throw 'Label verification failed' }}
-Write-Output ('Labeled disk ' + $n + ' drive ' + $check.DriveLetter + ': as {label}')
-"""
-
-_WIN_LABEL_GUEST_OPS_TIMEOUT = 60
-
-
 def label_shared_disk_on_source_windows(
     source_provider: "VMWareProvider",
     prepared_plan: dict[str, Any],
@@ -537,12 +539,6 @@ def _win_ensure_shared_volume_online(ssh_conn: VMSSHConnection, vm_label: str, v
     return _win_get_shared_drive_letter(ssh_conn, vm_label, volume_label)
 
 
-_WIN_VOLUME_DISCOVERY_TIMEOUT = 60
-_WIN_VOLUME_DISCOVERY_POLL_INTERVAL = 5
-_WIN_VERIFICATION_RETRY_TIMEOUT = 300
-_WIN_VERIFICATION_RETRY_INTERVAL = 15
-
-
 def _win_get_shared_drive_letter(ssh_conn: VMSSHConnection, vm_label: str, volume_label: str) -> str:
     """Find the drive letter of the shared volume by its filesystem label.
 
@@ -562,6 +558,7 @@ def _win_get_shared_drive_letter(ssh_conn: VMSSHConnection, vm_label: str, volum
     """
 
     def _try_get_drive_letter() -> str | None:
+        """Poll for the shared volume's drive letter by filesystem label."""
         try:
             return _win_run_powershell(
                 ssh_conn,
@@ -718,6 +715,7 @@ def verify_shared_disk_data_windows(
     test_file_vm2 = "test-vm2.txt"
 
     def _do_verification() -> bool | None:
+        """Run bidirectional read/write verification between both Windows VMs."""
         try:
             with ctx.ssh_vm1:
                 drive1 = _win_ensure_shared_volume_online(ctx.ssh_vm1, "VM1", volume_label)

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -7,6 +7,7 @@ after migration.
 from __future__ import annotations
 
 import base64
+import re
 import shlex
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -57,6 +58,10 @@ _WIN_VOLUME_DISCOVERY_TIMEOUT = 60
 _WIN_VOLUME_DISCOVERY_POLL_INTERVAL = 5
 _WIN_VERIFICATION_RETRY_TIMEOUT = 300
 _WIN_VERIFICATION_RETRY_INTERVAL = 15
+_GUEST_TOOLS_READY_TIMEOUT = 300
+
+_HEX_SERIAL_RE = re.compile(r"^[a-fA-F0-9]+$")
+_SAFE_LABEL_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 def _mount_shared_partition(ssh_conn: VMSSHConnection, partition: str, mount_point: str, vm_label: str) -> None:
@@ -391,8 +396,11 @@ def _find_shared_disk_serial(
     for device in owner_vm.config.hardware.device:
         if not isinstance(device, vim.vm.device.VirtualDisk):
             continue
-        if hasattr(device.backing, "fileName") and device.backing.fileName == shared_vmdk_path:
-            backing_uuid = getattr(device.backing, "uuid", None)
+        if (
+            isinstance(device.backing, vim.vm.device.VirtualDisk.FlatVer2BackingInfo)
+            and device.backing.fileName == shared_vmdk_path
+        ):
+            backing_uuid = device.backing.uuid
             break
     if not backing_uuid:
         raise ValueError(f"Cannot find backing UUID for shared VMDK '{shared_vmdk_path}' on VM '{owner_name}'")
@@ -400,6 +408,41 @@ def _find_shared_disk_serial(
     serial = backing_uuid.replace("-", "").lower()
     LOGGER.info(f"Shared disk on '{owner_name}': backing.uuid={backing_uuid}, serial={serial}")
     return serial
+
+
+def _disable_fast_startup(
+    source_provider: "VMWareProvider",
+    owner_vm: vim.VirtualMachine,
+    owner_name: str,
+    auth: vim.vm.guest.NamePasswordAuthentication,
+    vcenter_host: str,
+) -> None:
+    """Disable Windows Fast Startup via Guest Ops to prevent hiberfile.sys creation.
+
+    Windows hybrid shutdown writes a hibernation file that causes virt-customize to fail
+    during migration (ConversionHasWarnings / CustomizationFailed).
+
+    Args:
+        source_provider: VMWare provider instance.
+        owner_vm: PyVmomi VM object for the owner VM.
+        owner_name: Display name of the owner VM.
+        auth: Guest authentication credentials.
+        vcenter_host: vCenter hostname for Guest Ops API.
+    """
+    try:
+        run_command_in_vmware_guest(
+            content=source_provider.content,
+            vm=owner_vm,
+            auth=auth,
+            command="powershell -Command powercfg /h off",
+            vcenter_host=vcenter_host,
+            timeout=_WIN_LABEL_GUEST_OPS_TIMEOUT,
+        )
+        LOGGER.info(f"Disabled Fast Startup on '{owner_name}' to ensure clean shutdown")
+    except GuestCommandError as e:
+        # Intentional best-effort (no-fallbacks exception): Fast Startup disable is
+        # non-critical — migration can succeed without it, but may produce warnings.
+        LOGGER.warning(f"Failed to disable Fast Startup on '{owner_name}' (best-effort): {e}")
 
 
 def _execute_guest_label_command(
@@ -410,21 +453,26 @@ def _execute_guest_label_command(
     volume_label: str,
     source_provider_data: dict[str, Any],
 ) -> None:
-    """Authenticate via Guest Ops, label the shared disk, and disable Fast Startup.
+    """Authenticate via Guest Ops and label the shared disk on the source Windows VM.
 
     Args:
         source_provider: VMWare provider instance.
         owner_vm: PyVmomi VM object for the owner VM.
         owner_name: Display name of the owner VM.
-        disk_serial: Disk serial number to match inside the guest.
-        volume_label: NTFS volume label to set.
+        disk_serial: Hex disk serial number to match inside the guest.
+        volume_label: Alphanumeric NTFS volume label to set.
         source_provider_data: Provider config (uses guest_vm_win_user/password).
 
     Raises:
-        ValueError: If credentials or vCenter host unavailable.
+        ValueError: If credentials, vCenter host unavailable, or inputs invalid.
         GuestCommandError: If the labeling PowerShell command fails.
     """
-    if not source_provider.wait_for_vmware_guest_info(owner_vm, timeout=300):
+    if not _HEX_SERIAL_RE.match(disk_serial):
+        raise ValueError(f"Invalid disk serial (hex expected): {disk_serial}")
+    if not _SAFE_LABEL_RE.match(volume_label):
+        raise ValueError(f"Invalid volume label (alphanumeric expected): {volume_label}")
+
+    if not source_provider.wait_for_vmware_guest_info(owner_vm, timeout=_GUEST_TOOLS_READY_TIMEOUT):
         raise ValueError(f"VMware Tools not available on '{owner_name}' after power-on, cannot label shared disk")
 
     try:
@@ -455,21 +503,13 @@ def _execute_guest_label_command(
     )
     LOGGER.info(f"Shared disk labeling on '{owner_name}': {output.strip()}")
 
-    # Disable Fast Startup before graceful shutdown to prevent hiberfile.sys creation.
-    # Windows hybrid shutdown writes a hibernation file that causes virt-customize to fail
-    # during migration (ConversionHasWarnings / CustomizationFailed).
-    try:
-        run_command_in_vmware_guest(
-            content=source_provider.content,
-            vm=owner_vm,
-            auth=auth,
-            command="powershell -Command powercfg /h off",
-            vcenter_host=vcenter_host,
-            timeout=_WIN_LABEL_GUEST_OPS_TIMEOUT,
-        )
-        LOGGER.info(f"Disabled Fast Startup on '{owner_name}' to ensure clean shutdown")
-    except GuestCommandError as e:
-        LOGGER.warning(f"Failed to disable Fast Startup on '{owner_name}' (best-effort): {e}")
+    _disable_fast_startup(
+        source_provider=source_provider,
+        owner_vm=owner_vm,
+        owner_name=owner_name,
+        auth=auth,
+        vcenter_host=vcenter_host,
+    )
 
 
 def label_shared_disk_on_source_windows(

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -6,12 +6,14 @@ after migration.
 
 from __future__ import annotations
 
+import base64
 import shlex
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from ocp_resources.virtual_machine import VirtualMachine
 from paramiko.ssh_exception import AuthenticationException, ChannelException, NoValidConnectionsError, SSHException
+from pyVmomi import vim
 from simple_logger.logger import get_logger
 
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
@@ -20,9 +22,12 @@ from exceptions.exceptions import GuestCommandError
 from utilities.naming import resolve_destination_vm_name
 from utilities.post_migration import get_ssh_credentials_from_provider_config
 from utilities.ssh_utils import SSHConnectionManager, VMSSHConnection, run_cmd_in_vm
+from utilities.vmware_guest_operations import run_command_in_vmware_guest
 
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
+
+    from libs.providers.vmware import VMWareProvider
 
 LOGGER = get_logger(name=__name__)
 
@@ -325,7 +330,146 @@ def verify_shared_disk_data(
     LOGGER.info("Shared disk verification successful - bidirectional access confirmed")
 
 
-_SHARED_VOLUME_LABEL = "SHARED"
+_SHARED_LABEL_PREFIX = "SHARED"
+
+_WIN_LABEL_PS_TEMPLATE = """\
+$ErrorActionPreference = 'Stop'
+$wmiDisk = Get-CimInstance Win32_DiskDrive | Where-Object {{ $_.SerialNumber -eq '{serial}' }}
+if (-not $wmiDisk) {{ throw 'No disk with serial {serial}' }}
+$n = $wmiDisk.Index
+Set-Disk -Number $n -IsOffline $false -ErrorAction SilentlyContinue
+Set-Disk -Number $n -IsReadOnly $false -ErrorAction SilentlyContinue
+Start-Sleep -Seconds 2
+$vol = Get-Partition -DiskNumber $n | Get-Volume | Where-Object {{ $_.FileSystemType -eq 'NTFS' -and $_.DriveLetter }}
+if (-not $vol) {{ throw ('No NTFS volume with drive letter on disk ' + $n) }}
+$vol | ForEach-Object {{ Set-Volume -DriveLetter $_.DriveLetter -NewFileSystemLabel '{label}' }}
+$check = Get-Volume -FileSystemLabel '{label}' -ErrorAction SilentlyContinue
+if (-not $check) {{ throw 'Label verification failed' }}
+Write-Output ('Labeled disk ' + $n + ' drive ' + $check.DriveLetter + ': as {label}')
+"""
+
+_WIN_LABEL_GUEST_OPS_TIMEOUT = 60
+
+
+def label_shared_disk_on_source_windows(
+    source_provider: "VMWareProvider",
+    prepared_plan: dict[str, Any],
+    source_provider_data: dict[str, Any],
+    session_uuid: str,
+) -> None:
+    """Label the shared disk on the source Windows VM before migration.
+
+    Dynamically detects the shared VMDK by comparing disk backing files
+    across VMs, retrieves the VMware backing UUID (which forklift maps to
+    the disk serial number), and matches it to the Windows disk via WMI
+    ``Win32_DiskDrive.SerialNumber``. Sets a unique NTFS volume label
+    via VMware Guest Operations (no SSH needed).
+
+    The generated label (``SHARED-<session_uuid>``) is stored in
+    ``prepared_plan["_shared_disk_label"]`` so post-migration verification
+    can find the volume by the same label.
+
+    Must be called after cloning + relinking and before migration.
+
+    Args:
+        source_provider: VMWare provider instance.
+        prepared_plan: Plan config dict (from prepared_plan fixture).
+        source_provider_data: Provider config from .providers.json.
+        session_uuid: Session-unique identifier (from fixture_store).
+
+    Raises:
+        ValueError: If no shared disk found or Windows credentials missing.
+        GuestCommandError: If PowerShell commands fail inside the guest.
+    """
+    volume_label = f"{_SHARED_LABEL_PREFIX}-{session_uuid}"
+    prepared_plan["_shared_disk_label"] = volume_label
+    LOGGER.info(f"Generated shared disk volume label: '{volume_label}'")
+    vm_configs = prepared_plan["virtual_machines"]
+    vm_names = [vm["name"] for vm in vm_configs]
+
+    owner_idx = next(
+        (idx for idx, vm in enumerate(vm_configs) if vm.get("migrate_shared_disks") is True),
+        None,
+    )
+    if owner_idx is None:
+        raise ValueError("No VM with migrate_shared_disks=True found in plan")
+
+    owner_name = vm_names[owner_idx]
+    owner_vm = prepared_plan["source_vms_data"][owner_name]["provider_vm_api"]
+
+    vmdk_positions = source_provider._build_vmdk_position_map(vm_names)
+    shared_vmdks = source_provider._find_shared_vmdks(vmdk_positions)
+
+    if not shared_vmdks:
+        raise ValueError(f"No shared VMDKs found between VMs: {vm_names}")
+
+    shared_vmdk_path = next(iter(shared_vmdks))
+
+    backing_uuid = None
+    for device in owner_vm.config.hardware.device:
+        if not isinstance(device, vim.vm.device.VirtualDisk):
+            continue
+        if hasattr(device.backing, "fileName") and device.backing.fileName == shared_vmdk_path:
+            backing_uuid = getattr(device.backing, "uuid", None)
+            break
+    if not backing_uuid:
+        raise ValueError(f"Cannot find backing UUID for shared VMDK '{shared_vmdk_path}' on VM '{owner_name}'")
+
+    disk_serial = backing_uuid.replace("-", "").lower()
+    LOGGER.info(f"Shared disk on '{owner_name}': backing.uuid={backing_uuid}, serial={disk_serial}")
+
+    LOGGER.info(f"Powering on '{owner_name}' for shared disk labeling")
+    source_provider.start_vm(owner_vm)
+    try:
+        if not source_provider.wait_for_vmware_guest_info(owner_vm, timeout=300):
+            raise ValueError(f"VMware Tools not available on '{owner_name}' after power-on, cannot label shared disk")
+
+        try:
+            win_user = source_provider_data["guest_vm_win_user"]
+            win_pass = source_provider_data["guest_vm_win_password"]
+        except KeyError as e:
+            raise ValueError(
+                f"Windows VM credentials not found in provider config: {e}. "
+                "Required: guest_vm_win_user, guest_vm_win_password"
+            ) from e
+
+        auth = vim.vm.guest.NamePasswordAuthentication(username=win_user, password=win_pass, interactiveSession=False)
+
+        ps_script = _WIN_LABEL_PS_TEMPLATE.format(serial=disk_serial, label=volume_label)
+        encoded_cmd = base64.b64encode(ps_script.encode("utf-16-le")).decode("ascii")
+
+        vcenter_host = source_provider.host
+        if vcenter_host is None:
+            raise ValueError(f"vCenter host not available for provider used by VM '{owner_name}'")
+
+        output = run_command_in_vmware_guest(
+            content=source_provider.content,
+            vm=owner_vm,
+            auth=auth,
+            command=f"powershell -EncodedCommand {encoded_cmd}",
+            vcenter_host=vcenter_host,
+            timeout=_WIN_LABEL_GUEST_OPS_TIMEOUT,
+        )
+        LOGGER.info(f"Shared disk labeling on '{owner_name}': {output.strip()}")
+
+        # Disable Fast Startup before graceful shutdown to prevent hiberfile.sys creation.
+        # Windows hybrid shutdown writes a hibernation file that causes virt-customize to fail
+        # during migration (ConversionHasWarnings / CustomizationFailed).
+        try:
+            run_command_in_vmware_guest(
+                content=source_provider.content,
+                vm=owner_vm,
+                auth=auth,
+                command="powershell -Command powercfg /h off",
+                vcenter_host=vcenter_host,
+                timeout=_WIN_LABEL_GUEST_OPS_TIMEOUT,
+            )
+            LOGGER.info(f"Disabled Fast Startup on '{owner_name}' to ensure clean shutdown")
+        except GuestCommandError:
+            LOGGER.warning(f"Failed to disable Fast Startup on '{owner_name}' (best-effort)")
+    finally:
+        LOGGER.info(f"Gracefully shutting down '{owner_name}' after shared disk labeling")
+        source_provider.shutdown_vm_guest(owner_vm)
 
 
 def _win_run_powershell(
@@ -352,22 +496,23 @@ def _win_run_powershell(
     return _run_cmd_on_vm(ssh_conn, ["powershell", "-Command", script], description)
 
 
-def _win_ensure_shared_volume_online(ssh_conn: VMSSHConnection, vm_label: str) -> str:
-    """Bring offline disks online and return the SHARED volume drive letter.
+def _win_ensure_shared_volume_online(ssh_conn: VMSSHConnection, vm_label: str, volume_label: str) -> str:
+    """Bring offline disks online and return the shared volume drive letter.
 
     After migration, Windows SAN policy may leave non-boot disks offline.
     This brings all offline disks online, clears read-only flags, then
-    locates the SHARED volume by its filesystem label.
+    locates the shared volume by its filesystem label.
 
     Args:
         ssh_conn (VMSSHConnection): Active SSH connection to the Windows VM.
         vm_label (str): Label for log messages (e.g., "VM1").
+        volume_label (str): NTFS volume label to search for.
 
     Returns:
         str: Single-character drive letter (e.g., "E").
 
     Raises:
-        GuestCommandError: If SHARED volume not found after bringing disks online.
+        GuestCommandError: If shared volume not found after bringing disks online.
     """
     # Best-effort: piped Set-Disk fails on some vSphere versions due to a Windows SSH
     # console buffer bug. The targeted Set-Disk -Number <N> in _win_refresh_shared_disk
@@ -389,7 +534,7 @@ def _win_ensure_shared_volume_online(ssh_conn: VMSSHConnection, vm_label: str) -
         )
     except GuestCommandError as e:
         LOGGER.warning(f"{vm_label}: Set-Disk -IsReadOnly failed (best-effort): {e}")
-    return _win_get_shared_drive_letter(ssh_conn, vm_label)
+    return _win_get_shared_drive_letter(ssh_conn, vm_label, volume_label)
 
 
 _WIN_VOLUME_DISCOVERY_TIMEOUT = 60
@@ -398,8 +543,8 @@ _WIN_VERIFICATION_RETRY_TIMEOUT = 300
 _WIN_VERIFICATION_RETRY_INTERVAL = 15
 
 
-def _win_get_shared_drive_letter(ssh_conn: VMSSHConnection, vm_label: str) -> str:
-    """Find the drive letter of the SHARED volume by its filesystem label.
+def _win_get_shared_drive_letter(ssh_conn: VMSSHConnection, vm_label: str, volume_label: str) -> str:
+    """Find the drive letter of the shared volume by its filesystem label.
 
     Polls with a timeout because Windows may take a moment to mount the
     filesystem after the disk is brought online.
@@ -407,20 +552,21 @@ def _win_get_shared_drive_letter(ssh_conn: VMSSHConnection, vm_label: str) -> st
     Args:
         ssh_conn (VMSSHConnection): Active SSH connection to the Windows VM.
         vm_label (str): Label for log messages.
+        volume_label (str): NTFS volume label to search for.
 
     Returns:
         str: Single-character drive letter (e.g., "E").
 
     Raises:
-        GuestCommandError: If the SHARED volume is not found within the timeout.
+        GuestCommandError: If the volume is not found within the timeout.
     """
 
     def _try_get_drive_letter() -> str | None:
         try:
             return _win_run_powershell(
                 ssh_conn,
-                f"(Get-Volume -FileSystemLabel '{_SHARED_VOLUME_LABEL}').DriveLetter",
-                f"{vm_label} get SHARED drive letter",
+                f"(Get-Volume -FileSystemLabel '{volume_label}').DriveLetter",
+                f"{vm_label} get shared drive letter",
             ).strip()
         except GuestCommandError:
             return None
@@ -437,19 +583,19 @@ def _win_get_shared_drive_letter(ssh_conn: VMSSHConnection, vm_label: str) -> st
                 break
     except TimeoutExpiredError as exc:
         raise GuestCommandError(
-            f"{vm_label}: Volume with label '{_SHARED_VOLUME_LABEL}' not found after "
-            f"{_WIN_VOLUME_DISCOVERY_TIMEOUT}s. Ensure the shared disk on the source VM "
-            f"has an NTFS volume labeled '{_SHARED_VOLUME_LABEL}'."
+            f"{vm_label}: Volume with label '{volume_label}' not found after "
+            f"{_WIN_VOLUME_DISCOVERY_TIMEOUT}s. Ensure the shared disk was labeled "
+            f"by test_label_shared_disk before migration."
         ) from exc
 
     if not drive_letter:
-        raise GuestCommandError(f"{vm_label}: SHARED volume not found")
+        raise GuestCommandError(f"{vm_label}: Shared volume '{volume_label}' not found")
 
-    LOGGER.info(f"{vm_label}: SHARED volume is drive {drive_letter}:")
+    LOGGER.info(f"{vm_label}: Shared volume '{volume_label}' is drive {drive_letter}:")
     return drive_letter
 
 
-def _win_refresh_shared_disk(ssh_conn: VMSSHConnection, vm_label: str) -> None:
+def _win_refresh_shared_disk(ssh_conn: VMSSHConnection, vm_label: str, volume_label: str) -> None:
     """Flush NTFS metadata cache via disk offline/online cycle.
 
     NTFS does not see files written by another VM until the disk is taken
@@ -459,24 +605,27 @@ def _win_refresh_shared_disk(ssh_conn: VMSSHConnection, vm_label: str) -> None:
     Args:
         ssh_conn (VMSSHConnection): Active SSH connection to the Windows VM.
         vm_label (str): Label for log messages.
+        volume_label (str): NTFS volume label to locate the disk.
 
     Raises:
         GuestCommandError: If disk offline/online commands fail.
     """
     disk_num = _win_run_powershell(
         ssh_conn,
-        f"(Get-Volume -FileSystemLabel '{_SHARED_VOLUME_LABEL}' | Get-Partition).DiskNumber",
-        f"{vm_label} get SHARED disk number",
+        f"(Get-Volume -FileSystemLabel '{volume_label}' | Get-Partition).DiskNumber",
+        f"{vm_label} get shared disk number",
     ).strip()
     if not disk_num.isdigit():
-        raise GuestCommandError(f"{vm_label}: Cannot determine disk number for SHARED volume (got: '{disk_num}')")
+        raise GuestCommandError(
+            f"{vm_label}: Cannot determine disk number for volume '{volume_label}' (got: '{disk_num}')"
+        )
     _win_run_powershell(
         ssh_conn, f"Set-Disk -Number {disk_num} -IsOffline $true | Out-Null", f"{vm_label} disk offline"
     )
     _win_run_powershell(
         ssh_conn, f"Set-Disk -Number {disk_num} -IsOffline $false | Out-Null", f"{vm_label} disk online"
     )
-    LOGGER.info(f"{vm_label}: Refreshed SHARED disk (disk {disk_num})")
+    LOGGER.info(f"{vm_label}: Refreshed shared disk '{volume_label}' (disk {disk_num})")
 
 
 def _win_write_marker(ssh_conn: VMSSHConnection, drive_letter: str, filename: str, content: str, vm_label: str) -> None:
@@ -533,7 +682,8 @@ def verify_shared_disk_data_windows(
     """Verify shared disk is accessible from both Windows VMs after migration.
 
     Uses NTFS volume label to locate the shared disk (no Linux device paths).
-    The shared disk must be formatted with NTFS and labeled ``SHARED``.
+    The label is set dynamically by ``label_shared_disk_on_source_windows``
+    before migration and read from ``prepared_plan["_shared_disk_label"]``.
 
     Flow:
     1. Confirm shared PVC exists via KubeVirt volumeStatus
@@ -553,10 +703,16 @@ def verify_shared_disk_data_windows(
         AssertionError: If shared disk data verification fails.
         GuestCommandError: If SSH or PowerShell commands fail.
     """
+    volume_label = prepared_plan.get("_shared_disk_label")
+    if not volume_label:
+        raise ValueError(
+            "No shared disk label found in prepared_plan. Ensure test_label_shared_disk ran before migration."
+        )
+
     # Shared PVC validated by helper (device paths unused — Windows uses volume labels)
     ctx = _prepare_shared_disk_verification(prepared_plan, vm_ssh_connections, source_provider_data, ocp_admin_client)
 
-    LOGGER.info(f"Verifying Windows shared disk between {ctx.vm1_name} and {ctx.vm2_name}")
+    LOGGER.info(f"Verifying Windows shared disk (label='{volume_label}') between {ctx.vm1_name} and {ctx.vm2_name}")
 
     test_file_vm1 = "test-vm1.txt"
     test_file_vm2 = "test-vm2.txt"
@@ -564,20 +720,20 @@ def verify_shared_disk_data_windows(
     def _do_verification() -> bool | None:
         try:
             with ctx.ssh_vm1:
-                drive1 = _win_ensure_shared_volume_online(ctx.ssh_vm1, "VM1")
+                drive1 = _win_ensure_shared_volume_online(ctx.ssh_vm1, "VM1", volume_label)
                 _win_write_marker(ctx.ssh_vm1, drive1, test_file_vm1, "Data from VM1", "VM1")
 
                 with ctx.ssh_vm2:
-                    drive2 = _win_ensure_shared_volume_online(ctx.ssh_vm2, "VM2")
-                    _win_refresh_shared_disk(ctx.ssh_vm2, "VM2")
-                    drive2 = _win_get_shared_drive_letter(ctx.ssh_vm2, "VM2")
+                    drive2 = _win_ensure_shared_volume_online(ctx.ssh_vm2, "VM2", volume_label)
+                    _win_refresh_shared_disk(ctx.ssh_vm2, "VM2", volume_label)
+                    drive2 = _win_get_shared_drive_letter(ctx.ssh_vm2, "VM2", volume_label)
                     _win_read_marker(ctx.ssh_vm2, drive2, test_file_vm1, "Data from VM1", "VM2")
 
                     _win_write_marker(ctx.ssh_vm2, drive2, test_file_vm2, "Data from VM2", "VM2")
-                    _win_refresh_shared_disk(ctx.ssh_vm2, "VM2")
+                    _win_refresh_shared_disk(ctx.ssh_vm2, "VM2", volume_label)
 
-                _win_refresh_shared_disk(ctx.ssh_vm1, "VM1")
-                drive1 = _win_get_shared_drive_letter(ctx.ssh_vm1, "VM1")
+                _win_refresh_shared_disk(ctx.ssh_vm1, "VM1", volume_label)
+                drive1 = _win_get_shared_drive_letter(ctx.ssh_vm1, "VM1", volume_label)
                 _win_read_marker(ctx.ssh_vm1, drive1, test_file_vm2, "Data from VM2", "VM1")
 
                 return True

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -439,12 +439,9 @@ def _disable_fast_startup(
             timeout=_WIN_LABEL_GUEST_OPS_TIMEOUT,
         )
         LOGGER.info(f"Disabled Fast Startup on '{owner_name}' to ensure clean shutdown")
-    except Exception as e:
-        # Intentional best-effort (no-fallbacks exception): Fast Startup disable is
-        # non-critical — migration can succeed without it, but may produce warnings.
-        # Broad catch because run_command_in_vmware_guest can raise GuestCommandError,
-        # vim.fault.* (GuestOperationsFault, InvalidGuestLogin), timeouts, and
-        # connection errors — none should abort the critical labeling flow.
+    except (GuestCommandError, vim.fault.VimFault, TimeoutExpiredError, ConnectionError, OSError) as e:
+        # Best-effort: Fast Startup disable is non-critical — migration can succeed
+        # without it, but may produce ConversionHasWarnings.
         LOGGER.warning(f"Failed to disable Fast Startup on '{owner_name}' (best-effort): {e}")
 
 
@@ -780,7 +777,7 @@ def _win_do_bidirectional_verification(
     volume_label: str,
     test_file_vm1: str,
     test_file_vm2: str,
-) -> bool:
+) -> None:
     """Run bidirectional read/write verification between both Windows VMs.
 
     Args:
@@ -789,8 +786,9 @@ def _win_do_bidirectional_verification(
         test_file_vm1: Marker filename written by VM1.
         test_file_vm2: Marker filename written by VM2.
 
-    Returns:
-        True if both VMs can read each other's marker files.
+    Raises:
+        GuestCommandError: If any PowerShell command fails.
+        AssertionError: If marker file content doesn't match expected data.
     """
     with ctx.ssh_vm1:
         drive1 = _win_ensure_shared_volume_online(ctx.ssh_vm1, "VM1", volume_label)
@@ -808,8 +806,6 @@ def _win_do_bidirectional_verification(
         _win_refresh_shared_disk(ctx.ssh_vm1, "VM1", volume_label)
         drive1 = _win_get_shared_drive_letter(ctx.ssh_vm1, "VM1", volume_label)
         _win_read_marker(ctx.ssh_vm1, drive1, test_file_vm2, "Data from VM2", "VM1")
-
-    return True
 
 
 def verify_shared_disk_data_windows(
@@ -861,7 +857,8 @@ def verify_shared_disk_data_windows(
     def _attempt() -> bool | None:
         nonlocal last_exc
         try:
-            return _win_do_bidirectional_verification(ctx, volume_label, test_file_vm1, test_file_vm2)
+            _win_do_bidirectional_verification(ctx, volume_label, test_file_vm1, test_file_vm2)
+            return True
         except (
             SSHException,
             AuthenticationException,

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -558,15 +558,20 @@ def _win_get_shared_drive_letter(ssh_conn: VMSSHConnection, vm_label: str, volum
     """
 
     def _try_get_drive_letter() -> str | None:
-        """Poll for the shared volume's drive letter by filesystem label."""
-        try:
-            return _win_run_powershell(
-                ssh_conn,
-                f"(Get-Volume -FileSystemLabel '{volume_label}').DriveLetter",
-                f"{vm_label} get shared drive letter",
-            ).strip()
-        except GuestCommandError:
-            return None
+        """Poll for the shared volume's drive letter by filesystem label.
+
+        Returns:
+            Single-character drive letter, or None if the volume is not yet available.
+
+        Raises:
+            GuestCommandError: On real SSH/PowerShell failures (not volume-not-found).
+        """
+        result = _win_run_powershell(
+            ssh_conn,
+            f"(Get-Volume -FileSystemLabel '{volume_label}' -ErrorAction SilentlyContinue).DriveLetter",
+            f"{vm_label} get shared drive letter",
+        ).strip()
+        return result if result and len(result) == 1 else None
 
     drive_letter: str | None = None
     try:
@@ -714,8 +719,14 @@ def verify_shared_disk_data_windows(
     test_file_vm1 = "test-vm1.txt"
     test_file_vm2 = "test-vm2.txt"
 
+    last_exc: Exception | None = None
+
     def _do_verification() -> bool | None:
-        """Run bidirectional read/write verification between both Windows VMs."""
+        """Run bidirectional read/write verification between both Windows VMs.
+
+        Returns:
+            True if both VMs can read each other's marker files, None on transient failure (triggers retry).
+        """
         try:
             with ctx.ssh_vm1:
                 drive1 = _win_ensure_shared_volume_online(ctx.ssh_vm1, "VM1", volume_label)
@@ -746,6 +757,8 @@ def verify_shared_disk_data_windows(
             GuestCommandError,
             AssertionError,
         ) as e:
+            nonlocal last_exc
+            last_exc = e
             LOGGER.warning(f"Shared disk verification failed: {type(e).__name__}: {e} - retrying...")
             return None
 
@@ -757,9 +770,10 @@ def verify_shared_disk_data_windows(
         ):
             if sample:
                 break
-    except TimeoutExpiredError as e:
+    except TimeoutExpiredError:
+        last_err = f" Last error: {type(last_exc).__name__}: {last_exc}" if last_exc else ""
         raise TimeoutExpiredError(
-            f"Windows shared disk verification failed after {_WIN_VERIFICATION_RETRY_TIMEOUT}s"
-        ) from e
+            f"Windows shared disk verification failed after {_WIN_VERIFICATION_RETRY_TIMEOUT}s.{last_err}"
+        ) from last_exc
 
     LOGGER.info("Windows shared disk verification successful - bidirectional access confirmed")

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -63,6 +63,11 @@ _GUEST_TOOLS_READY_TIMEOUT = 300
 _HEX_SERIAL_RE = re.compile(r"[a-fA-F0-9]+")
 _SAFE_LABEL_RE = re.compile(r"[a-zA-Z0-9_-]+")
 
+_MARKER_VM1_FILENAME = "test-vm1.txt"
+_MARKER_VM2_FILENAME = "test-vm2.txt"
+_MARKER_VM1_CONTENT = "Data from VM1"
+_MARKER_VM2_CONTENT = "Data from VM2"
+
 
 def _mount_shared_partition(ssh_conn: VMSSHConnection, partition: str, mount_point: str, vm_label: str) -> None:
     """Mount a shared disk partition on a VM.
@@ -371,13 +376,13 @@ def _find_shared_disk_serial(
     disk serial via ``Win32_DiskDrive.SerialNumber``).
 
     Args:
-        source_provider: VMWare provider instance.
-        owner_vm: Owner VM pyvmomi object.
-        owner_name: Owner VM name (for error messages).
-        vm_names: All VM names in the plan.
+        source_provider (VMWareProvider): VMWare provider instance.
+        owner_vm (vim.VirtualMachine): Owner VM pyvmomi object.
+        owner_name (str): Owner VM name (for error messages).
+        vm_names (list[str]): All VM names in the plan.
 
     Returns:
-        Disk serial string (backing UUID without dashes, lowercase).
+        str: Disk serial string (backing UUID without dashes, lowercase).
 
     Raises:
         ValueError: If no shared VMDK found or backing UUID unavailable.
@@ -428,11 +433,11 @@ def _disable_fast_startup(
         Failure is logged and execution continues.
 
     Args:
-        source_provider: VMWare provider instance.
-        owner_vm: PyVmomi VM object for the owner VM.
-        owner_name: Display name of the owner VM.
-        auth: Guest authentication credentials.
-        vcenter_host: vCenter hostname for Guest Ops API.
+        source_provider (VMWareProvider): VMWare provider instance.
+        owner_vm (vim.VirtualMachine): PyVmomi VM object for the owner VM.
+        owner_name (str): Display name of the owner VM.
+        auth (vim.vm.guest.NamePasswordAuthentication): Guest authentication credentials.
+        vcenter_host (str): vCenter hostname for Guest Ops API.
     """
     try:
         run_command_in_vmware_guest(
@@ -459,13 +464,13 @@ def _get_guest_auth(
     """Wait for VMware Tools and return guest auth + vCenter host.
 
     Args:
-        source_provider: VMWare provider instance.
-        owner_vm: PyVmomi VM object for the owner VM.
-        owner_name: Display name of the owner VM.
-        source_provider_data: Provider config (uses guest_vm_win_user/password).
+        source_provider (VMWareProvider): VMWare provider instance.
+        owner_vm (vim.VirtualMachine): PyVmomi VM object for the owner VM.
+        owner_name (str): Display name of the owner VM.
+        source_provider_data (dict[str, Any]): Provider config (uses guest_vm_win_user/password).
 
     Returns:
-        Tuple of (NamePasswordAuthentication, vcenter_host).
+        tuple: (NamePasswordAuthentication, vcenter_host).
 
     Raises:
         ValueError: If Tools not ready, credentials missing, or vCenter host unavailable.
@@ -502,13 +507,13 @@ def _execute_guest_label_command(
     """Label the shared disk on the source Windows VM via Guest Ops.
 
     Args:
-        source_provider: VMWare provider instance.
-        owner_vm: PyVmomi VM object for the owner VM.
-        owner_name: Display name of the owner VM.
-        disk_serial: Hex disk serial number to match inside the guest.
-        volume_label: Alphanumeric NTFS volume label to set.
-        auth: Guest authentication credentials.
-        vcenter_host: vCenter hostname.
+        source_provider (VMWareProvider): VMWare provider instance.
+        owner_vm (vim.VirtualMachine): PyVmomi VM object for the owner VM.
+        owner_name (str): Display name of the owner VM.
+        disk_serial (str): Hex disk serial number to match inside the guest.
+        volume_label (str): Alphanumeric NTFS volume label to set.
+        auth (vim.vm.guest.NamePasswordAuthentication): Guest authentication credentials.
+        vcenter_host (str): vCenter hostname.
 
     Raises:
         ValueError: If disk_serial or volume_label format is invalid.
@@ -549,10 +554,10 @@ def label_shared_disk_on_source_windows(
     for post-migration verification.
 
     Args:
-        source_provider: VMWare provider instance.
-        prepared_plan: Plan config dict (from prepared_plan fixture).
-        source_provider_data: Provider config from .providers.json.
-        session_uuid: Session-unique identifier (from fixture_store).
+        source_provider (VMWareProvider): VMWare provider instance.
+        prepared_plan (dict[str, Any]): Plan config dict (from prepared_plan fixture).
+        source_provider_data (dict[str, Any]): Provider config from .providers.json.
+        session_uuid (str): Session-unique identifier (from fixture_store).
 
     Raises:
         ValueError: If no shared disk found or Windows credentials missing.
@@ -603,7 +608,10 @@ def label_shared_disk_on_source_windows(
         )
     finally:
         LOGGER.info(f"Gracefully shutting down '{owner_name}' after shared disk labeling")
-        source_provider.shutdown_vm_guest(owner_vm)
+        try:
+            source_provider.shutdown_vm_guest(owner_vm)
+        except Exception:
+            LOGGER.warning(f"Failed to shut down '{owner_name}' after labeling", exc_info=True)
 
 
 def _win_run_powershell(
@@ -722,6 +730,7 @@ def _win_get_shared_drive_letter(ssh_conn: VMSSHConnection, vm_label: str, volum
             f"by test_label_shared_disk before migration."
         ) from exc
 
+    # Type narrowing: TimeoutSampler guarantees either break (drive_letter set) or TimeoutExpiredError
     assert drive_letter is not None
     LOGGER.info(f"{vm_label}: Shared volume '{volume_label}' is drive {drive_letter}:")
     return drive_letter
@@ -793,7 +802,8 @@ def _win_read_marker(ssh_conn: VMSSHConnection, drive_letter: str, filename: str
         vm_label (str): Label for log messages.
 
     Raises:
-        GuestCommandError: If the read command fails or content does not match.
+        GuestCommandError: If the read command fails.
+        AssertionError: If content does not match expected data.
     """
     ps_path = f"{drive_letter}:\\{filename}".replace("'", "''")
     content = _win_run_powershell(
@@ -802,7 +812,7 @@ def _win_read_marker(ssh_conn: VMSSHConnection, drive_letter: str, filename: str
         f"{vm_label} read {filename}",
     )
     if expected not in content.strip():
-        raise GuestCommandError(f"{vm_label} cannot read expected data from {filename}: {content}")
+        raise AssertionError(f"{vm_label} cannot read expected data from {filename}: {content}")
     LOGGER.info(f"{vm_label}: Successfully read {filename}")
 
 
@@ -815,30 +825,31 @@ def _win_do_bidirectional_verification(
     """Run bidirectional read/write verification between both Windows VMs.
 
     Args:
-        ctx: Shared disk verification context (SSH connections, VM names).
-        volume_label: NTFS volume label to locate the shared disk.
-        test_file_vm1: Marker filename written by VM1.
-        test_file_vm2: Marker filename written by VM2.
+        ctx (_SharedDiskContext): Shared disk verification context (SSH connections, VM names).
+        volume_label (str): NTFS volume label to locate the shared disk.
+        test_file_vm1 (str): Marker filename written by VM1.
+        test_file_vm2 (str): Marker filename written by VM2.
 
     Raises:
-        GuestCommandError: If any PowerShell command fails or marker content doesn't match.
+        GuestCommandError: If any PowerShell command fails.
+        AssertionError: If marker content does not match expected data.
     """
     with ctx.ssh_vm1:
         drive1 = _win_ensure_shared_volume_online(ctx.ssh_vm1, "VM1", volume_label)
-        _win_write_marker(ctx.ssh_vm1, drive1, test_file_vm1, "Data from VM1", "VM1")
+        _win_write_marker(ctx.ssh_vm1, drive1, test_file_vm1, _MARKER_VM1_CONTENT, "VM1")
 
         with ctx.ssh_vm2:
             _win_ensure_shared_volume_online(ctx.ssh_vm2, "VM2", volume_label)  # drive letter re-queried after refresh
             _win_refresh_shared_disk(ctx.ssh_vm2, "VM2", volume_label)
             drive2 = _win_get_shared_drive_letter(ctx.ssh_vm2, "VM2", volume_label)
-            _win_read_marker(ctx.ssh_vm2, drive2, test_file_vm1, "Data from VM1", "VM2")
+            _win_read_marker(ctx.ssh_vm2, drive2, test_file_vm1, _MARKER_VM1_CONTENT, "VM2")
 
-            _win_write_marker(ctx.ssh_vm2, drive2, test_file_vm2, "Data from VM2", "VM2")
+            _win_write_marker(ctx.ssh_vm2, drive2, test_file_vm2, _MARKER_VM2_CONTENT, "VM2")
             _win_refresh_shared_disk(ctx.ssh_vm2, "VM2", volume_label)
 
         _win_refresh_shared_disk(ctx.ssh_vm1, "VM1", volume_label)
         drive1 = _win_get_shared_drive_letter(ctx.ssh_vm1, "VM1", volume_label)
-        _win_read_marker(ctx.ssh_vm1, drive1, test_file_vm2, "Data from VM2", "VM1")
+        _win_read_marker(ctx.ssh_vm1, drive1, test_file_vm2, _MARKER_VM2_CONTENT, "VM1")
 
 
 def verify_shared_disk_data_windows(
@@ -881,15 +892,12 @@ def verify_shared_disk_data_windows(
 
     LOGGER.info(f"Verifying Windows shared disk (label='{volume_label}') between {ctx.vm1_name} and {ctx.vm2_name}")
 
-    test_file_vm1 = "test-vm1.txt"
-    test_file_vm2 = "test-vm2.txt"
-
     last_exc: Exception | None = None
 
     def _attempt() -> bool | None:
         nonlocal last_exc
         try:
-            _win_do_bidirectional_verification(ctx, volume_label, test_file_vm1, test_file_vm2)
+            _win_do_bidirectional_verification(ctx, volume_label, _MARKER_VM1_FILENAME, _MARKER_VM2_FILENAME)
             return True
         except (
             SSHException,

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -422,6 +422,11 @@ def _disable_fast_startup(
     Windows hybrid shutdown writes a hibernation file that causes virt-customize to fail
     during migration (ConversionHasWarnings / CustomizationFailed).
 
+    Note:
+        Intentional deviation from no-fallbacks rule — Fast Startup disable is
+        a non-critical optimization that does not affect migration correctness.
+        Failure is logged and execution continues.
+
     Args:
         source_provider: VMWare provider instance.
         owner_vm: PyVmomi VM object for the owner VM.
@@ -717,9 +722,7 @@ def _win_get_shared_drive_letter(ssh_conn: VMSSHConnection, vm_label: str, volum
             f"by test_label_shared_disk before migration."
         ) from exc
 
-    if not drive_letter:
-        raise GuestCommandError(f"{vm_label}: Shared volume '{volume_label}' not found")
-
+    assert drive_letter is not None
     LOGGER.info(f"{vm_label}: Shared volume '{volume_label}' is drive {drive_letter}:")
     return drive_letter
 
@@ -893,7 +896,6 @@ def verify_shared_disk_data_windows(
             NoValidConnectionsError,
             ChannelException,
             SSHConnectionSetupError,
-            OSError,
             ConnectionError,
             GuestCommandError,
         ) as e:

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -404,7 +404,7 @@ def _find_shared_disk_serial(
 
 def _execute_guest_label_command(
     source_provider: "VMWareProvider",
-    owner_vm: Any,
+    owner_vm: vim.VirtualMachine,
     owner_name: str,
     disk_serial: str,
     volume_label: str,

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from ocp_resources.virtual_machine import VirtualMachine
+from paramiko.ssh_exception import AuthenticationException, ChannelException, NoValidConnectionsError, SSHException
 from simple_logger.logger import get_logger
 
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
@@ -366,23 +367,35 @@ def _win_ensure_shared_volume_online(ssh_conn: VMSSHConnection, vm_label: str) -
         str: Single-character drive letter (e.g., "E").
 
     Raises:
-        GuestCommandError: If PowerShell commands fail or SHARED volume not found.
+        GuestCommandError: If SHARED volume not found after bringing disks online.
     """
-    _win_run_powershell(
-        ssh_conn,
-        "Get-Disk | Where-Object {$_.OperationalStatus -eq 'Offline'} | Set-Disk -IsOffline $false | Out-Null",
-        f"{vm_label} bring offline disks online",
-    )
-    _win_run_powershell(
-        ssh_conn,
-        "Get-Disk | Where-Object {$_.IsReadOnly -eq $true -and $_.Number -ne 0} | Set-Disk -IsReadOnly $false | Out-Null",
-        f"{vm_label} clear read-only flags",
-    )
+    # Best-effort: piped Set-Disk fails on some vSphere versions due to a Windows SSH
+    # console buffer bug. The targeted Set-Disk -Number <N> in _win_refresh_shared_disk
+    # is the reliable path; this is just an initial attempt to bring disks online.
+    try:
+        _win_run_powershell(
+            ssh_conn,
+            "Get-Disk | Where-Object {$_.OperationalStatus -eq 'Offline'} | Set-Disk -IsOffline $false | Out-Null",
+            f"{vm_label} bring offline disks online",
+        )
+    except GuestCommandError as e:
+        LOGGER.warning(f"{vm_label}: Set-Disk -IsOffline failed (best-effort): {e}")
+    try:
+        _win_run_powershell(
+            ssh_conn,
+            "Get-Disk | Where-Object {$_.IsReadOnly -eq $true -and $_.Number -ne 0} "
+            "| Set-Disk -IsReadOnly $false | Out-Null",
+            f"{vm_label} clear read-only flags",
+        )
+    except GuestCommandError as e:
+        LOGGER.warning(f"{vm_label}: Set-Disk -IsReadOnly failed (best-effort): {e}")
     return _win_get_shared_drive_letter(ssh_conn, vm_label)
 
 
 _WIN_VOLUME_DISCOVERY_TIMEOUT = 60
 _WIN_VOLUME_DISCOVERY_POLL_INTERVAL = 5
+_WIN_VERIFICATION_RETRY_TIMEOUT = 300
+_WIN_VERIFICATION_RETRY_INTERVAL = 15
 
 
 def _win_get_shared_drive_letter(ssh_conn: VMSSHConnection, vm_label: str) -> str:
@@ -412,6 +425,7 @@ def _win_get_shared_drive_letter(ssh_conn: VMSSHConnection, vm_label: str) -> st
         except GuestCommandError:
             return None
 
+    drive_letter: str | None = None
     try:
         for sample in TimeoutSampler(
             wait_timeout=_WIN_VOLUME_DISCOVERY_TIMEOUT,
@@ -419,15 +433,20 @@ def _win_get_shared_drive_letter(ssh_conn: VMSSHConnection, vm_label: str) -> st
             func=_try_get_drive_letter,
         ):
             if sample and len(sample) == 1:
-                LOGGER.info(f"{vm_label}: SHARED volume is drive {sample}:")
-                return sample
+                drive_letter = sample
+                break
     except TimeoutExpiredError as exc:
         raise GuestCommandError(
             f"{vm_label}: Volume with label '{_SHARED_VOLUME_LABEL}' not found after "
             f"{_WIN_VOLUME_DISCOVERY_TIMEOUT}s. Ensure the shared disk on the source VM "
             f"has an NTFS volume labeled '{_SHARED_VOLUME_LABEL}'."
         ) from exc
-    raise GuestCommandError(f"{vm_label}: SHARED volume discovery ended without result")
+
+    if not drive_letter:
+        raise GuestCommandError(f"{vm_label}: SHARED volume not found")
+
+    LOGGER.info(f"{vm_label}: SHARED volume is drive {drive_letter}:")
+    return drive_letter
 
 
 def _win_refresh_shared_disk(ssh_conn: VMSSHConnection, vm_label: str) -> None:
@@ -461,7 +480,7 @@ def _win_refresh_shared_disk(ssh_conn: VMSSHConnection, vm_label: str) -> None:
 
 
 def _win_write_marker(ssh_conn: VMSSHConnection, drive_letter: str, filename: str, content: str, vm_label: str) -> None:
-    """Write a marker file on the SHARED volume and flush to disk.
+    """Write a marker file on the SHARED volume.
 
     Args:
         ssh_conn (VMSSHConnection): Active SSH connection to the Windows VM.
@@ -471,7 +490,7 @@ def _win_write_marker(ssh_conn: VMSSHConnection, drive_letter: str, filename: st
         vm_label (str): Label for log messages.
 
     Raises:
-        GuestCommandError: If write or flush command fails.
+        GuestCommandError: If the write command fails.
     """
     ps_path = f"{drive_letter}:\\{filename}".replace("'", "''")
     ps_content = content.replace("'", "''")
@@ -480,6 +499,29 @@ def _win_write_marker(ssh_conn: VMSSHConnection, drive_letter: str, filename: st
         f"Set-Content -Path '{ps_path}' -Value '{ps_content}'",
         f"{vm_label} write {filename}",
     )
+
+
+def _win_read_marker(ssh_conn: VMSSHConnection, drive_letter: str, filename: str, expected: str, vm_label: str) -> None:
+    """Read a marker file from the SHARED volume and verify its content.
+
+    Args:
+        ssh_conn (VMSSHConnection): Active SSH connection to the Windows VM.
+        drive_letter (str): Drive letter (e.g., "E").
+        filename (str): File name to read (e.g., "test-vm1.txt").
+        expected (str): Expected content substring.
+        vm_label (str): Label for log messages.
+
+    Raises:
+        AssertionError: If the file content does not contain the expected string.
+        GuestCommandError: If the read command fails.
+    """
+    content = _win_run_powershell(
+        ssh_conn,
+        f"Get-Content -Path '{drive_letter}:\\{filename}'",
+        f"{vm_label} read {filename}",
+    )
+    assert expected in content.strip(), f"{vm_label} cannot read expected data from {filename}: {content}"
+    LOGGER.info(f"{vm_label}: Successfully read {filename}")
 
 
 def verify_shared_disk_data_windows(
@@ -496,8 +538,8 @@ def verify_shared_disk_data_windows(
     Flow:
     1. Confirm shared PVC exists via KubeVirt volumeStatus
     2. VM1: bring shared disk online, write test data
-    3. VM2: bring shared disk online (fresh mount, no stale cache), read VM1's data, write own data
-    4. VM1: refresh disk (offline/online to flush NTFS cache), read VM2's data
+    3. VM2: bring shared disk online, refresh (clear stale NTFS cache), read VM1's data, write, refresh (flush to disk)
+    4. VM1: refresh disk (invalidate cache), read VM2's data
 
     Args:
         prepared_plan (dict[str, Any]): Plan config with virtual_machines, source_vms_data, and _vm_target_namespace.
@@ -517,32 +559,48 @@ def verify_shared_disk_data_windows(
     test_file_vm1 = "test-vm1.txt"
     test_file_vm2 = "test-vm2.txt"
 
-    with ctx.ssh_vm1:
-        drive1 = _win_ensure_shared_volume_online(ctx.ssh_vm1, "VM1")
-        _win_write_marker(ctx.ssh_vm1, drive1, test_file_vm1, "Data from VM1", "VM1")
+    def _do_verification() -> bool | None:
+        try:
+            with ctx.ssh_vm1:
+                drive1 = _win_ensure_shared_volume_online(ctx.ssh_vm1, "VM1")
+                _win_write_marker(ctx.ssh_vm1, drive1, test_file_vm1, "Data from VM1", "VM1")
 
-        with ctx.ssh_vm2:
-            drive2 = _win_ensure_shared_volume_online(ctx.ssh_vm2, "VM2")
+                with ctx.ssh_vm2:
+                    drive2 = _win_ensure_shared_volume_online(ctx.ssh_vm2, "VM2")
+                    _win_refresh_shared_disk(ctx.ssh_vm2, "VM2")
+                    drive2 = _win_get_shared_drive_letter(ctx.ssh_vm2, "VM2")
+                    _win_read_marker(ctx.ssh_vm2, drive2, test_file_vm1, "Data from VM1", "VM2")
 
-            vm2_read = _win_run_powershell(
-                ctx.ssh_vm2,
-                f"Get-Content -Path '{drive2}:\\{test_file_vm1}'",
-                "VM2 read VM1 data",
-            )
-            assert "Data from VM1" in vm2_read.strip(), f"VM2 cannot read VM1's data: {vm2_read}"
-            LOGGER.info(f"VM2 ({ctx.vm2_name}): Successfully read VM1's data")
+                    _win_write_marker(ctx.ssh_vm2, drive2, test_file_vm2, "Data from VM2", "VM2")
+                    _win_refresh_shared_disk(ctx.ssh_vm2, "VM2")
 
-            _win_write_marker(ctx.ssh_vm2, drive2, test_file_vm2, "Data from VM2", "VM2")
+                _win_refresh_shared_disk(ctx.ssh_vm1, "VM1")
+                drive1 = _win_get_shared_drive_letter(ctx.ssh_vm1, "VM1")
+                _win_read_marker(ctx.ssh_vm1, drive1, test_file_vm2, "Data from VM2", "VM1")
 
-        _win_refresh_shared_disk(ctx.ssh_vm1, "VM1")
-        drive1 = _win_get_shared_drive_letter(ctx.ssh_vm1, "VM1")
+                return True
+        except (
+            SSHException,
+            AuthenticationException,
+            NoValidConnectionsError,
+            ChannelException,
+            GuestCommandError,
+            AssertionError,
+        ) as e:
+            LOGGER.warning(f"Shared disk verification failed: {type(e).__name__}: {e} - retrying...")
+            return None
 
-        vm1_read = _win_run_powershell(
-            ctx.ssh_vm1,
-            f"Get-Content -Path '{drive1}:\\{test_file_vm2}'",
-            "VM1 read VM2 data",
-        )
-        assert "Data from VM2" in vm1_read.strip(), f"VM1 cannot read VM2's data: {vm1_read}"
-        LOGGER.info(f"VM1 ({ctx.vm1_name}): Successfully read VM2's data")
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=_WIN_VERIFICATION_RETRY_TIMEOUT,
+            sleep=_WIN_VERIFICATION_RETRY_INTERVAL,
+            func=_do_verification,
+        ):
+            if sample:
+                break
+    except TimeoutExpiredError as e:
+        raise TimeoutExpiredError(
+            f"Windows shared disk verification failed after {_WIN_VERIFICATION_RETRY_TIMEOUT}s"
+        ) from e
 
     LOGGER.info("Windows shared disk verification successful - bidirectional access confirmed")

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -279,3 +279,242 @@ def verify_shared_disk_data(
         _umount_shared_partition(ssh_vm1, mount_point, "VM1 final")
 
     LOGGER.info("Shared disk verification successful - bidirectional access confirmed")
+
+
+_SHARED_VOLUME_LABEL = "SHARED"
+
+
+def _win_run_powershell(
+    ssh_conn: VMSSHConnection,
+    script: str,
+    description: str,
+) -> str:
+    """Execute a PowerShell command on a Windows VM via SSH.
+
+    SSH on Windows lands in CMD by default. This wraps the script
+    in ``powershell -Command "..."`` so it is interpreted by PowerShell.
+
+    Args:
+        ssh_conn (VMSSHConnection): Active SSH connection to the Windows VM.
+        script (str): PowerShell script to execute (single command or semicolon-separated).
+        description (str): Human-readable description for logging.
+
+    Returns:
+        str: Command stdout.
+
+    Raises:
+        GuestCommandError: If the command fails (non-zero return code).
+    """
+    return _run_cmd_on_vm(ssh_conn, ["powershell", "-Command", script], description)
+
+
+def _win_ensure_shared_volume_online(ssh_conn: VMSSHConnection, vm_label: str) -> str:
+    """Bring offline disks online and return the SHARED volume drive letter.
+
+    After migration, Windows SAN policy may leave non-boot disks offline.
+    This brings all offline disks online, clears read-only flags, then
+    locates the SHARED volume by its filesystem label.
+
+    Args:
+        ssh_conn (VMSSHConnection): Active SSH connection to the Windows VM.
+        vm_label (str): Label for log messages (e.g., "VM1").
+
+    Returns:
+        str: Single-character drive letter (e.g., "E").
+
+    Raises:
+        GuestCommandError: If PowerShell commands fail or SHARED volume not found.
+    """
+    _win_run_powershell(
+        ssh_conn,
+        "Get-Disk | Where-Object {$_.OperationalStatus -eq 'Offline'} | Set-Disk -IsOffline $false | Out-Null",
+        f"{vm_label} bring offline disks online",
+    )
+    _win_run_powershell(
+        ssh_conn,
+        "Get-Disk | Where-Object {$_.IsReadOnly -eq $true -and $_.Number -ne 0} | Set-Disk -IsReadOnly $false | Out-Null",
+        f"{vm_label} clear read-only flags",
+    )
+    return _win_get_shared_drive_letter(ssh_conn, vm_label)
+
+
+_WIN_VOLUME_DISCOVERY_TIMEOUT = 60
+_WIN_VOLUME_DISCOVERY_POLL_INTERVAL = 5
+
+
+def _win_get_shared_drive_letter(ssh_conn: VMSSHConnection, vm_label: str) -> str:
+    """Find the drive letter of the SHARED volume by its filesystem label.
+
+    Polls with a timeout because Windows may take a moment to mount the
+    filesystem after the disk is brought online.
+
+    Args:
+        ssh_conn (VMSSHConnection): Active SSH connection to the Windows VM.
+        vm_label (str): Label for log messages.
+
+    Returns:
+        str: Single-character drive letter (e.g., "E").
+
+    Raises:
+        GuestCommandError: If the SHARED volume is not found within the timeout.
+    """
+
+    def _try_get_drive_letter() -> str | None:
+        try:
+            return _win_run_powershell(
+                ssh_conn,
+                f"(Get-Volume -FileSystemLabel '{_SHARED_VOLUME_LABEL}').DriveLetter",
+                f"{vm_label} get SHARED drive letter",
+            ).strip()
+        except GuestCommandError:
+            return None
+
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=_WIN_VOLUME_DISCOVERY_TIMEOUT,
+            sleep=_WIN_VOLUME_DISCOVERY_POLL_INTERVAL,
+            func=_try_get_drive_letter,
+        ):
+            if sample and len(sample) == 1:
+                LOGGER.info(f"{vm_label}: SHARED volume is drive {sample}:")
+                return sample
+    except TimeoutExpiredError as exc:
+        raise GuestCommandError(
+            f"{vm_label}: Volume with label '{_SHARED_VOLUME_LABEL}' not found after "
+            f"{_WIN_VOLUME_DISCOVERY_TIMEOUT}s. Ensure the shared disk on the source VM "
+            f"has an NTFS volume labeled '{_SHARED_VOLUME_LABEL}'."
+        ) from exc
+    raise GuestCommandError(f"{vm_label}: SHARED volume not found")
+
+
+def _win_refresh_shared_disk(ssh_conn: VMSSHConnection, vm_label: str) -> None:
+    """Flush NTFS metadata cache via disk offline/online cycle.
+
+    NTFS does not see files written by another VM until the disk is taken
+    offline and brought back online. This is the Windows equivalent of
+    ``blockdev --flushbufs`` used in the Linux verification.
+
+    Args:
+        ssh_conn (VMSSHConnection): Active SSH connection to the Windows VM.
+        vm_label (str): Label for log messages.
+
+    Raises:
+        GuestCommandError: If disk offline/online commands fail.
+    """
+    disk_num = _win_run_powershell(
+        ssh_conn,
+        f"(Get-Volume -FileSystemLabel '{_SHARED_VOLUME_LABEL}' | Get-Partition).DiskNumber",
+        f"{vm_label} get SHARED disk number",
+    ).strip()
+    if not disk_num.isdigit():
+        raise GuestCommandError(f"{vm_label}: Cannot determine disk number for SHARED volume (got: '{disk_num}')")
+    _win_run_powershell(
+        ssh_conn, f"Set-Disk -Number {disk_num} -IsOffline $true | Out-Null", f"{vm_label} disk offline"
+    )
+    _win_run_powershell(
+        ssh_conn, f"Set-Disk -Number {disk_num} -IsOffline $false | Out-Null", f"{vm_label} disk online"
+    )
+    LOGGER.info(f"{vm_label}: Refreshed SHARED disk (disk {disk_num})")
+
+
+def _win_write_marker(ssh_conn: VMSSHConnection, drive_letter: str, filename: str, content: str, vm_label: str) -> None:
+    """Write a marker file on the SHARED volume.
+
+    Args:
+        ssh_conn (VMSSHConnection): Active SSH connection to the Windows VM.
+        drive_letter (str): Drive letter (e.g., "E").
+        filename (str): File name to write (e.g., "test-vm1.txt").
+        content (str): Text content to write.
+        vm_label (str): Label for log messages.
+
+    Raises:
+        GuestCommandError: If write command fails.
+    """
+    path = f"{drive_letter}:\\{filename}"
+    _win_run_powershell(
+        ssh_conn,
+        f"Set-Content -Path '{path}' -Value '{content}'",
+        f"{vm_label} write {filename}",
+    )
+
+
+def verify_shared_disk_data_windows(
+    prepared_plan: dict[str, Any],
+    vm_ssh_connections: SSHConnectionManager,
+    source_provider_data: dict[str, Any],
+    ocp_admin_client: "DynamicClient",
+) -> None:
+    """Verify shared disk is accessible from both Windows VMs after migration.
+
+    Uses NTFS volume label to locate the shared disk (no Linux device paths).
+    The shared disk must be formatted with NTFS and labeled ``SHARED``.
+
+    Flow:
+    1. Confirm shared PVC exists via KubeVirt volumeStatus
+    2. VM1: bring shared disk online, write test data
+    3. VM2: bring shared disk online (fresh mount, no stale cache), read VM1's data, write own data
+    4. VM1: refresh disk (offline/online to flush NTFS cache), read VM2's data
+
+    Args:
+        prepared_plan (dict[str, Any]): Plan config with virtual_machines, source_vms_data, and _vm_target_namespace.
+        vm_ssh_connections (SSHConnectionManager): SSH connection manager.
+        source_provider_data (dict[str, Any]): Provider configuration from .providers.json.
+        ocp_admin_client (DynamicClient): OpenShift admin client for destination VM lookup.
+
+    Raises:
+        AssertionError: If shared disk data verification fails.
+        GuestCommandError: If SSH or PowerShell commands fail.
+    """
+    vm1_config = prepared_plan["virtual_machines"][0]
+    vm2_config = prepared_plan["virtual_machines"][1]
+    vm1_name = vm1_config["name"]
+    vm2_name = vm2_config["name"]
+    vm_namespace = prepared_plan["_vm_target_namespace"]
+    vm1_dest_name = resolve_destination_vm_name(vm1_config)
+    vm2_dest_name = resolve_destination_vm_name(vm2_config)
+
+    _get_shared_disk_devices(ocp_admin_client, vm_namespace, vm1_dest_name, vm2_dest_name)
+
+    LOGGER.info(f"Verifying Windows shared disk between {vm1_name} and {vm2_name}")
+
+    vm1_info = prepared_plan["source_vms_data"][vm1_name]
+    vm2_info = prepared_plan["source_vms_data"][vm2_name]
+
+    vm1_user, vm1_pass = get_ssh_credentials_from_provider_config(source_provider_data, vm1_info)
+    vm2_user, vm2_pass = get_ssh_credentials_from_provider_config(source_provider_data, vm2_info)
+
+    ssh_vm1 = vm_ssh_connections.create(vm_name=vm1_name, username=vm1_user, password=vm1_pass)
+    ssh_vm2 = vm_ssh_connections.create(vm_name=vm2_name, username=vm2_user, password=vm2_pass)
+
+    test_file_vm1 = "test-vm1.txt"
+    test_file_vm2 = "test-vm2.txt"
+
+    with ssh_vm1:
+        drive1 = _win_ensure_shared_volume_online(ssh_vm1, "VM1")
+        _win_write_marker(ssh_vm1, drive1, test_file_vm1, "Data from VM1", "VM1")
+
+        with ssh_vm2:
+            drive2 = _win_ensure_shared_volume_online(ssh_vm2, "VM2")
+
+            vm2_read = _win_run_powershell(
+                ssh_vm2,
+                f"Get-Content -Path '{drive2}:\\{test_file_vm1}'",
+                "VM2 read VM1 data",
+            )
+            assert "Data from VM1" in vm2_read.strip(), f"VM2 cannot read VM1's data: {vm2_read}"
+            LOGGER.info(f"VM2 ({vm2_name}): Successfully read VM1's data")
+
+            _win_write_marker(ssh_vm2, drive2, test_file_vm2, "Data from VM2", "VM2")
+
+        _win_refresh_shared_disk(ssh_vm1, "VM1")
+        drive1 = _win_get_shared_drive_letter(ssh_vm1, "VM1")
+
+        vm1_read = _win_run_powershell(
+            ssh_vm1,
+            f"Get-Content -Path '{drive1}:\\{test_file_vm2}'",
+            "VM1 read VM2 data",
+        )
+        assert "Data from VM2" in vm1_read.strip(), f"VM1 cannot read VM2's data: {vm1_read}"
+        LOGGER.info(f"VM1 ({vm1_name}): Successfully read VM2's data")
+
+    LOGGER.info("Windows shared disk verification successful - bidirectional access confirmed")

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -610,8 +610,8 @@ def label_shared_disk_on_source_windows(
         LOGGER.info(f"Gracefully shutting down '{owner_name}' after shared disk labeling")
         try:
             source_provider.shutdown_vm_guest(owner_vm)
-        except Exception:
-            LOGGER.warning(f"Failed to shut down '{owner_name}' after labeling", exc_info=True)
+        except (vim.fault.VimFault, ConnectionError, OSError, TimeoutExpiredError) as e:
+            LOGGER.warning(f"Failed to shut down '{owner_name}' after labeling: {e}")
 
 
 def _win_run_powershell(

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -480,11 +480,6 @@ def _win_write_marker(ssh_conn: VMSSHConnection, drive_letter: str, filename: st
         f"Set-Content -Path '{ps_path}' -Value '{ps_content}'",
         f"{vm_label} write {filename}",
     )
-    _win_run_powershell(
-        ssh_conn,
-        f"fsutil volume flush {drive_letter}:",
-        f"{vm_label} flush {drive_letter}:",
-    )
 
 
 def verify_shared_disk_data_windows(

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -7,6 +7,7 @@ after migration.
 from __future__ import annotations
 
 import shlex
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from ocp_resources.virtual_machine import VirtualMachine
@@ -191,6 +192,67 @@ def _get_shared_disk_devices(
     return {vm1_dest_name: vm1_device, vm2_dest_name: vm2_device}
 
 
+@dataclass
+class _SharedDiskContext:
+    """Common context extracted by _prepare_shared_disk_verification."""
+
+    vm1_name: str
+    vm2_name: str
+    vm1_dest_name: str
+    vm2_dest_name: str
+    ssh_vm1: VMSSHConnection
+    ssh_vm2: VMSSHConnection
+    shared_devices: dict[str, str]
+
+
+def _prepare_shared_disk_verification(
+    prepared_plan: dict[str, Any],
+    vm_ssh_connections: SSHConnectionManager,
+    source_provider_data: dict[str, Any],
+    ocp_admin_client: "DynamicClient",
+) -> _SharedDiskContext:
+    """Extract common setup for shared disk verification (Linux and Windows).
+
+    Both verify functions share the same preamble: extract VM configs,
+    resolve destination names, validate shared PVC exists, get SSH
+    credentials, and create SSH connections.
+
+    Args:
+        prepared_plan (dict[str, Any]): Plan config with virtual_machines, source_vms_data, and _vm_target_namespace.
+        vm_ssh_connections (SSHConnectionManager): SSH connection manager.
+        source_provider_data (dict[str, Any]): Provider configuration from .providers.json.
+        ocp_admin_client (DynamicClient): OpenShift admin client for destination VM lookup.
+
+    Returns:
+        _SharedDiskContext: Common context for shared disk verification.
+    """
+    vm1_config = prepared_plan["virtual_machines"][0]
+    vm2_config = prepared_plan["virtual_machines"][1]
+    vm1_name = vm1_config["name"]
+    vm2_name = vm2_config["name"]
+    vm_namespace = prepared_plan["_vm_target_namespace"]
+    vm1_dest_name = resolve_destination_vm_name(vm1_config)
+    vm2_dest_name = resolve_destination_vm_name(vm2_config)
+    shared_devices = _get_shared_disk_devices(ocp_admin_client, vm_namespace, vm1_dest_name, vm2_dest_name)
+
+    vm1_info = prepared_plan["source_vms_data"][vm1_name]
+    vm2_info = prepared_plan["source_vms_data"][vm2_name]
+    vm1_user, vm1_pass = get_ssh_credentials_from_provider_config(source_provider_data, vm1_info)
+    vm2_user, vm2_pass = get_ssh_credentials_from_provider_config(source_provider_data, vm2_info)
+    ssh_vm1 = vm_ssh_connections.create(vm_name=vm1_name, username=vm1_user, password=vm1_pass)
+    ssh_vm2 = vm_ssh_connections.create(vm_name=vm2_name, username=vm2_user, password=vm2_pass)
+
+    return _SharedDiskContext(
+        vm1_name=vm1_name,
+        vm2_name=vm2_name,
+        vm1_dest_name=vm1_dest_name,
+        vm2_dest_name=vm2_dest_name,
+        ssh_vm1=ssh_vm1,
+        ssh_vm2=ssh_vm2,
+        shared_devices=shared_devices,
+    )
+
+
 def verify_shared_disk_data(
     prepared_plan: dict[str, Any],
     vm_ssh_connections: SSHConnectionManager,
@@ -217,27 +279,11 @@ def verify_shared_disk_data(
         AssertionError: If shared disk data verification fails.
         GuestCommandError: If SSH commands fail.
     """
-    vm1_config = prepared_plan["virtual_machines"][0]
-    vm2_config = prepared_plan["virtual_machines"][1]
-    vm1_name = vm1_config["name"]
-    vm2_name = vm2_config["name"]
-    vm_namespace = prepared_plan["_vm_target_namespace"]
-    vm1_dest_name = resolve_destination_vm_name(vm1_config)
-    vm2_dest_name = resolve_destination_vm_name(vm2_config)
-    device_by_vm = _get_shared_disk_devices(ocp_admin_client, vm_namespace, vm1_dest_name, vm2_dest_name)
-    vm1_device = device_by_vm[vm1_dest_name]
-    vm2_device = device_by_vm[vm2_dest_name]
+    ctx = _prepare_shared_disk_verification(prepared_plan, vm_ssh_connections, source_provider_data, ocp_admin_client)
+    vm1_device = ctx.shared_devices[ctx.vm1_dest_name]
+    vm2_device = ctx.shared_devices[ctx.vm2_dest_name]
 
-    LOGGER.info(f"Verifying shared disk between {vm1_name} and {vm2_name}")
-
-    vm1_info = prepared_plan["source_vms_data"][vm1_name]
-    vm2_info = prepared_plan["source_vms_data"][vm2_name]
-
-    vm1_user, vm1_pass = get_ssh_credentials_from_provider_config(source_provider_data, vm1_info)
-    vm2_user, vm2_pass = get_ssh_credentials_from_provider_config(source_provider_data, vm2_info)
-
-    ssh_vm1 = vm_ssh_connections.create(vm_name=vm1_name, username=vm1_user, password=vm1_pass)
-    ssh_vm2 = vm_ssh_connections.create(vm_name=vm2_name, username=vm2_user, password=vm2_pass)
+    LOGGER.info(f"Verifying shared disk between {ctx.vm1_name} and {ctx.vm2_name}")
 
     mount_point = "/mnt/shared_disk"
     vm1_partition = f"{vm1_device}1"
@@ -245,38 +291,35 @@ def verify_shared_disk_data(
     test_file_vm1 = f"{mount_point}/test-vm1.txt"
     test_file_vm2 = f"{mount_point}/test-vm2.txt"
 
-    # VM1: Mount shared disk, write test data, unmount (keep connection open for verify phase)
-    LOGGER.info(f"VM1 ({vm1_name}): Mounting shared disk {vm1_partition}")
-    with ssh_vm1:
-        _mount_shared_partition(ssh_vm1, vm1_partition, mount_point, "VM1")
-        _write_marker(ssh_vm1, test_file_vm1, "Data from VM1", "VM1")
-        _umount_shared_partition(ssh_vm1, mount_point, "VM1")
+    LOGGER.info(f"VM1 ({ctx.vm1_name}): Mounting shared disk {vm1_partition}")
+    with ctx.ssh_vm1:
+        _mount_shared_partition(ctx.ssh_vm1, vm1_partition, mount_point, "VM1")
+        _write_marker(ctx.ssh_vm1, test_file_vm1, "Data from VM1", "VM1")
+        _umount_shared_partition(ctx.ssh_vm1, mount_point, "VM1")
 
-        # VM2: Mount shared disk, verify VM1's data, write own data, unmount
-        LOGGER.info(f"VM2 ({vm2_name}): Mounting shared disk {vm2_partition}")
-        with ssh_vm2:
-            _mount_shared_partition(ssh_vm2, vm2_partition, mount_point, "VM2")
+        LOGGER.info(f"VM2 ({ctx.vm2_name}): Mounting shared disk {vm2_partition}")
+        with ctx.ssh_vm2:
+            _mount_shared_partition(ctx.ssh_vm2, vm2_partition, mount_point, "VM2")
 
-            vm2_read_data = run_cmd_in_vm(ssh_vm2, ["sudo", "cat", test_file_vm1], "VM2 read VM1 data")
+            vm2_read_data = run_cmd_in_vm(ctx.ssh_vm2, ["sudo", "cat", test_file_vm1], "VM2 read VM1 data")
             assert "Data from VM1" in vm2_read_data.strip(), f"VM2 cannot read VM1's data: {vm2_read_data}"
-            LOGGER.info(f"VM2 ({vm2_name}): Successfully read VM1's data")
+            LOGGER.info(f"VM2 ({ctx.vm2_name}): Successfully read VM1's data")
 
-            _write_marker(ssh_vm2, test_file_vm2, "Data from VM2", "VM2")
-            _umount_shared_partition(ssh_vm2, mount_point, "VM2")
+            _write_marker(ctx.ssh_vm2, test_file_vm2, "Data from VM2", "VM2")
+            _umount_shared_partition(ctx.ssh_vm2, mount_point, "VM2")
 
-        # Verify bidirectional access (remount with cache flush)
-        LOGGER.info(f"VM1 ({vm1_name}): Verifying bidirectional access")
+        LOGGER.info(f"VM1 ({ctx.vm1_name}): Verifying bidirectional access")
         # Flush block device buffers to clear stale kernel cache.
         # XFS (non-cluster filesystem) retains metadata in kernel buffer cache.
         # Without this, VM1 won't see VM2's newly written files even after remount.
-        run_cmd_in_vm(ssh_vm1, ["sudo", "blockdev", "--flushbufs", vm1_device], "VM1 flush buffers")
-        run_cmd_in_vm(ssh_vm1, ["sudo", "mount", vm1_partition, mount_point], "VM1 remount")
+        run_cmd_in_vm(ctx.ssh_vm1, ["sudo", "blockdev", "--flushbufs", vm1_device], "VM1 flush buffers")
+        run_cmd_in_vm(ctx.ssh_vm1, ["sudo", "mount", vm1_partition, mount_point], "VM1 remount")
 
-        vm1_read_data = run_cmd_in_vm(ssh_vm1, ["sudo", "cat", test_file_vm2], "VM1 read VM2 data")
+        vm1_read_data = run_cmd_in_vm(ctx.ssh_vm1, ["sudo", "cat", test_file_vm2], "VM1 read VM2 data")
         assert "Data from VM2" in vm1_read_data.strip(), f"VM1 cannot read VM2's data: {vm1_read_data}"
-        LOGGER.info(f"VM1 ({vm1_name}): Successfully read VM2's data")
+        LOGGER.info(f"VM1 ({ctx.vm1_name}): Successfully read VM2's data")
 
-        _umount_shared_partition(ssh_vm1, mount_point, "VM1 final")
+        _umount_shared_partition(ctx.ssh_vm1, mount_point, "VM1 final")
 
     LOGGER.info("Shared disk verification successful - bidirectional access confirmed")
 
@@ -369,7 +412,6 @@ def _win_get_shared_drive_letter(ssh_conn: VMSSHConnection, vm_label: str) -> st
         except GuestCommandError:
             return None
 
-    drive_letter = ""
     try:
         for sample in TimeoutSampler(
             wait_timeout=_WIN_VOLUME_DISCOVERY_TIMEOUT,
@@ -378,15 +420,14 @@ def _win_get_shared_drive_letter(ssh_conn: VMSSHConnection, vm_label: str) -> st
         ):
             if sample and len(sample) == 1:
                 LOGGER.info(f"{vm_label}: SHARED volume is drive {sample}:")
-                drive_letter = sample
-                break
+                return sample
     except TimeoutExpiredError as exc:
         raise GuestCommandError(
             f"{vm_label}: Volume with label '{_SHARED_VOLUME_LABEL}' not found after "
             f"{_WIN_VOLUME_DISCOVERY_TIMEOUT}s. Ensure the shared disk on the source VM "
             f"has an NTFS volume labeled '{_SHARED_VOLUME_LABEL}'."
         ) from exc
-    return drive_letter
+    raise GuestCommandError(f"{vm_label}: SHARED volume discovery ended without result")
 
 
 def _win_refresh_shared_disk(ssh_conn: VMSSHConnection, vm_label: str) -> None:
@@ -420,7 +461,7 @@ def _win_refresh_shared_disk(ssh_conn: VMSSHConnection, vm_label: str) -> None:
 
 
 def _win_write_marker(ssh_conn: VMSSHConnection, drive_letter: str, filename: str, content: str, vm_label: str) -> None:
-    """Write a marker file on the SHARED volume.
+    """Write a marker file on the SHARED volume and flush to disk.
 
     Args:
         ssh_conn (VMSSHConnection): Active SSH connection to the Windows VM.
@@ -430,13 +471,19 @@ def _win_write_marker(ssh_conn: VMSSHConnection, drive_letter: str, filename: st
         vm_label (str): Label for log messages.
 
     Raises:
-        GuestCommandError: If write command fails.
+        GuestCommandError: If write or flush command fails.
     """
-    path = f"{drive_letter}:\\{filename}"
+    ps_path = f"{drive_letter}:\\{filename}".replace("'", "''")
+    ps_content = content.replace("'", "''")
     _win_run_powershell(
         ssh_conn,
-        f"Set-Content -Path '{path}' -Value '{content}'",
+        f"Set-Content -Path '{ps_path}' -Value '{ps_content}'",
         f"{vm_label} write {filename}",
+    )
+    _win_run_powershell(
+        ssh_conn,
+        f"fsutil volume flush {drive_letter}:",
+        f"{vm_label} flush {drive_letter}:",
     )
 
 
@@ -467,56 +514,40 @@ def verify_shared_disk_data_windows(
         AssertionError: If shared disk data verification fails.
         GuestCommandError: If SSH or PowerShell commands fail.
     """
-    vm1_config = prepared_plan["virtual_machines"][0]
-    vm2_config = prepared_plan["virtual_machines"][1]
-    vm1_name = vm1_config["name"]
-    vm2_name = vm2_config["name"]
-    vm_namespace = prepared_plan["_vm_target_namespace"]
-    vm1_dest_name = resolve_destination_vm_name(vm1_config)
-    vm2_dest_name = resolve_destination_vm_name(vm2_config)
+    # Shared PVC validated by helper (device paths unused — Windows uses volume labels)
+    ctx = _prepare_shared_disk_verification(prepared_plan, vm_ssh_connections, source_provider_data, ocp_admin_client)
 
-    _get_shared_disk_devices(ocp_admin_client, vm_namespace, vm1_dest_name, vm2_dest_name)
-
-    LOGGER.info(f"Verifying Windows shared disk between {vm1_name} and {vm2_name}")
-
-    vm1_info = prepared_plan["source_vms_data"][vm1_name]
-    vm2_info = prepared_plan["source_vms_data"][vm2_name]
-
-    vm1_user, vm1_pass = get_ssh_credentials_from_provider_config(source_provider_data, vm1_info)
-    vm2_user, vm2_pass = get_ssh_credentials_from_provider_config(source_provider_data, vm2_info)
-
-    ssh_vm1 = vm_ssh_connections.create(vm_name=vm1_name, username=vm1_user, password=vm1_pass)
-    ssh_vm2 = vm_ssh_connections.create(vm_name=vm2_name, username=vm2_user, password=vm2_pass)
+    LOGGER.info(f"Verifying Windows shared disk between {ctx.vm1_name} and {ctx.vm2_name}")
 
     test_file_vm1 = "test-vm1.txt"
     test_file_vm2 = "test-vm2.txt"
 
-    with ssh_vm1:
-        drive1 = _win_ensure_shared_volume_online(ssh_vm1, "VM1")
-        _win_write_marker(ssh_vm1, drive1, test_file_vm1, "Data from VM1", "VM1")
+    with ctx.ssh_vm1:
+        drive1 = _win_ensure_shared_volume_online(ctx.ssh_vm1, "VM1")
+        _win_write_marker(ctx.ssh_vm1, drive1, test_file_vm1, "Data from VM1", "VM1")
 
-        with ssh_vm2:
-            drive2 = _win_ensure_shared_volume_online(ssh_vm2, "VM2")
+        with ctx.ssh_vm2:
+            drive2 = _win_ensure_shared_volume_online(ctx.ssh_vm2, "VM2")
 
             vm2_read = _win_run_powershell(
-                ssh_vm2,
+                ctx.ssh_vm2,
                 f"Get-Content -Path '{drive2}:\\{test_file_vm1}'",
                 "VM2 read VM1 data",
             )
             assert "Data from VM1" in vm2_read.strip(), f"VM2 cannot read VM1's data: {vm2_read}"
-            LOGGER.info(f"VM2 ({vm2_name}): Successfully read VM1's data")
+            LOGGER.info(f"VM2 ({ctx.vm2_name}): Successfully read VM1's data")
 
-            _win_write_marker(ssh_vm2, drive2, test_file_vm2, "Data from VM2", "VM2")
+            _win_write_marker(ctx.ssh_vm2, drive2, test_file_vm2, "Data from VM2", "VM2")
 
-        _win_refresh_shared_disk(ssh_vm1, "VM1")
-        drive1 = _win_get_shared_drive_letter(ssh_vm1, "VM1")
+        _win_refresh_shared_disk(ctx.ssh_vm1, "VM1")
+        drive1 = _win_get_shared_drive_letter(ctx.ssh_vm1, "VM1")
 
         vm1_read = _win_run_powershell(
-            ssh_vm1,
+            ctx.ssh_vm1,
             f"Get-Content -Path '{drive1}:\\{test_file_vm2}'",
             "VM1 read VM2 data",
         )
         assert "Data from VM2" in vm1_read.strip(), f"VM1 cannot read VM2's data: {vm1_read}"
-        LOGGER.info(f"VM1 ({vm1_name}): Successfully read VM2's data")
+        LOGGER.info(f"VM1 ({ctx.vm1_name}): Successfully read VM2's data")
 
     LOGGER.info("Windows shared disk verification successful - bidirectional access confirmed")

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -463,7 +463,7 @@ def _get_guest_auth(
         Tuple of (NamePasswordAuthentication, vcenter_host).
 
     Raises:
-        ValueError: If Tools not ready or vCenter host unavailable.
+        ValueError: If Tools not ready, credentials missing, or vCenter host unavailable.
     """
     if not source_provider.wait_for_vmware_guest_info(owner_vm, timeout=_GUEST_TOOLS_READY_TIMEOUT):
         raise ValueError(f"VMware Tools not available on '{owner_name}' after power-on, cannot label shared disk")

--- a/utilities/shared_disk.py
+++ b/utilities/shared_disk.py
@@ -310,8 +310,7 @@ def verify_shared_disk_data(
         ocp_admin_client (DynamicClient): OpenShift admin client for destination VM lookup.
 
     Raises:
-        AssertionError: If shared disk data verification fails.
-        GuestCommandError: If SSH commands fail.
+        GuestCommandError: If SSH commands or data verification fails.
     """
     ctx = _prepare_shared_disk_verification(prepared_plan, vm_ssh_connections, source_provider_data, ocp_admin_client)
     vm1_device = ctx.shared_devices[ctx.vm1_dest_name]
@@ -793,15 +792,15 @@ def _win_read_marker(ssh_conn: VMSSHConnection, drive_letter: str, filename: str
         vm_label (str): Label for log messages.
 
     Raises:
-        AssertionError: If the file content does not contain the expected string.
-        GuestCommandError: If the read command fails.
+        GuestCommandError: If the read command fails or content does not match.
     """
     content = _win_run_powershell(
         ssh_conn,
         f"Get-Content -Path '{drive_letter}:\\{filename}'",
         f"{vm_label} read {filename}",
     )
-    assert expected in content.strip(), f"{vm_label} cannot read expected data from {filename}: {content}"
+    if expected not in content.strip():
+        raise GuestCommandError(f"{vm_label} cannot read expected data from {filename}: {content}")
     LOGGER.info(f"{vm_label}: Successfully read {filename}")
 
 
@@ -820,15 +819,14 @@ def _win_do_bidirectional_verification(
         test_file_vm2: Marker filename written by VM2.
 
     Raises:
-        GuestCommandError: If any PowerShell command fails.
-        AssertionError: If marker file content doesn't match expected data.
+        GuestCommandError: If any PowerShell command fails or marker content doesn't match.
     """
     with ctx.ssh_vm1:
         drive1 = _win_ensure_shared_volume_online(ctx.ssh_vm1, "VM1", volume_label)
         _win_write_marker(ctx.ssh_vm1, drive1, test_file_vm1, "Data from VM1", "VM1")
 
         with ctx.ssh_vm2:
-            _win_ensure_shared_volume_online(ctx.ssh_vm2, "VM2", volume_label)
+            _win_ensure_shared_volume_online(ctx.ssh_vm2, "VM2", volume_label)  # drive letter re-queried after refresh
             _win_refresh_shared_disk(ctx.ssh_vm2, "VM2", volume_label)
             drive2 = _win_get_shared_drive_letter(ctx.ssh_vm2, "VM2", volume_label)
             _win_read_marker(ctx.ssh_vm2, drive2, test_file_vm1, "Data from VM1", "VM2")
@@ -868,8 +866,7 @@ def verify_shared_disk_data_windows(
         ocp_admin_client (DynamicClient): OpenShift admin client for destination VM lookup.
 
     Raises:
-        AssertionError: If shared disk data verification fails.
-        GuestCommandError: If SSH or PowerShell commands fail.
+        GuestCommandError: If SSH, PowerShell commands, or data verification fails.
     """
     volume_label = prepared_plan["_shared_disk_label"]
     if not _SAFE_LABEL_RE.fullmatch(volume_label):

--- a/utilities/ssh_utils.py
+++ b/utilities/ssh_utils.py
@@ -19,9 +19,7 @@ from pytest_testconfig import config as py_config
 from rrmngmnt import Host, RootUser, User, UserWithPKey
 from simple_logger.logger import get_logger
 from timeout_sampler import TimeoutSampler, TimeoutExpiredError
-from exceptions.exceptions import GuestCommandError
-
-from exceptions.exceptions import SSHConnectionSetupError
+from exceptions.exceptions import GuestCommandError, SSHConnectionSetupError
 from libs.base_provider import BaseProvider
 
 LOGGER = get_logger(__name__)

--- a/utilities/ssh_utils.py
+++ b/utilities/ssh_utils.py
@@ -21,6 +21,7 @@ from simple_logger.logger import get_logger
 from timeout_sampler import TimeoutSampler, TimeoutExpiredError
 from exceptions.exceptions import GuestCommandError
 
+from exceptions.exceptions import SSHConnectionSetupError
 from libs.base_provider import BaseProvider
 
 LOGGER = get_logger(__name__)
@@ -129,7 +130,7 @@ class VMSSHConnection:
         # Get virtctl binary path
         virtctl_path = shutil.which("virtctl")
         if not virtctl_path:
-            raise RuntimeError(
+            raise SSHConnectionSetupError(
                 "virtctl command not found in PATH. "
                 "Please install virtctl before running the test suite. "
                 "See README.md for installation instructions."

--- a/utilities/vmware_guest_operations.py
+++ b/utilities/vmware_guest_operations.py
@@ -103,9 +103,6 @@ def run_command_in_vmware_guest(
             if process_info:
                 break
 
-        if process_info.exitCode != 0:
-            raise GuestCommandError(f"Guest process {pid} on VM {vm.name} exited with code {process_info.exitCode}")
-
         transfer_info = fm.InitiateFileTransferFromGuest(vm=vm, auth=auth, guestFilePath=output_file)
         url = transfer_info.url
         if "://*" in url:
@@ -115,7 +112,14 @@ def run_command_in_vmware_guest(
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
         with urllib.request.urlopen(url, context=ctx, timeout=_FILE_TRANSFER_TIMEOUT) as resp:
-            return resp.read().decode("utf-8")
+            output = resp.read().decode("utf-8")
+
+        if process_info.exitCode != 0:
+            raise GuestCommandError(
+                f"Guest process {pid} on VM {vm.name} exited with code {process_info.exitCode}. Output:\n{output}"
+            )
+
+        return output
     finally:
         try:
             fm.DeleteFileInGuest(vm=vm, auth=auth, filePath=output_file)


### PR DESCRIPTION
## Summary
- Add Windows shared disk migration test (tier1) for MTV-4639
- Implement dynamic NTFS labeling via VMware Guest Operations API — labels the shared disk on the source VM before migration using PowerShell commands executed through vSphere Guest Ops
- Add post-migration verification that reads/writes marker files on the shared RWX PVC from both Windows VMs via SSH
- 7-step incremental test pattern: label_shared_disk → storagemap → networkmap → plan → migrate → verify_shared_disk_data → check_vms

## Changed Files
| File | Change |
|------|--------|
| `tests/shared_disk/test_shared_disk_windows_migration.py` | New test class with 7-step incremental pattern for Windows shared disk migration |
| `utilities/shared_disk.py` | Add `label_shared_disk_on_source_windows()`, `verify_shared_disk_data_windows()`, and Windows-specific helpers (`_win_run_powershell`, `_win_ensure_shared_volume_online`, `_win_get_shared_drive_letter`, `_win_write_marker`, `_win_read_marker`, `_win_refresh_shared_disk`) |
| `tests/tests_config/config.py` | Add `test_shared_disk_windows_migration` config section with VM specs and `migrateSharedDisks` overrides |
| `utilities/vmware_guest_operations.py` | Move exit code check after output retrieval so error messages include command output |
| `libs/providers/vmware.py` | Add `find_shared_vmdk_paths()` public method wrapping internal VMDK detection |
| `AGENTS.md` | Document 7-step Windows shared-disk pattern and add `migrate_shared_disks` to VM config table |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NTFS label–based, end-to-end “cold” shared-disk migration verification for Windows VMs, with marker exchange validation.
  * Expanded shared-disk migration tests to cover multiple Windows VMs with per-VM shared-disk toggling.
* **Bug Fixes**
  * Improved guest command error reporting by including captured guest output.
  * Improved SSH port-forward setup failures with a dedicated setup error.
* **Refactor / Tests**
  * Unified shared-disk verification flow across Linux and Windows and improved VMware detection of shared VMDKs.
  * Added a new Windows shared-disk migration test case and associated configuration/coverage.
* **Documentation**
  * Updated shared-disk test guidance and added the `shared_disk` pytest marker in the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->