### PR TITLE
MTV-5824: Add ca.crt provider secret field migration test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -784,6 +784,9 @@ class TestNameHere:
 - **Class-level parametrization**: Use `class_plan_config` with `indirect=True`
 - **Shared state**: Store resources on class with `self.__class__.attribute`
 - **Test ordering**: Use `@pytest.mark.incremental` at class level for sequential test dependencies
+- **4-step plan-readiness pattern**: verify_\<feature\> -> storagemap -> networkmap -> plan
+  Used when the feature under test is exercised during provider/plan creation (e.g., CA cert field
+  validation). No migration is executed — plan readiness proves the feature works.
 - **5-step pattern**: storagemap -> networkmap -> plan -> migrate -> check_vms
 - **6-step shared-disk pattern (Linux)**: storagemap -> networkmap -> plan -> migrate -> verify_shared_disk_data -> check_vms
   Shared disk tests insert `test_verify_shared_disk_data` before `test_check_vms`. This step mounts,
@@ -988,6 +991,7 @@ Class-scoped teardown fixture that cleans up migrated VMs after each test class 
 | `copyoffload`           | Copy-offload (XCOPY) tests             |
 | `copyoffload_sanity`    | Copy-offload sanity subset             |
 | `copyoffload_snapshots` | Copy-offload snapshot tests (vSphere)  |
+| `ca_crt`                | CA certificate field (ca.crt) tests    |
 | `vsphere`               | VMware vSphere provider-specific tests |
 | `shared_disk`           | Shared disk migration tests            |
 
