### PR TITLE
fix: support vSphere template cloning with configurable resource pool

### DIFF
--- a/.providers.json.example
+++ b/.providers.json.example
@@ -56,7 +56,16 @@
       "non_xcopy_datastore_id": "datastore-99999",
 
       "default_vm_name": "rhel9-template",
-      "resource_pool": "<VSPHERE RESOURCE POOL NAME>",
+
+      # Optional: vSphere resource pool for VM placement during cloning
+      # Priority order for resource pool selection:
+      #   1. This configured value (highest priority - explicit override)
+      #   2. Target ESXi host's pool (when esxi_host is set - automatic compatibility)
+      #   3. Source VM/template's pool (preserve original location)
+      #   4. Cluster-wide search with datastore compatibility check (fallback)
+      # Example: "e2e-qe-resources" or leave commented to use automatic selection
+      # "resource_pool": "<VSPHERE RESOURCE POOL NAME>",
+
       "storage_hostname": "storage.example.com",
       "storage_username": "admin",
       "storage_password": "your-password-here",  # pragma: allowlist secret

--- a/conftest.py
+++ b/conftest.py
@@ -811,6 +811,7 @@ def multus_network_name(
     source_provider: BaseProvider,
     source_provider_inventory: ForkliftInventory,
     class_plan_config: dict[str, Any],
+    prepared_plan: dict[str, Any],
     request: pytest.FixtureRequest,
 ) -> dict[str, str]:
     """Create NADs based on network requirements with unique names per test class.
@@ -830,6 +831,7 @@ def multus_network_name(
         source_provider (BaseProvider): Source provider instance
         source_provider_inventory (ForkliftInventory): Source provider inventory
         class_plan_config (dict[str, Any]): Plan configuration from class parametrization
+        prepared_plan (dict[str, Any]): Prepared plan with cloned VM names
         request (pytest.FixtureRequest): Pytest fixture request
 
     Returns:
@@ -853,9 +855,10 @@ def multus_network_name(
     else:
         nad_namespace = target_namespace
 
-    # Get VM/template names from the class plan config
-    vms = [vm["name"] for vm in class_plan_config["virtual_machines"]]
-    LOGGER.info(f"Found VMs from class config: {vms}")
+    # Get cloned VM names from prepared_plan (not original template names from class_plan_config)
+    # After cloning, prepared_plan has the actual VM names (e.g., auto-zzsx-xcopy-template-test-...)
+    vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
+    LOGGER.info(f"Found VMs from prepared plan: {vms}")
 
     # Query networks using provider abstraction (handles templates vs VMs internally)
     networks = source_provider.get_vm_or_template_networks(names=vms, inventory=source_provider_inventory)

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -1302,7 +1302,7 @@ class VMWareProvider(BaseProvider):
         # 1. Explicit config (copyoffload.resource_pool) - user override
         # 2. Target host's pool - automatic compatibility when host is specified
         # 3. Source VM's pool - preserve original location
-        # 4. Cluster search - fallback for templates
+        # 4. Cluster search - fallback for templates (with datastore compatibility check)
         configured_pool_name = self.copyoffload_config.get("resource_pool") if self.copyoffload_config else None
         if configured_pool_name:
             # Use explicitly configured resource pool (highest priority)
@@ -1317,13 +1317,24 @@ class VMWareProvider(BaseProvider):
             relocate_spec.pool = source_vm.resourcePool
             LOGGER.info("Using source VM's resource pool")
         else:
-            # If source is a template with no pool, find a suitable one from the cluster
+            # If source is a template with no pool, find a compatible one from the cluster
+            # Verify datastore accessibility to avoid incompatible pool selection
             container = self.view_manager.CreateContainerView(self.content.rootFolder, [vim.ComputeResource], True)
-            view = container.view  # type: ignore[attr-defined]
-            relocate_spec.pool = next((cr.resourcePool for cr in view if cr.resourcePool), None)
-            container.Destroy()
-            if relocate_spec.pool:
-                LOGGER.info("Using resource pool from cluster compute resource")
+            try:
+                view = container.view  # type: ignore[attr-defined]
+                for compute_resource in view:
+                    if not compute_resource.resourcePool:
+                        continue
+                    # Verify target datastore is accessible from this compute resource
+                    if target_datastore in compute_resource.datastore:
+                        relocate_spec.pool = compute_resource.resourcePool
+                        LOGGER.info(
+                            f"Using resource pool from compute resource '{compute_resource.name}' "
+                            f"(datastore compatible)"
+                        )
+                        break
+            finally:
+                container.Destroy()
 
         if not relocate_spec.pool:
             raise VmCloneError("Could not determine a valid resource pool for cloning.")
@@ -1868,19 +1879,28 @@ class VMWareProvider(BaseProvider):
 
         Returns:
             List of network mappings in format [{"name": "network-name"}, ...]
+
+        Raises:
+            ValueError: If networks not found or VM/template lookup fails
         """
         try:
             # Try Forklift inventory first (works for VMs)
             return inventory.vms_networks_mappings(vms=names)
         except ValueError as e:
