### PR TITLE
fix: correct LUKS test suite description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,8 +591,10 @@ For technical implementation details, see the
 
 ## LUKS Disk Encryption Migration (tier1)
 
-The test suite includes migration tests for VMs with LUKS-encrypted disks. These tests verify that
-LUKS encryption is preserved after cold migration by checking `lsblk` output on the migrated VM.
+This test suite verifies MTV's ability to handle the migration of LUKS-encrypted VMs. It ensures
+that MTV correctly processes decryption secrets during the ImageConversion phase, validating both
+successful migration when correct credentials are provided and expected failure when invalid
+credentials are used.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -591,10 +591,9 @@ For technical implementation details, see the
 
 ## LUKS Disk Encryption Migration (tier1)
 
-This test suite verifies MTV's ability to handle the migration of LUKS-encrypted VMs. It ensures
-that MTV correctly processes decryption secrets during the ImageConversion phase, validating both
-successful migration when correct credentials are provided and expected failure when invalid
-credentials are used.
+This test suite verifies MTV's ability to migrate LUKS-encrypted VMs. It validates both
+successful cold migration when the correct decryption passphrase is provided, and expected
+failure at the ImageConversion phase when invalid credentials are used.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ For technical implementation details, see the
 
 This test suite verifies MTV's ability to migrate LUKS-encrypted VMs. It validates both
 successful cold migration when the correct decryption passphrase is provided, and expected
-failure at the ImageConversion phase when invalid credentials are used.
+failure at the ImageConversion phase when an incorrect LUKS decryption passphrase is used.
 
 ### Configuration
 


### PR DESCRIPTION
## Summary
- Fix the LUKS test suite description in README to accurately reflect test purpose
- Previous description framed the tests as verifying disk encryption preservation
- Actual purpose: validating MTV's credential handling during ImageConversion — both successful migration with correct credentials and expected failure with invalid credentials

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the LUKS disk encryption migration section to clarify what the suite validates during VM migration.
  * The description now focuses on decryption secret handling during the image conversion phase, covering both successful migrations with correct credentials and expected failures with invalid credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->