@@ -997,6 +1001,7 @@ Provider-type skip logic runs in `pytest_collection_modifyitems` (in `conftest.p
 
 - Warm migration tests → `@pytest.mark.warm`
 - Copy-offload snapshot tests → `@pytest.mark.copyoffload_snapshots`
+- CA certificate field tests → `@pytest.mark.ca_crt`
 
 See the documented hook in `conftest.py` for how to add new provider-type skip rules.
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ The Quick Start runs **tier0** tests (smoke tests). You can run other test categ
 | `copyoffload_sanity` | Copy-offload sanity subset (see below) | Quick copy-offload validation |
 | `warm` | Warm migrations (VMs stay running) | Specific scenario testing |
 | `shared_disk` | Shared disk migration tests | Testing shared disk between VMs |
+| `ca_crt` | CA certificate field (ca.crt) in provider secrets | Testing ca.crt secret field support |
 | `vsphere` | VMware vSphere provider-specific tests | Tests specific to vSphere provider |
 | `upgrade` | Migration across MTV operator upgrades | Validating upgrade compatibility |
 

--- a/conftest.py
+++ b/conftest.py
@@ -45,11 +45,7 @@ from utilities.copyoffload_constants import FORKLIFT_CONTROLLER_NAME
 from libs.base_provider import BaseProvider
 from libs.forklift_inventory import (
     ForkliftInventory,
-    OpenshiftForkliftInventory,
-    OpenstackForliftinventory,
-    OvaForkliftInventory,
-    OvirtForkliftInventory,
-    VsphereForkliftInventory,
+    create_forklift_inventory,
 )
 from libs.providers.openshift import OCPProvider
 from libs.providers.vmware import VMWareProvider
@@ -338,6 +334,19 @@ def pytest_collection_modifyitems(session, config, items):
                         or "vsphere" in item.keywords
                     ):
                         item.add_marker(vsphere_only_skip)
+
+            # Skip CA cert tests for providers that don't use CA certificates.
+            ca_cert_unsupported = (
+                Provider.ProviderType.OPENSHIFT,
+                Provider.ProviderType.OVA,
+            )
+            if source_provider_type in ca_cert_unsupported:
+                ca_cert_skip = pytest.mark.skip(
+                    reason=f"{source_provider_type} does not use CA certificates in provider secrets"
+                )
+                for item in items:
+                    if "ca_crt" in item.keywords:
+                        item.add_marker(ca_cert_skip)
 
     _session_store = get_fixture_store(session)
     vms_for_current_session: set = set()
@@ -1493,24 +1502,7 @@ def forklift_pods_state(ocp_admin_client: DynamicClient) -> None:
 def source_provider_inventory(
     ocp_admin_client: DynamicClient, mtv_namespace: str, source_provider: BaseProvider
 ) -> ForkliftInventory:
-    if not source_provider.ocp_resource:
-        raise ValueError("source_provider.ocp_resource is not set")
-
-    providers = {
-        Provider.ProviderType.OVA: OvaForkliftInventory,
-        Provider.ProviderType.RHV: OvirtForkliftInventory,
-        Provider.ProviderType.VSPHERE: VsphereForkliftInventory,
-        Provider.ProviderType.OPENSHIFT: OpenshiftForkliftInventory,
-        Provider.ProviderType.OPENSTACK: OpenstackForliftinventory,
-    }
-    provider_instance = providers.get(source_provider.type)
-
-    if not provider_instance:
-        raise ValueError(f"Provider {source_provider.type} not implemented")
-
-    return provider_instance(  # type: ignore
-        client=ocp_admin_client, namespace=mtv_namespace, provider_name=source_provider.ocp_resource.name
-    )
+    return create_forklift_inventory(client=ocp_admin_client, mtv_namespace=mtv_namespace, provider=source_provider)
 
 
 @pytest.fixture(scope="session")

--- a/libs/forklift_inventory.py
+++ b/libs/forklift_inventory.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import abc
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from kubernetes.dynamic.client import DynamicClient
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
@@ -8,7 +10,59 @@ from ocp_resources.route import Route
 from simple_logger.logger import get_logger
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+if TYPE_CHECKING:
+    from libs.base_provider import BaseProvider
+
+PROVIDER_INVENTORY_MAP: dict[str, type[ForkliftInventory]] = {}
+
 LOGGER = get_logger(__name__)
+
+
+def _register_inventory_classes() -> None:
+    """Populate PROVIDER_INVENTORY_MAP after all classes are defined."""
+    PROVIDER_INVENTORY_MAP.update({
+        Provider.ProviderType.OVA: OvaForkliftInventory,
+        Provider.ProviderType.RHV: OvirtForkliftInventory,
+        Provider.ProviderType.VSPHERE: VsphereForkliftInventory,
+        Provider.ProviderType.OPENSHIFT: OpenshiftForkliftInventory,
+        Provider.ProviderType.OPENSTACK: OpenstackForliftinventory,
+    })
+
+
+def create_forklift_inventory(
+    client: DynamicClient,
+    mtv_namespace: str,
+    provider: BaseProvider,
+) -> ForkliftInventory:
+    """ForkliftInventory instance for the given provider.
+
+    Args:
+        client (DynamicClient): OpenShift admin client.
+        mtv_namespace (str): MTV operator namespace.
+        provider (BaseProvider): Source provider instance.
+
+    Returns:
+        ForkliftInventory: Inventory instance matching the provider type.
+
+    Raises:
+        ValueError: If ocp_resource is not set on the provider.
+        ValueError: If the provider type is not supported.
+    """
+    if not PROVIDER_INVENTORY_MAP:
+        _register_inventory_classes()
+
+    if provider.ocp_resource is None:
+        raise ValueError(f"{provider.type} provider ocp_resource is not set")
+
+    provider_class = PROVIDER_INVENTORY_MAP.get(provider.type)
+    if provider_class is None:
+        raise ValueError(f"Provider {provider.type} not implemented")
+
+    return provider_class(  # type: ignore[call-arg]  # Subclasses use 'namespace' param while base class uses 'mtv_namespace'
+        client=client,
+        namespace=mtv_namespace,
+        provider_name=provider.ocp_resource.name,
+    )
 
 
 class ForkliftInventory(abc.ABC):

--- a/pytest.ini
+++ b/pytest.ini
@@ -31,6 +31,7 @@ markers =
     openstack: OpenStack provider-specific tests
     openshift: OpenShift provider-specific tests
     deep_inspection: Deep Inspection / Conversion CR tests (vSphere only)
+    ca_crt: CA certificate field (ca.crt) provider secret tests
     upgrade: MTV operator upgrade tests
 
 junit_logging = all

--- a/tests/cold/conftest.py
+++ b/tests/cold/conftest.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from libs.base_provider import BaseProvider
+from libs.forklift_inventory import ForkliftInventory, create_forklift_inventory
+from utilities.utils import create_source_provider, get_value_from_py_config
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+    from ocp_resources.secret import Secret
+
+
+@pytest.fixture(scope="class")  # Class-scoped: separate provider per test class with ca.crt in the secret
+def ca_crt_source_provider(
+    fixture_store: dict[str, Any],
+    session_uuid: str,
+    source_provider_data: dict[str, Any],
+    target_namespace: str,
+    ocp_admin_client: DynamicClient,
+    tmp_path_factory: pytest.TempPathFactory,
+    destination_ocp_secret: Secret,  # pragma: allowlist secret
+) -> Generator[BaseProvider, None, None]:
+    """Source provider configured with ca.crt secret field instead of cacert.
+
+    Uses the standard Kubernetes ca.crt convention (MTV-4561) to verify
+    Forklift accepts the new field name for CA certificates.
+
+    Args:
+        fixture_store (dict[str, Any]): Session fixture store for resource tracking.
+        session_uuid (str): Unique session identifier.
+        source_provider_data (dict[str, Any]): Provider configuration from providers JSON.
+        target_namespace (str): Target namespace for provider resources.
+        ocp_admin_client (DynamicClient): OpenShift admin client.
+        tmp_path_factory (pytest.TempPathFactory): Temp directory factory for cert files.
+        destination_ocp_secret (Secret): Destination OCP cluster secret.
+
+    Yields:
+        BaseProvider: Source provider instance using ca.crt in the secret.
+    """
+    with create_source_provider(
+        fixture_store=fixture_store,
+        session_uuid=session_uuid,
+        source_provider_data=source_provider_data,
+        namespace=target_namespace,
+        admin_client=ocp_admin_client,
+        tmp_dir=tmp_path_factory,
+        ocp_admin_client=ocp_admin_client,
+        destination_ocp_secret=destination_ocp_secret,
+        insecure=get_value_from_py_config(value="source_provider_insecure_skip_verify"),
+        ca_cert_key="ca.crt",
+    ) as _source_provider:
+        yield _source_provider
+
+    _source_provider.disconnect()
+
+
+@pytest.fixture(scope="class")  # Class-scoped: must match ca_crt_source_provider scope
+def ca_crt_source_provider_inventory(
+    ocp_admin_client: DynamicClient,
+    mtv_namespace: str,
+    ca_crt_source_provider: BaseProvider,
+) -> ForkliftInventory:
+    """ForkliftInventory instance for the ca.crt provider.
+
+    Args:
+        ocp_admin_client (DynamicClient): OpenShift admin client.
+        mtv_namespace (str): MTV operator namespace.
+        ca_crt_source_provider (BaseProvider): Source provider using ca.crt secret field.
+
+    Returns:
+        ForkliftInventory: Inventory instance for the ca.crt provider.
+    """
+    return create_forklift_inventory(
+        client=ocp_admin_client,
+        mtv_namespace=mtv_namespace,
+        provider=ca_crt_source_provider,
+    )

--- a/tests/cold/test_ca_crt_migration.py
+++ b/tests/cold/test_ca_crt_migration.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from ocp_resources.network_map import NetworkMap
+from ocp_resources.plan import Plan
+from ocp_resources.secret import Secret
+from ocp_resources.storage_map import StorageMap
+from pytest_testconfig import config as py_config
+
+from libs.base_provider import BaseProvider
+from libs.forklift_inventory import ForkliftInventory
+from utilities.mtv_migration import (
+    create_plan_resource,
+    get_network_migration_map,
+    get_storage_migration_map,
+)
+from utilities.utils import get_value_from_py_config, populate_vm_ids
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from libs.providers.openshift import OCPProvider
+
+
+@pytest.mark.vsphere
+@pytest.mark.rhv
+@pytest.mark.openstack
+@pytest.mark.esxi
+@pytest.mark.ca_crt
+@pytest.mark.tier1
+@pytest.mark.incremental
+@pytest.mark.skipif(
+    get_value_from_py_config("source_provider_insecure_skip_verify"),
+    reason="CA cert field test requires SSL verification enabled (insecure=false)",
+)
+@pytest.mark.parametrize(
+    "class_plan_config",
+    [
+        pytest.param(
+            py_config["tests_params"]["test_ca_crt_cold_migration"],
+        )
+    ],
+    indirect=True,
+    ids=["MTV-4561-ca-crt"],
+)
+class TestCaCrtColdMigration:
+    """Verify Forklift accepts ca.crt secret field instead of cacert (MTV-4561).
+
+    Validates provider connectivity and plan readiness using the standard
+    Kubernetes ca.crt convention. No migration is executed — the CA cert
+    code path (getTLSConfig -> Authenticate) runs during provider creation,
+    so plan readiness proves the feature works.
+    """
+
+    storage_map: StorageMap
+    network_map: NetworkMap
+    plan_resource: Plan
+
+    @pytest.mark.usefixtures("prepared_plan")
+    def test_verify_ca_crt_secret(
+        self,
+        ca_crt_source_provider: BaseProvider,
+        ocp_admin_client: DynamicClient,
+    ) -> None:
+        """Verify the provider secret uses ca.crt field instead of cacert."""
+        assert ca_crt_source_provider.ocp_resource is not None, "ocp_resource is not set"
+        secret_ref = ca_crt_source_provider.ocp_resource.instance.spec.secret
+        secret = Secret(
+            client=ocp_admin_client,
+            name=secret_ref.name,
+            namespace=secret_ref.namespace,
+        )
+        secret_data_keys = list(secret.instance.data.keys())
+        assert "ca.crt" in secret_data_keys, f"Expected 'ca.crt' in secret keys, got: {secret_data_keys}"
+        assert "cacert" not in secret_data_keys, (
+            f"Legacy 'cacert' should not be in secret keys, got: {secret_data_keys}"
+        )
+
+    def test_create_storagemap(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: DynamicClient,
+        ca_crt_source_provider: BaseProvider,
+        destination_provider: OCPProvider,
+        ca_crt_source_provider_inventory: ForkliftInventory,
+        target_namespace: str,
+    ) -> None:
+        """Create StorageMap resource for migration."""
+        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.storage_map = get_storage_migration_map(
+            fixture_store=fixture_store,
+            source_provider=ca_crt_source_provider,
+            destination_provider=destination_provider,
+            source_provider_inventory=ca_crt_source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            vms=vms,
+        )
+        assert self.storage_map, "StorageMap creation failed"
+
+    def test_create_networkmap(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: DynamicClient,
+        ca_crt_source_provider: BaseProvider,
+        destination_provider: OCPProvider,
+        ca_crt_source_provider_inventory: ForkliftInventory,
+        target_namespace: str,
+        multus_network_name: dict[str, str],
+    ) -> None:
+        """Create NetworkMap resource for migration."""
+        vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+        self.__class__.network_map = get_network_migration_map(
+            fixture_store=fixture_store,
+            source_provider=ca_crt_source_provider,
+            destination_provider=destination_provider,
+            source_provider_inventory=ca_crt_source_provider_inventory,
+            ocp_admin_client=ocp_admin_client,
+            target_namespace=target_namespace,
+            multus_network_name=multus_network_name,
+            vms=vms,
+        )
+        assert self.network_map, "NetworkMap creation failed"
+
+    def test_create_plan(
+        self,
+        prepared_plan: dict[str, Any],
+        fixture_store: dict[str, Any],
+        ocp_admin_client: DynamicClient,
+        ca_crt_source_provider: BaseProvider,
+        destination_provider: OCPProvider,
+        target_namespace: str,
+        ca_crt_source_provider_inventory: ForkliftInventory,
+    ) -> None:
+        """Create MTV Plan CR resource."""
+        populate_vm_ids(prepared_plan, ca_crt_source_provider_inventory)
+
+        self.__class__.plan_resource = create_plan_resource(
+            ocp_admin_client=ocp_admin_client,
+            fixture_store=fixture_store,
+            source_provider=ca_crt_source_provider,
+            destination_provider=destination_provider,
+            storage_map=self.storage_map,
+            network_map=self.network_map,
+            virtual_machines_list=prepared_plan["virtual_machines"],
+            target_namespace=target_namespace,
+            warm_migration=prepared_plan.get("warm_migration", False),
+        )
+        assert self.plan_resource, "Plan creation failed"

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -721,6 +721,12 @@ tests_params: dict = {
         "migrate_shared_disks": True,
         "target_power_state": "on",
     },
+    "test_ca_crt_cold_migration": {
+        "virtual_machines": [
+            {"name": "mtv-tests-rhel8", "guest_agent": True},
+        ],
+        "warm_migration": False,
+    },
     "test_upgrade_cold_migration": {
         "virtual_machines": [
             {"name": "mtv-tests-rhel8", "guest_agent": True},

--- a/utilities/utils.py
+++ b/utilities/utils.py
@@ -160,21 +160,23 @@ def _fetch_and_store_cacert(
     secret_string_data: dict[str, Any],
     tmp_dir: pytest.TempPathFactory | None,
     session_uuid: str,
+    ca_cert_key: str = "cacert",
 ) -> Path:
-    """
-    Fetch CA certificate from provider and store in secret data.
+    """Fetch CA certificate from provider and store in secret data.
 
     Args:
-        source_provider_data: Provider configuration with 'type' and 'fqdn'
-        secret_string_data: Secret data dict to add 'cacert' to
-        tmp_dir: Temp directory factory for cert file
-        session_uuid: Session UUID for unique filename
+        source_provider_data (dict[str, Any]): Provider configuration with 'type' and 'fqdn'.
+        secret_string_data (dict[str, Any]): Secret data dict to store the certificate in.
+        tmp_dir (pytest.TempPathFactory | None): Temp directory factory for cert file.
+        session_uuid (str): Session UUID for unique filename.
+        ca_cert_key (str): Secret field name for the CA certificate. Defaults to "cacert".
+            Use "ca.crt" for the standard Kubernetes convention (MTV-4561).
 
     Returns:
-        Path to the certificate file
+        Path: Path to the certificate file.
 
     Raises:
-        ValueError: If tmp_dir is not provided
+        ValueError: If tmp_dir is not provided.
     """
     source_provider_type = source_provider_data["type"]
     if not tmp_dir:
@@ -184,7 +186,7 @@ def _fetch_and_store_cacert(
         provider_fqdn=source_provider_data["fqdn"],
         cert_file=tmp_dir.mktemp(source_provider_type.upper()) / f"{source_provider_type}_{session_uuid}_cert.crt",
     )
-    secret_string_data["cacert"] = cert_file.read_text()
+    secret_string_data[ca_cert_key] = cert_file.read_text()
     return cert_file
 
 
@@ -273,7 +275,30 @@ def create_source_provider(
     destination_ocp_secret: Secret,
     insecure: bool,
     tmp_dir: pytest.TempPathFactory | None = None,
+    ca_cert_key: str = "cacert",
 ) -> Generator[BaseProvider, None, None]:
+    """Source provider configured and registered as a Forklift Provider CR.
+
+    Args:
+        source_provider_data (dict[str, Any]): Provider configuration from providers JSON.
+        namespace (str): Target namespace for the provider resources.
+        admin_client (DynamicClient): OpenShift client for resource creation.
+        session_uuid (str): Unique session identifier for resource naming.
+        fixture_store (dict[str, Any]): Session fixture store for resource tracking and teardown.
+        ocp_admin_client (DynamicClient): OpenShift admin client for cluster operations.
+        destination_ocp_secret (Secret): Secret for the destination OCP provider.
+        insecure (bool): Whether to skip TLS certificate verification.
+        tmp_dir (pytest.TempPathFactory | None): Temporary directory factory for storing fetched certificates.
+        ca_cert_key (str): Secret data key for the CA certificate (default: "cacert",
+            use "ca.crt" to test the alternative secret field name).
+
+    Yields:
+        BaseProvider: Connected source provider instance.
+
+    Raises:
+        ValueError: If the provider type cannot be determined from source_provider_data.
+        ValueError: If the provider secret fails to create.
+    """
     # common
     source_provider_secret: Secret | None = None
     source_provider: Any = None
@@ -320,7 +345,7 @@ def create_source_provider(
                 LOGGER.info(f"Normalized VMware API URL for TLS: '{original_url}' -> '{normalized_url}'")
             source_provider_data_copy["api_url"] = normalized_url
             secret_string_data["url"] = normalized_url
-            _fetch_and_store_cacert(source_provider_data_copy, secret_string_data, tmp_dir, session_uuid)
+            _fetch_and_store_cacert(source_provider_data_copy, secret_string_data, tmp_dir, session_uuid, ca_cert_key)
 
     elif rhv_provider(provider_data=source_provider_data_copy):
         source_provider = OvirtProvider
@@ -330,7 +355,9 @@ def create_source_provider(
 
         # Always fetch CA certificate for RHV provider, even when insecure=True
         # The certificate is required for imageio connection, insecureSkipVerify controls validation
-        cert_file = _fetch_and_store_cacert(source_provider_data_copy, secret_string_data, tmp_dir, session_uuid)
+        cert_file = _fetch_and_store_cacert(
+            source_provider_data_copy, secret_string_data, tmp_dir, session_uuid, ca_cert_key
+        )
 
         # Set ca_file in provider_args only when secure mode (for SDK connection)
         if not insecure:
@@ -355,7 +382,7 @@ def create_source_provider(
 
         # Add CA certificate for SSL verification
         if not insecure:
-            _fetch_and_store_cacert(source_provider_data_copy, secret_string_data, tmp_dir, session_uuid)
+            _fetch_and_store_cacert(source_provider_data_copy, secret_string_data, tmp_dir, session_uuid, ca_cert_key)
 
     elif ova_provider(provider_data=source_provider_data_copy):
         source_provider = OVAProvider


### PR DESCRIPTION
## Summary
- Add tier1 cold migration test verifying Forklift accepts the standard Kubernetes `ca.crt` field in provider secrets (MTV-4561 / kubev2v/forklift#5549)
- Add `ca_cert_key` parameter to `_fetch_and_store_cacert()` and `create_source_provider()` — defaults to `"cacert"`, no behavior change for existing tests
- Supported providers: vSphere, ESXi, RHV, OpenStack (skipped for OpenShift/OVA via collection-time hook)
- Uses existing `mtv-tests-rhel8` VM — no new infrastructure required

## Test plan
- [ ] Run `uv run pytest -s --collect-only -m tier1` and verify `TestCaCrtColdMigration` is collected
- [ ] Run with vSphere provider: confirm provider secret has `ca.crt` key (not `cacert`)
- [ ] Run regression alongside `TestSanityColdMtvMigration` to verify legacy `cacert` path is unaffected
- [ ] Verify test is skipped for OpenShift/OVA providers
- [ ] Verify test is skipped when `source_provider_insecure_skip_verify=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for storing provider CA certificates under a configurable secret field (e.g., `ca.crt`).
  * Added cold-migration planning coverage to validate CA certificate field readiness.

* **Bug Fixes**
  * Improved consistency of CA certificate handling across supported provider types.
  * Adjusted test collection to skip `ca_crt`-tagged tests for non-applicable provider kinds.

* **Tests**
  * Added new cold migration test verifying CA certificate secret contents plus readiness steps (storagemap → networkmap → plan).

* **Documentation**
  * Updated marker documentation and test guidance to include the new `ca_crt` category.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->