-            # If VM not found in inventory, try direct vSphere query (for templates)
-            if "not found" in str(e):
+            # Only fall back to vSphere API if VM not found in inventory (template case)
+            # Propagate network mapping failures (no networks on VM) immediately
+            error_msg = str(e)
+            if "not found" in error_msg and "Available VMs:" in error_msg:
                 LOGGER.info(f"VM(s) not found in Forklift inventory, querying vSphere directly for templates: {names}")
                 return self._get_networks_from_vsphere(names=names)
+            # Re-raise if it's a different error (e.g., "Networks not found for vms")
             raise
 
     def _get_networks_from_vsphere(self, names: list[str]) -> list[dict[str, str]]:
         """Query vSphere directly for network information from VMs or templates.
+
+        Reuses _get_network_name_from_device() to properly handle all network
+        backing types including DVS portgroups.
 
         Args:
             names: List of VM/template names to query
@@ -1895,38 +1915,17 @@ class VMWareProvider(BaseProvider):
 
         for vm_name in names:
             vm_obj = self.get_obj([vim.VirtualMachine], vm_name)
-            LOGGER.info(
-                f"Querying networks for VM/template: {vm_name} (isTemplate: {vm_obj.config.template if vm_obj.config else 'unknown'})"
-            )
 
             if not vm_obj.config or not vm_obj.config.hardware or not vm_obj.config.hardware.device:
                 LOGGER.warning(f"VM/template '{vm_name}' has no hardware devices configured")
                 continue
 
-            device_count = len(vm_obj.config.hardware.device)
-            nic_count = 0
-            LOGGER.info(f"Found {device_count} hardware devices on '{vm_name}'")
-
             for device in vm_obj.config.hardware.device:
                 if isinstance(device, vim.vm.device.VirtualEthernetCard):
-                    nic_count += 1
-                    # Extract network name from backing info
-                    backing = device.backing
-                    LOGGER.info(
-                        f"Found NIC: {device.deviceInfo.label if device.deviceInfo else 'unknown'}, backing type: {type(backing).__name__}"
-                    )
-
-                    if hasattr(backing, "network") and backing.network:
-                        network_names.add(backing.network.name)
-                        LOGGER.info(f"  -> Network: {backing.network.name}")
-                    elif hasattr(backing, "deviceName"):
-                        # Standard port group
-                        network_names.add(backing.deviceName)
-                        LOGGER.info(f"  -> Device name: {backing.deviceName}")
-                    else:
-                        LOGGER.warning(f"  -> No network name found in backing info")
-
-            LOGGER.info(f"VM/template '{vm_name}': {nic_count} NICs found, {len(network_names)} unique networks")
+                    # Reuse existing method that handles all network backing types
+                    network_name = self._get_network_name_from_device(device)
+                    if network_name and network_name != "Unknown":
+                        network_names.add(network_name)
 
         if not network_names:
             raise ValueError(f"No networks found for VMs/templates {names}")

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -1895,20 +1895,38 @@ class VMWareProvider(BaseProvider):
 
         for vm_name in names:
             vm_obj = self.get_obj([vim.VirtualMachine], vm_name)
+            LOGGER.info(
+                f"Querying networks for VM/template: {vm_name} (isTemplate: {vm_obj.config.template if vm_obj.config else 'unknown'})"
+            )
 
             if not vm_obj.config or not vm_obj.config.hardware or not vm_obj.config.hardware.device:
                 LOGGER.warning(f"VM/template '{vm_name}' has no hardware devices configured")
                 continue
 
+            device_count = len(vm_obj.config.hardware.device)
+            nic_count = 0
+            LOGGER.info(f"Found {device_count} hardware devices on '{vm_name}'")
+
             for device in vm_obj.config.hardware.device:
                 if isinstance(device, vim.vm.device.VirtualEthernetCard):
+                    nic_count += 1
                     # Extract network name from backing info
                     backing = device.backing
+                    LOGGER.info(
+                        f"Found NIC: {device.deviceInfo.label if device.deviceInfo else 'unknown'}, backing type: {type(backing).__name__}"
+                    )
+
                     if hasattr(backing, "network") and backing.network:
                         network_names.add(backing.network.name)
+                        LOGGER.info(f"  -> Network: {backing.network.name}")
                     elif hasattr(backing, "deviceName"):
                         # Standard port group
                         network_names.add(backing.deviceName)
+                        LOGGER.info(f"  -> Device name: {backing.deviceName}")
+                    else:
+                        LOGGER.warning(f"  -> No network name found in backing info")
+
+            LOGGER.info(f"VM/template '{vm_name}': {nic_count} NICs found, {len(network_names)} unique networks")
 
         if not network_names:
             raise ValueError(f"No networks found for VMs/templates {names}")

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -1290,20 +1290,40 @@ class VMWareProvider(BaseProvider):
 
         relocate_spec.datastore = target_datastore  # Ensure relocate_spec uses the determined datastore
 
+        # Handle target ESXi host specification
         target_esxi_host = kwargs.get("target_esxi_host")
+        host_obj = None
         if target_esxi_host:
             host_obj = self.get_obj([vim.HostSystem], target_esxi_host)
             relocate_spec.host = host_obj
             LOGGER.info(f"Using target host from config: {host_obj.name}")
 
-        # If the source is a template, it may not have a resource pool; find a suitable one from the cluster.
-        if not source_vm.resourcePool:
+        # Determine resource pool with priority order:
+        # 1. Explicit config (copyoffload.resource_pool) - user override
+        # 2. Target host's pool - automatic compatibility when host is specified
+        # 3. Source VM's pool - preserve original location
+        # 4. Cluster search - fallback for templates
+        configured_pool_name = self.copyoffload_config.get("resource_pool") if self.copyoffload_config else None
+        if configured_pool_name:
+            # Use explicitly configured resource pool (highest priority)
+            relocate_spec.pool = self.get_obj([vim.ResourcePool], configured_pool_name)
+            LOGGER.info(f"Using configured resource pool: {configured_pool_name}")
+        elif host_obj:
+            # When a target host is specified, use its parent compute resource's pool to ensure compatibility
+            relocate_spec.pool = host_obj.parent.resourcePool
+            LOGGER.info(f"Using resource pool from target host's compute resource: {host_obj.parent.name}")
+        elif source_vm.resourcePool:
+            # Use source VM's resource pool if available
+            relocate_spec.pool = source_vm.resourcePool
+            LOGGER.info("Using source VM's resource pool")
+        else:
+            # If source is a template with no pool, find a suitable one from the cluster
             container = self.view_manager.CreateContainerView(self.content.rootFolder, [vim.ComputeResource], True)
             view = container.view  # type: ignore[attr-defined]
             relocate_spec.pool = next((cr.resourcePool for cr in view if cr.resourcePool), None)
             container.Destroy()
-        else:
-            relocate_spec.pool = source_vm.resourcePool
+            if relocate_spec.pool:
+                LOGGER.info("Using resource pool from cluster compute resource")
 
         if not relocate_spec.pool:
             raise VmCloneError("Could not determine a valid resource pool for cloning.")

--- a/libs/providers/vmware.py
+++ b/libs/providers/vmware.py
@@ -1857,16 +1857,63 @@ class VMWareProvider(BaseProvider):
         names: list[str],
         inventory: ForkliftInventory,
     ) -> list[dict[str, str]]:
-        """Delegate to Forklift inventory for VMware VMs.
+        """Get network mappings for VMs or templates.
+
+        Tries Forklift inventory first (for VMs), falls back to direct vSphere
+        API query (for templates not in inventory).
 
         Args:
-            names: List of VM names to query
+            names: List of VM/template names to query
             inventory: Forklift inventory instance
 
         Returns:
-            List of network mappings
+            List of network mappings in format [{"name": "network-name"}, ...]
         """
