### PR TITLE
feat: add firmware, secure boot, and TPM verification to post-migration checks

### DIFF
--- a/libs/base_provider.py
+++ b/libs/base_provider.py
@@ -26,6 +26,7 @@ class BaseProvider(abc.ABC):
         "memory_in_mb": 0,
         "snapshots_data": [],
         "power_state": "",
+        "firmware": {},
     }
 
     def __init__(

--- a/libs/providers/openshift.py
+++ b/libs/providers/openshift.py
@@ -200,7 +200,7 @@ class OCPProvider(BaseProvider):
 
         devices: dict[str, Any] = domain.get("devices", {})
         tpm_config: dict[str, Any] | None = devices.get("tpm")
-        firmware_info["tpm_present"] = tpm_config is not None
+        firmware_info["tpm_present"] = bool(tpm_config.get("persistent")) if tpm_config else False
 
         bootloader: dict[str, Any] | None = firmware_spec.get("bootloader") if firmware_spec else None
         efi_config: dict[str, Any] | None = bootloader.get("efi") if bootloader else None

--- a/libs/providers/openshift.py
+++ b/libs/providers/openshift.py
@@ -122,7 +122,8 @@ class OCPProvider(BaseProvider):
             dict[str, Any]: VM information dictionary.
 
         Raises:
-            ValueError: If `ocp_resource` is not set or VM fails to start.
+            ValueError: If `ocp_resource` is not set, VM fails to start,
+                or secureBoot is missing from an EFI VM's firmware config.
             InvalidVMNameError: If destination VM name fails Kubernetes validation.
         """
         if not self.ocp_resource:

--- a/libs/providers/openshift.py
+++ b/libs/providers/openshift.py
@@ -192,8 +192,27 @@ class OCPProvider(BaseProvider):
         )
 
         # Serial number (from firmware) - for serial preservation verification
-        firmware_spec: dict[str, Any] | None = cnv_vm.instance.spec.template.spec.domain.get("firmware")
+        domain: dict[str, Any] = cnv_vm.instance.spec.template.spec.domain
+
+        firmware_spec: dict[str, Any] | None = domain.get("firmware")
         result_vm_info["serial"] = firmware_spec.get("serial") if firmware_spec else None
+        firmware_info: dict[str, Any] = {}
+
+        devices: dict[str, Any] = domain.get("devices", {})
+        tpm_config: dict[str, Any] | None = devices.get("tpm")
+        firmware_info["tpm_present"] = bool(tpm_config.get("persistent")) if tpm_config else False
+
+        bootloader = firmware_spec.get("bootloader") if firmware_spec else None
+        efi_config = bootloader.get("efi") if bootloader else None
+
+        if efi_config:
+            firmware_info["boot_firmware"] = "efi"
+            firmware_info["secure_boot"] = efi_config["secureBoot"]
+        else:
+            firmware_info["boot_firmware"] = "bios"
+            firmware_info["secure_boot"] = False
+
+        result_vm_info["firmware"] = firmware_info
 
         # Extract template once to avoid duplicate attribute access
         template = cnv_vm.instance.spec.template

--- a/libs/providers/openshift.py
+++ b/libs/providers/openshift.py
@@ -196,10 +196,12 @@ class OCPProvider(BaseProvider):
 
         firmware_spec: dict[str, Any] | None = domain.get("firmware")
         result_vm_info["serial"] = firmware_spec.get("serial") if firmware_spec else None
+        # Firmware configuration — boot type, secure boot, TPM
         firmware_info: dict[str, Any] = {}
 
         devices: dict[str, Any] = domain.get("devices", {})
         tpm_config: dict[str, Any] | None = devices.get("tpm")
+        # KubeVirt adds empty tpm: {} even for VMs without TPM; only persistent=true indicates actual TPM
         firmware_info["tpm_present"] = bool(tpm_config.get("persistent")) if tpm_config else False
 
         bootloader: dict[str, Any] | None = firmware_spec.get("bootloader") if firmware_spec else None

--- a/libs/providers/openshift.py
+++ b/libs/providers/openshift.py
@@ -200,14 +200,17 @@ class OCPProvider(BaseProvider):
 
         devices: dict[str, Any] = domain.get("devices", {})
         tpm_config: dict[str, Any] | None = devices.get("tpm")
-        firmware_info["tpm_present"] = bool(tpm_config.get("persistent")) if tpm_config else False
+        firmware_info["tpm_present"] = tpm_config is not None
 
-        bootloader = firmware_spec.get("bootloader") if firmware_spec else None
-        efi_config = bootloader.get("efi") if bootloader else None
+        bootloader: dict[str, Any] | None = firmware_spec.get("bootloader") if firmware_spec else None
+        efi_config: dict[str, Any] | None = bootloader.get("efi") if bootloader else None
 
         if efi_config:
             firmware_info["boot_firmware"] = "efi"
-            firmware_info["secure_boot"] = efi_config["secureBoot"]
+            secure_boot: bool | None = efi_config.get("secureBoot")
+            if secure_boot is None:
+                raise ValueError(f"secureBoot not found in EFI config for VM '{cnv_vm_name}'")
+            firmware_info["secure_boot"] = secure_boot
         else:
             firmware_info["boot_firmware"] = "bios"
             firmware_info["secure_boot"] = False

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -735,6 +735,8 @@ class VMWareProvider(BaseProvider):
         if not boot_firmware_raw:
             raise ValueError(f"firmware attribute is missing or empty for VM '{_vm.name}'")
         boot_firmware: str = boot_firmware_raw.lower()
+        if boot_firmware not in ("bios", "efi"):
+            raise ValueError(f"Unexpected firmware type '{boot_firmware}' for VM '{_vm.name}'")
         firmware_info["boot_firmware"] = boot_firmware
         boot_options: vim.vm.BootOptions | None = vm_config.bootOptions
         if boot_firmware == "efi":

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -736,10 +736,9 @@ class VMWareProvider(BaseProvider):
         boot_firmware: str = boot_firmware_raw.lower()
         firmware_info["boot_firmware"] = boot_firmware
         boot_options: vim.vm.BootOptions | None = vm_config.bootOptions
-        if boot_firmware == "efi" and boot_options is None:
-            raise ValueError(f"bootOptions is None for EFI VM '{_vm.name}' — expected boot configuration")
         if boot_firmware == "efi":
-            assert boot_options is not None  # Guaranteed by ValueError check above
+            if boot_options is None:
+                raise ValueError(f"bootOptions is None for EFI VM '{_vm.name}' — expected boot configuration")
             firmware_info["secure_boot"] = boot_options.efiSecureBootEnabled
         else:
             firmware_info["secure_boot"] = False

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -730,8 +730,11 @@ class VMWareProvider(BaseProvider):
         result_vm_info["win_os"] = "win" in vm_config.guestId
 
         firmware_info: dict[str, Any] = {}
-        firmware_info["boot_firmware"] = vm_config.firmware
+        boot_firmware = vm_config.firmware.lower()
+        firmware_info["boot_firmware"] = boot_firmware
         boot_options = vm_config.bootOptions
+        if boot_firmware == "efi" and boot_options is None:
+            raise ValueError(f"bootOptions is None for EFI VM '{_vm.name}' — expected boot configuration")
         firmware_info["secure_boot"] = boot_options.efiSecureBootEnabled if boot_options else False
 
         firmware_info["tpm_present"] = any(

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -730,9 +730,12 @@ class VMWareProvider(BaseProvider):
         result_vm_info["win_os"] = "win" in vm_config.guestId
 
         firmware_info: dict[str, Any] = {}
-        boot_firmware = vm_config.firmware.lower()
+        boot_firmware_raw: str | None = vm_config.firmware
+        if not boot_firmware_raw:
+            raise ValueError(f"firmware attribute is missing or empty for VM '{_vm.name}'")
+        boot_firmware: str = boot_firmware_raw.lower()
         firmware_info["boot_firmware"] = boot_firmware
-        boot_options = vm_config.bootOptions
+        boot_options: vim.vm.BootOptions | None = vm_config.bootOptions
         if boot_firmware == "efi" and boot_options is None:
             raise ValueError(f"bootOptions is None for EFI VM '{_vm.name}' — expected boot configuration")
         firmware_info["secure_boot"] = boot_options.efiSecureBootEnabled if boot_options else False

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -729,6 +729,16 @@ class VMWareProvider(BaseProvider):
         # Guest OS
         result_vm_info["win_os"] = "win" in vm_config.guestId
 
+        firmware_info: dict[str, Any] = {}
+        firmware_info["boot_firmware"] = vm_config.firmware
+        boot_options = vm_config.bootOptions
+        firmware_info["secure_boot"] = boot_options.efiSecureBootEnabled if boot_options else False
+
+        firmware_info["tpm_present"] = any(
+            isinstance(device, vim.vm.device.VirtualTPM) for device in vm_config.hardware.device
+        )
+        result_vm_info["firmware"] = firmware_info
+
         # Power state
         if _vm.runtime.powerState == "poweredOn":
             result_vm_info["power_state"] = "on"

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -738,7 +738,11 @@ class VMWareProvider(BaseProvider):
         boot_options: vim.vm.BootOptions | None = vm_config.bootOptions
         if boot_firmware == "efi" and boot_options is None:
             raise ValueError(f"bootOptions is None for EFI VM '{_vm.name}' — expected boot configuration")
-        firmware_info["secure_boot"] = boot_options.efiSecureBootEnabled if boot_options else False
+        if boot_firmware == "efi":
+            assert boot_options is not None  # Guaranteed by ValueError check above
+            firmware_info["secure_boot"] = boot_options.efiSecureBootEnabled
+        else:
+            firmware_info["secure_boot"] = False
 
         firmware_info["tpm_present"] = any(
             isinstance(device, vim.vm.device.VirtualTPM) for device in vm_config.hardware.device

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -729,6 +729,7 @@ class VMWareProvider(BaseProvider):
         # Guest OS
         result_vm_info["win_os"] = "win" in vm_config.guestId
 
+        # Firmware configuration — boot type, secure boot, TPM
         firmware_info: dict[str, Any] = {}
         boot_firmware_raw: str | None = vm_config.firmware
         if not boot_firmware_raw:

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -1266,6 +1266,7 @@ def check_boot_configuration(source_vm: dict[str, Any], destination_vm: dict[str
 
     Raises:
         AssertionError: If firmware type, secure boot, or TPM settings don't match.
+        KeyError: If required firmware keys are missing in source or destination VM info.
     """
     source_firmware: dict[str, Any] = source_vm["firmware"]
     dest_firmware: dict[str, Any] = destination_vm["firmware"]
@@ -1668,7 +1669,7 @@ def check_vms(
 
             try:
                 check_boot_configuration(source_vm=source_vm, destination_vm=destination_vm)
-            except (AssertionError, KeyError) as exp:
+            except Exception as exp:
                 res[vm_name].append(f"check_boot_configuration - {str(exp)}")
 
         # Group 4: RHV-specific checks

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -1276,11 +1276,12 @@ def check_boot_configuration(source_vm: dict[str, Any], destination_vm: dict[str
         ("secure_boot", "Secure boot"),
         ("tpm_present", "TPM"),
     ]
+    mismatches: list[str] = []
     for key, label in firmware_checks:
-        assert source_firmware[key] == dest_firmware[key], (
-            f"{label} mismatch for VM '{destination_vm['name']}': "
-            f"source={source_firmware[key]}, destination={dest_firmware[key]}"
-        )
+        if source_firmware[key] != dest_firmware[key]:
+            mismatches.append(f"{label}: source={source_firmware[key]}, destination={dest_firmware[key]}")
+    if mismatches:
+        raise AssertionError(f"Firmware mismatch for VM '{destination_vm['name']}': {'; '.join(mismatches)}")
 
     LOGGER.info(
         f"Firmware checks passed for VM '{destination_vm['name']}': "

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -1257,8 +1257,8 @@ def check_serial_preservation(
         LOGGER.info(f"Serial preserved correctly (OCP {ocp_version} < 4.20, plain UUID): {dest_serial}")
 
 
-def check_firmware_and_tpm(source_vm: dict[str, Any], destination_vm: dict[str, Any]) -> None:
-    """Verify firmware type and TPM settings are preserved after migration.
+def check_boot_configuration(source_vm: dict[str, Any], destination_vm: dict[str, Any]) -> None:
+    """Verify boot configuration is preserved after migration.
 
     Args:
         source_vm: Source VM info dictionary with firmware data.
@@ -1270,7 +1270,11 @@ def check_firmware_and_tpm(source_vm: dict[str, Any], destination_vm: dict[str, 
     source_firmware: dict[str, Any] = source_vm["firmware"]
     dest_firmware: dict[str, Any] = destination_vm["firmware"]
 
-    firmware_checks = [("boot_firmware", "Boot firmware"), ("secure_boot", "Secure boot"), ("tpm_present", "TPM")]
+    firmware_checks: list[tuple[str, str]] = [
+        ("boot_firmware", "Boot firmware"),
+        ("secure_boot", "Secure boot"),
+        ("tpm_present", "TPM"),
+    ]
     for key, label in firmware_checks:
         assert source_firmware[key] == dest_firmware[key], (
             f"{label} mismatch for VM '{destination_vm['name']}': "
@@ -1663,9 +1667,9 @@ def check_vms(
                 res[vm_name].append(f"check_serial_preservation - {str(exp)}")
 
             try:
-                check_firmware_and_tpm(source_vm=source_vm, destination_vm=destination_vm)
-            except Exception as exp:
-                res[vm_name].append(f"check_firmware_and_tpm - {str(exp)}")
+                check_boot_configuration(source_vm=source_vm, destination_vm=destination_vm)
+            except (AssertionError, KeyError) as exp:
+                res[vm_name].append(f"check_boot_configuration - {str(exp)}")
 
         # Group 4: RHV-specific checks
         if rhv_provider(source_provider_data) and isinstance(source_provider, OvirtProvider):

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -1170,6 +1170,45 @@ def check_serial_preservation(
         LOGGER.info(f"Serial preserved correctly (OCP {ocp_version} < 4.20, plain UUID): {dest_serial}")
 
 
+def check_firmware_and_tpm(source_vm: dict[str, Any], destination_vm: dict[str, Any]) -> None:
+    """Verify firmware type and TPM settings are preserved after migration.
+
+    Args:
+        source_vm: Source VM info dictionary with firmware data.
+        destination_vm: Destination VM info dictionary with firmware data.
+
+    Raises:
+        AssertionError: If firmware type, secure boot, or TPM settings don't match.
+    """
+    source_firmware: dict[str, Any] = source_vm["firmware"]
+    dest_firmware: dict[str, Any] = destination_vm["firmware"]
+
+    source_boot = source_firmware["boot_firmware"]
+    dest_boot = dest_firmware["boot_firmware"]
+    assert source_boot == dest_boot, (
+        f"Boot firmware mismatch for VM '{destination_vm['name']}': source={source_boot}, destination={dest_boot}"
+    )
+
+    source_secure_boot = source_firmware["secure_boot"]
+    dest_secure_boot = dest_firmware["secure_boot"]
+    assert source_secure_boot == dest_secure_boot, (
+        f"Secure boot mismatch for VM '{destination_vm['name']}': "
+        f"source={source_secure_boot}, destination={dest_secure_boot}"
+    )
+
+    source_tpm = source_firmware["tpm_present"]
+    dest_tpm = dest_firmware["tpm_present"]
+    assert source_tpm == dest_tpm, (
+        f"TPM mismatch for VM '{destination_vm['name']}': "
+        f"source tpm_present={source_tpm}, destination tpm_present={dest_tpm}"
+    )
+
+    LOGGER.info(
+        f"Firmware checks passed for VM '{destination_vm['name']}': "
+        f"boot={dest_boot}, secure_boot={dest_secure_boot}, tpm={dest_tpm}"
+    )
+
+
 def check_vm_node_placement(
     destination_vm: dict[str, Any],
     expected_node: str,
@@ -1547,6 +1586,11 @@ def check_vms(
                 )
             except Exception as exp:
                 res[vm_name].append(f"check_serial_preservation - {str(exp)}")
+
+            try:
+                check_firmware_and_tpm(source_vm=source_vm, destination_vm=destination_vm)
+            except Exception as exp:
+                res[vm_name].append(f"check_firmware_and_tpm - {str(exp)}")
 
         # Group 4: RHV-specific checks
         if rhv_provider(source_provider_data) and isinstance(source_provider, OvirtProvider):

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -1183,29 +1183,17 @@ def check_firmware_and_tpm(source_vm: dict[str, Any], destination_vm: dict[str, 
     source_firmware: dict[str, Any] = source_vm["firmware"]
     dest_firmware: dict[str, Any] = destination_vm["firmware"]
 
-    source_boot = source_firmware["boot_firmware"]
-    dest_boot = dest_firmware["boot_firmware"]
-    assert source_boot == dest_boot, (
-        f"Boot firmware mismatch for VM '{destination_vm['name']}': source={source_boot}, destination={dest_boot}"
-    )
-
-    source_secure_boot = source_firmware["secure_boot"]
-    dest_secure_boot = dest_firmware["secure_boot"]
-    assert source_secure_boot == dest_secure_boot, (
-        f"Secure boot mismatch for VM '{destination_vm['name']}': "
-        f"source={source_secure_boot}, destination={dest_secure_boot}"
-    )
-
-    source_tpm = source_firmware["tpm_present"]
-    dest_tpm = dest_firmware["tpm_present"]
-    assert source_tpm == dest_tpm, (
-        f"TPM mismatch for VM '{destination_vm['name']}': "
-        f"source tpm_present={source_tpm}, destination tpm_present={dest_tpm}"
-    )
+    firmware_checks = [("boot_firmware", "Boot firmware"), ("secure_boot", "Secure boot"), ("tpm_present", "TPM")]
+    for key, label in firmware_checks:
+        assert source_firmware[key] == dest_firmware[key], (
+            f"{label} mismatch for VM '{destination_vm['name']}': "
+            f"source={source_firmware[key]}, destination={dest_firmware[key]}"
+        )
 
     LOGGER.info(
         f"Firmware checks passed for VM '{destination_vm['name']}': "
-        f"boot={dest_boot}, secure_boot={dest_secure_boot}, tpm={dest_tpm}"
+        f"boot={dest_firmware['boot_firmware']}, secure_boot={dest_firmware['secure_boot']}, "
+        f"tpm={dest_firmware['tpm_present']}"
     )
 
 


### PR DESCRIPTION
Add firmware metadata extraction and verification to ensure migration preserves boot configuration:

- VMware provider: extract boot firmware type (bios/efi), secure boot setting, and TPM presence from source VMs
- OpenShift provider: extract the same firmware metadata from destination CNV VMs
- post_migration: add check_boot_configuration() that asserts source and destination firmware type, secure boot, and TPM all match
- Wire into existing check_vms() flow so vSphere migration tests automatically validate firmware preservation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VM details now include firmware information for supported providers: boot firmware type (EFI/BIOS), secure boot status, TPM presence, and serial when available.
* **Bug Fixes**
  * Improved and standardized firmware/serial extraction logic, with stricter validation for EFI secure boot/boot options where required.
* **Tests / Validation**
  * Enhanced post-migration checks to compare boot firmware, secure boot, and TPM settings between source and destination, with clearer per-VM mismatch reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->