### PR TITLE
feat: add nested virtualization and VBS verification checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -648,7 +648,9 @@ if not vm_id:
 
 - `.get("key", <default>)` on `py_config`, `plan`, `tests_params`, or any dict we control
 - `.get("key")` on external data without validation afterward
-- Using `False` as default when the key is always present in config (exception: `warm_migration` and `copyoffload` are optional flags — `.get()` is correct)
+- Using `False` as default when the key is always present in config
+  (exception: `warm_migration`, `copyoffload`, and `enable_nested_virtualization`
+  are optional flags — `.get()` is correct)
 
 ### Provider Config Key Access (MUST)
 

--- a/libs/providers/openshift.py
+++ b/libs/providers/openshift.py
@@ -286,7 +286,8 @@ class OCPProvider(BaseProvider):
         result_vm_info["cpu"]["num_cores"] = cnv_vm.vmi.instance.spec.domain.cpu.cores
         result_vm_info["cpu"]["num_sockets"] = cnv_vm.vmi.instance.spec.domain.cpu.sockets
         # CPU features are read from the VM template spec (not VMI) because features are configured at template level.
-        result_vm_info["cpu"]["features"] = list(cnv_vm.instance.spec.template.spec.domain.cpu.get("features", []))
+        template_cpu: dict[str, Any] = cnv_vm.instance.spec.template.spec.domain.get("cpu", {})
+        result_vm_info["cpu"]["features"] = list(template_cpu.get("features", []))
 
         result_vm_info["memory_in_mb"] = int(
             humanfriendly.parse_size(

--- a/libs/providers/openshift.py
+++ b/libs/providers/openshift.py
@@ -285,6 +285,8 @@ class OCPProvider(BaseProvider):
 
         result_vm_info["cpu"]["num_cores"] = cnv_vm.vmi.instance.spec.domain.cpu.cores
         result_vm_info["cpu"]["num_sockets"] = cnv_vm.vmi.instance.spec.domain.cpu.sockets
+        # CPU features are read from the VM template spec (not VMI) because features are configured at template level.
+        result_vm_info["cpu"]["features"] = list(cnv_vm.instance.spec.template.spec.domain.cpu.get("features", []))
 
         result_vm_info["memory_in_mb"] = int(
             humanfriendly.parse_size(

--- a/tests/cold/test_cold_migration_comprehensive.py
+++ b/tests/cold/test_cold_migration_comprehensive.py
@@ -47,6 +47,8 @@ class TestColdMigrationComprehensive:
     - Target VM labels
     - Target VM affinity rules
     - Custom target namespace for VMs
+    - Nested virtualization disabled (vmx/svm CPU features)
+    - VBS (Virtualization Based Security) verification
     """
 
     storage_map: StorageMap
@@ -176,6 +178,7 @@ class TestColdMigrationComprehensive:
             target_labels=target_vm_labels["vm_labels"],
             target_affinity=prepared_plan["target_affinity"],
             vm_target_namespace=prepared_plan["vm_target_namespace"],
+            enable_nested_virtualization=prepared_plan["enable_nested_virtualization"],
         )
         assert self.plan_resource, "Plan creation failed"
 

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -584,6 +584,7 @@ tests_params: dict = {
         "warm_migration": True,
         "target_power_state": "on",
         "preserve_static_ips": True,
+        "enable_nested_virtualization": False,
         "vm_target_namespace": f"mtv-vms-warm-comprehensive-{uuid.uuid4().hex[:4]}",
         "multus_namespace": "default",  # Cross-namespace NAD access
         "pvc_name_template": '{{ .FileName | trimSuffix ".vmdk" | replace "_" "-" }}-{{.DiskIndex}}',
@@ -618,6 +619,7 @@ tests_params: dict = {
         "warm_migration": False,
         "target_power_state": "on",
         "preserve_static_ips": True,
+        "enable_nested_virtualization": False,
         "pvc_name_template": "{{.VmName}}-disk-{{.DiskIndex}}",
         "pvc_name_template_use_generate_name": False,
         "target_node_selector": {

--- a/tests/warm/test_warm_migration_comprehensive.py
+++ b/tests/warm/test_warm_migration_comprehensive.py
@@ -46,6 +46,7 @@ class TestWarmMigrationComprehensive:
 
     Tests the following MTV 2.10.0+ features:
     - Static IP preservation
+    - Nested virtualization and VBS verification
     - Custom VM target namespace
     - Custom PVC naming template
     - PVC naming with generateName
@@ -186,6 +187,7 @@ class TestWarmMigrationComprehensive:
             pvc_name_template_use_generate_name=prepared_plan["pvc_name_template_use_generate_name"],
             target_labels=target_vm_labels["vm_labels"],
             target_affinity=prepared_plan["target_affinity"],
+            enable_nested_virtualization=prepared_plan["enable_nested_virtualization"],
         )
         assert self.plan_resource, "Plan creation failed"
 

--- a/utilities/mtv_migration.py
+++ b/utilities/mtv_migration.py
@@ -145,6 +145,7 @@ def create_plan_resource(
     vm_target_namespace: str | None = None,
     migrate_shared_disks: bool | None = None,
     target_power_state: str | None = None,
+    enable_nested_virtualization: bool | None = None,
 ) -> Plan:
     """Create MTV Plan CR resource.
 
@@ -178,6 +179,8 @@ def create_plan_resource(
         migrate_shared_disks (bool | None): Whether to migrate shared disks at plan level. True enables shared disk
             migration for all VMs by default. Individual VMs can override via per-VM migrateSharedDisks. Defaults to None.
         target_power_state (str | None): Target power state for VMs after migration (e.g., 'on', 'off'). Defaults to None.
+        enable_nested_virtualization (bool | None): Whether to enable nested virtualization on migrated VMs.
+            When False, CPU features vmx/svm are disabled. Defaults to None (not set on Plan CR).
 
     Returns:
         Plan: The created Plan CR resource.
@@ -241,6 +244,9 @@ def create_plan_resource(
 
     if migrate_shared_disks is not None:
         plan_kwargs["migrate_shared_disks"] = migrate_shared_disks
+
+    if enable_nested_virtualization is not None:
+        plan_kwargs["enable_nested_virtualization"] = enable_nested_virtualization
 
     # Add copy-offload specific parameters if enabled
     if copyoffload:

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -772,6 +772,88 @@ def check_cpu(source_vm: dict[str, Any], destination_vm: dict[str, Any]) -> None
         raise AssertionError(f"CPU failed checks: {failed_checks}")
 
 
+def check_cpu_features(
+    destination_vm: dict[str, Any],
+    expected_features: list[dict[str, str]],
+) -> None:
+    """Verify CPU feature policies on the migrated VM.
+
+    Args:
+        destination_vm (dict[str, Any]): Destination VM data dictionary
+        expected_features (list[dict[str, str]]): Expected CPU features with policies,
+            e.g. [{"name": "vmx", "policy": "disable"}, {"name": "svm", "policy": "disable"}]
+
+    Raises:
+        AssertionError: If CPU features do not match expected configuration
+    """
+    actual_features: list[dict[str, Any]] = destination_vm["cpu"].get("features", [])
+    for expected in expected_features:
+        feature_name = expected["name"]
+        expected_policy = expected["policy"]
+        matching = [f for f in actual_features if f.get("name") == feature_name]
+        assert matching, f"CPU feature '{feature_name}' not found on migrated VM. Actual features: {actual_features}"
+        actual_policy = matching[0].get("policy")
+        assert actual_policy is not None, (
+            f"CPU feature '{feature_name}' found but has no 'policy' field. Feature data: {matching[0]}"
+        )
+        assert actual_policy == expected_policy, (
+            f"CPU feature '{feature_name}' has policy '{actual_policy}', expected '{expected_policy}'"
+        )
+
+    LOGGER.info(f"CPU feature verification passed: {[f['name'] + '=' + f['policy'] for f in expected_features]}")
+
+
+def check_vbs_status(
+    vm_name: str,
+    vm_ssh_connections: SSHConnectionManager,
+    source_provider_data: dict[str, Any],
+    source_vm_info: dict[str, Any],
+) -> None:
+    """Verify Virtualization Based Security (VBS) is disabled on a Windows VM.
+
+    Connects via SSH to the Windows guest and queries the DeviceGuard WMI class
+    to confirm VirtualizationBasedSecurityStatus is 0 (disabled).
+
+    Args:
+        vm_name (str): Name of the VM to check
+        vm_ssh_connections (SSHConnectionManager): SSH connections manager
+        source_provider_data (dict[str, Any]): Source provider data with Windows credentials
+        source_vm_info (dict[str, Any]): VM information including OS type
+
+    Raises:
+        ConnectionError: If SSH connection cannot be established to the VM
+        ValueError: If credentials are not found or VBS status command fails
+        AssertionError: If VBS is still running (status 2)
+    """
+    ssh_username, ssh_password = get_ssh_credentials_from_provider_config(source_provider_data, source_vm_info)
+    ssh_conn = vm_ssh_connections.create(vm_name=vm_name, username=ssh_username, password=ssh_password)
+
+    vbs_cmd = [
+        "powershell",
+        "-Command",
+        "(Get-CimInstance -Namespace root\\Microsoft\\Windows\\DeviceGuard "
+        "-ClassName Win32_DeviceGuard).VirtualizationBasedSecurityStatus",
+    ]
+
+    with ssh_conn:
+        if not ssh_conn.rrmngmnt_host:
+            raise ConnectionError(f"SSH connection not established for VM {vm_name}")
+
+        executor = ssh_conn.rrmngmnt_host.executor(user=ssh_conn.rrmngmnt_user)
+        executor.port = ssh_conn.local_port
+        rc, stdout, err = executor.run_cmd(vbs_cmd)
+
+        if rc != 0:
+            raise ValueError(f"VBS status command failed on VM '{vm_name}'. rc={rc}, stderr={err}")
+
+        vbs_status = stdout.strip()
+        assert vbs_status != "2", (
+            f"VBS is still running on VM '{vm_name}'. "
+            f"VirtualizationBasedSecurityStatus: {vbs_status}, expected: not 2 (not running)"
+        )
+        LOGGER.info(f"VBS verification passed for VM '{vm_name}': VirtualizationBasedSecurityStatus={vbs_status}")
+
+
 def check_memory(source_vm: dict[str, Any], destination_vm: dict[str, Any]) -> None:
     assert source_vm["memory_in_mb"] == destination_vm["memory_in_mb"]
 
@@ -1571,6 +1653,34 @@ def check_vms(
                 )
             except Exception as exp:
                 res[vm_name].append(f"check_vm_affinity - {str(exp)}")
+
+        # Nested virtualization checks — when enableNestedVirtualization is explicitly False
+        # Supported by all providers except OpenShift (OCP→OCP)
+        if (
+            plan.get("enable_nested_virtualization") is False
+            and source_provider.type != Provider.ProviderType.OPENSHIFT
+        ):
+            try:
+                check_cpu_features(
+                    destination_vm=destination_vm,
+                    expected_features=[
+                        {"name": "vmx", "policy": "disable"},
+                        {"name": "svm", "policy": "disable"},
+                    ],
+                )
+            except Exception as exp:
+                res[vm_name].append(f"check_cpu_features - {str(exp)}")
+
+            if vm_ssh_connections and destination_vm.get("power_state") == "on" and source_vm.get("win_os"):
+                try:
+                    check_vbs_status(
+                        vm_name=destination_vm_name,
+                        vm_ssh_connections=vm_ssh_connections,
+                        source_provider_data=source_provider_data,
+                        source_vm_info=source_vm,
+                    )
+                except Exception as exp:
+                    res[vm_name].append(f"check_vbs_status - {str(exp)}")
 
         # Group 2: Source-comparison checks — require real source VM data (OVA has none)
         if source_provider.type != Provider.ProviderType.OVA:

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -809,10 +809,12 @@ def check_vbs_status(
     source_provider_data: dict[str, Any],
     source_vm_info: dict[str, Any],
 ) -> None:
-    """Verify Virtualization Based Security (VBS) is disabled on a Windows VM.
+    """Verify Virtualization Based Security (VBS) is not running on a Windows VM.
 
     Connects via SSH to the Windows guest and queries the DeviceGuard WMI class
-    to confirm VirtualizationBasedSecurityStatus is 0 (disabled).
+    to confirm VirtualizationBasedSecurityStatus is not 2 (running).
+    Status 1 (enabled but not running) is expected when nested virtualization
+    extensions are disabled at the emulator level.
 
     Args:
         vm_name (str): Name of the VM to check
@@ -1570,7 +1572,7 @@ def check_vms(
                 res[vm_name].append(f"check_guest_agent - {str(exp)}")
 
         # SSH connectivity check - only when destination VM is powered on
-        if vm_ssh_connections and destination_vm.get("power_state") == "on":
+        if vm_ssh_connections is not None and destination_vm.get("power_state") == "on":
             try:
                 check_ssh_connectivity(
                     vm_name=destination_vm_name,
@@ -1621,7 +1623,7 @@ def check_vms(
                     )
                 except Exception as exp:
                     res[vm_name].append(f"check_nic_name_preservation - {str(exp)}")
-        elif vm_ssh_connections:
+        elif vm_ssh_connections is not None:
             LOGGER.info(
                 f"Skipping SSH connectivity check for VM {vm_name} - destination VM is not powered on "
                 f"(power_state: {destination_vm.get('power_state', 'unknown')})"
@@ -1671,7 +1673,7 @@ def check_vms(
             except Exception as exp:
                 res[vm_name].append(f"check_cpu_features - {str(exp)}")
 
-            if vm_ssh_connections and destination_vm.get("power_state") == "on" and source_vm.get("win_os"):
+            if vm_ssh_connections is not None and destination_vm.get("power_state") == "on" and source_vm.get("win_os"):
                 try:
                     check_vbs_status(
                         vm_name=destination_vm_name,

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -1675,7 +1675,11 @@ def check_vms(
             except Exception as exp:
                 res[vm_name].append(f"check_cpu_features - {str(exp)}")
 
-            if vm_ssh_connections is not None and destination_vm.get("power_state") == "on" and source_vm.get("win_os"):
+            if (
+                vm_ssh_connections is not None
+                and destination_vm.get("power_state") == "on"
+                and source_vm.get("win_os", False)
+            ):
                 try:
                     check_vbs_status(
                         vm_name=destination_vm_name,

--- a/utilities/post_migration.py
+++ b/utilities/post_migration.py
@@ -37,6 +37,12 @@ KUBERNETES_MAX_GENERATE_NAME_PREFIX_LENGTH: int = 58
 
 _LUKS_FSTYPE = "crypto_LUKS"  # lsblk filesystem-type identifier for LUKS partitions
 
+_VBS_STATUS_RUNNING = "2"
+_NESTED_VIRT_DISABLED_FEATURES: list[dict[str, str]] = [
+    {"name": "vmx", "policy": "disable"},
+    {"name": "svm", "policy": "disable"},
+]
+
 
 def get_ssh_credentials_from_provider_config(
     source_provider_data: dict[str, Any], source_vm_info: dict[str, Any]
@@ -849,7 +855,7 @@ def check_vbs_status(
             raise ValueError(f"VBS status command failed on VM '{vm_name}'. rc={rc}, stderr={err}")
 
         vbs_status = stdout.strip()
-        assert vbs_status != "2", (
+        assert vbs_status != _VBS_STATUS_RUNNING, (
             f"VBS is still running on VM '{vm_name}'. "
             f"VirtualizationBasedSecurityStatus: {vbs_status}, expected: not 2 (not running)"
         )
@@ -1656,8 +1662,7 @@ def check_vms(
             except Exception as exp:
                 res[vm_name].append(f"check_vm_affinity - {str(exp)}")
 
-        # Nested virtualization checks — when enableNestedVirtualization is explicitly False
-        # Supported by all providers except OpenShift (OCP→OCP)
+        # Nested virtualization checks not applicable for OCP→OCP migrations
         if (
             plan.get("enable_nested_virtualization") is False
             and source_provider.type != Provider.ProviderType.OPENSHIFT
@@ -1665,10 +1670,7 @@ def check_vms(
             try:
                 check_cpu_features(
                     destination_vm=destination_vm,
-                    expected_features=[
-                        {"name": "vmx", "policy": "disable"},
-                        {"name": "svm", "policy": "disable"},
-                    ],
+                    expected_features=_NESTED_VIRT_DISABLED_FEATURES,
                 )
             except Exception as exp:
                 res[vm_name].append(f"check_cpu_features - {str(exp)}")


### PR DESCRIPTION
Add support for enableNestedVirtualization plan parameter and post-migration verification of CPU features and VBS status.

- Add enable_nested_virtualization parameter to create_plan_resource()
- Add check_cpu_features() to verify vmx/svm CPU feature policies
- Add check_vbs_status() to verify VBS is disabled on Windows VMs
- Collect CPU features in OCP provider vm_dict()
- Integrate into TestColdMigrationComprehensive
- Integrate into TestWarmMigrationComprehensive
- Add enable_nested_virtualization config for both comprehensive tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now include nested virtualization settings in generated migration plans.
* **Bug Fixes**
  * Improved CPU feature reporting by pulling feature definitions from VM template configuration, making nested-virtualization feature detection more accurate.
* **Validation Updates**
  * Post-migration checks now confirm expected CPU feature policies when nested virtualization is disabled, and (for Windows when SSH is available) verify Virtualization-Based Security (VBS) status.
* **Tests**
  * Updated warm/cold comprehensive coverage to explicitly include nested virtualization and VBS checks, and wired the nested virtualization setting into plan creation.
* **Documentation**
  * Updated test guidance to allow deterministic configuration handling for nested virtualization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->