### PR TITLE
fix(warm): restrict ClusterRole tests to vSphere provider only

### DIFF
--- a/tests/warm/test_mtv_warm_clusterrole_migration.py
+++ b/tests/warm/test_mtv_warm_clusterrole_migration.py
@@ -16,6 +16,7 @@ from utilities.post_migration import check_vms
 from utilities.utils import get_value_from_py_config, populate_vm_ids
 
 
+@pytest.mark.vsphere
 @pytest.mark.remote
 @pytest.mark.tier1
 @pytest.mark.warm
@@ -129,6 +130,7 @@ class TestClusterroleWarmMtvMigration:
             )
 
 
+@pytest.mark.vsphere
 @pytest.mark.remote
 @pytest.mark.tier0
 @pytest.mark.warm


### PR DESCRIPTION
## Summary
- Add `@pytest.mark.vsphere` to both ClusterRole test classes
- The SCC requirement for `forklift-migrator-role` is vSphere-specific — on RHV the migration succeeds without SCC, causing the negative test to incorrectly fail
- The existing `pytest_collection_modifyitems` hook auto-skips items with the `vsphere` keyword for non-vSphere providers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added vSphere test coverage to two warm cluster role migration test scenarios, including both the SCC and non-SCC variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->