-        return inventory.vms_networks_mappings(vms=names)
+        try:
+            # Try Forklift inventory first (works for VMs)
+            return inventory.vms_networks_mappings(vms=names)
+        except ValueError as e:
+            # If VM not found in inventory, try direct vSphere query (for templates)
+            if "not found" in str(e):
+                LOGGER.info(f"VM(s) not found in Forklift inventory, querying vSphere directly for templates: {names}")
+                return self._get_networks_from_vsphere(names=names)
+            raise
+
+    def _get_networks_from_vsphere(self, names: list[str]) -> list[dict[str, str]]:
+        """Query vSphere directly for network information from VMs or templates.
+
+        Args:
+            names: List of VM/template names to query
+
+        Returns:
+            List of network mappings in format [{"name": "network-name"}, ...]
+
+        Raises:
+            ValueError: If no networks found or VM/template not found
+        """
+        network_names: set[str] = set()
+
+        for vm_name in names:
+            vm_obj = self.get_obj([vim.VirtualMachine], vm_name)
+
+            if not vm_obj.config or not vm_obj.config.hardware or not vm_obj.config.hardware.device:
+                LOGGER.warning(f"VM/template '{vm_name}' has no hardware devices configured")
+                continue
+
+            for device in vm_obj.config.hardware.device:
+                if isinstance(device, vim.vm.device.VirtualEthernetCard):
+                    # Extract network name from backing info
+                    backing = device.backing
+                    if hasattr(backing, "network") and backing.network:
+                        network_names.add(backing.network.name)
+                    elif hasattr(backing, "deviceName"):
+                        # Standard port group
+                        network_names.add(backing.deviceName)
+
+        if not network_names:
+            raise ValueError(f"No networks found for VMs/templates {names}")
+
+        return [{"name": name} for name in sorted(network_names)]
 
     def wait_for_vmware_guest_info(self, vm: vim.VirtualMachine, timeout: int = 60) -> bool:
         """Wait for VMware guest information to become available after VM power-on.


### PR DESCRIPTION
Add priority-based resource pool selection for VM cloning operations to support cloning from vSphere templates. Resolves DVS port conflicts by enabling template usage as clone sources.

Priority order:
1. Configured copyoffload.resource_pool (explicit override)
2. Target ESXi host's pool (automatic compatibility)
3. Source VM's pool (preserve original location)
4. Cluster-wide pool search (fallback for templates)

Related: MTV-5787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VM cloning by refining destination host and resource-pool selection, honoring configured options and providing safer fallbacks.
  * Enhanced network mapping during cloning by preferring existing inventory mappings first, then discovering networks directly when necessary.
  * Added clearer handling when expected network hardware/backing details are missing, reducing unexpected failures when no networks are found.
* **Tests**
  * Updated the Multus network fixture to base NAD naming on the prepared clone plan, aligning it with cloned VM/template names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->