### PR TITLE
feat(MTV-5979): add cancel and validation tests for standalone DI

### DIFF
--- a/tests/deep_inspection/conftest.py
+++ b/tests/deep_inspection/conftest.py
@@ -7,7 +7,12 @@ import pytest
 from ocp_resources.conversion import Conversion
 from ocp_resources.secret import Secret
 
-from utilities.deep_inspection import create_conversion_resource, create_di_connection_secret
+from utilities.deep_inspection import (
+    CONVERSION_TYPE_DEEP_INSPECTION,
+    create_conversion_resource,
+    create_di_connection_secret,
+)
+from utilities.resources import create_and_store_resource
 from utilities.utils import populate_vm_ids
 
 if TYPE_CHECKING:
@@ -46,27 +51,64 @@ def di_connection_secret(
 
 
 @pytest.fixture(scope="class")
-def di_vm_name(class_plan_config: dict[str, Any]) -> str:
-    """First VM name from the plan config.
+def di_resolved_vm(
+    class_plan_config: dict[str, Any],
+    source_provider_inventory: "ForkliftInventory",
+) -> dict[str, str]:
+    """First VM from the plan config with populated inventory ID.
 
     Args:
         class_plan_config (dict[str, Any]): Raw plan config from parametrization.
+        source_provider_inventory (ForkliftInventory): Source provider inventory.
+
+    Returns:
+        dict[str, str]: VM dict with 'name' and 'id' keys.
+    """
+    plan_config = deepcopy(class_plan_config)
+    populate_vm_ids(plan_config, source_provider_inventory)
+    return plan_config["virtual_machines"][0]
+
+
+@pytest.fixture(scope="class")
+def di_vm_name(di_resolved_vm: dict[str, str]) -> str:
+    """First VM name from the resolved plan config.
+
+    Args:
+        di_resolved_vm (dict[str, str]): Resolved VM dict with 'name' and 'id'.
 
     Returns:
         str: The VM name.
     """
-    return class_plan_config["virtual_machines"][0]["name"]
+    return di_resolved_vm["name"]
+
+
+@pytest.fixture(scope="class")
+def di_vddk_image(source_provider_data: dict[str, Any]) -> str:
+    """VDDK init container image from provider config.
+
+    Args:
+        source_provider_data (dict[str, Any]): Provider config from providers.json.
+
+    Returns:
+        str: The VDDK init container image.
+
+    Raises:
+        ValueError: If vddk_init_image is missing from provider data.
+    """
+    vddk_image = source_provider_data.get("vddk_init_image")
+    if not vddk_image:
+        raise ValueError("vddk_init_image missing from source_provider_data — required for DeepInspection")
+    return vddk_image
 
 
 @pytest.fixture(scope="class")
 def di_conversion_resource(
-    class_plan_config: dict[str, Any],
+    di_resolved_vm: dict[str, str],
     di_connection_secret: Secret,
+    di_vddk_image: str,
     fixture_store: dict[str, Any],
     ocp_admin_client: "DynamicClient",
     target_namespace: str,
-    source_provider_data: dict[str, Any],
-    source_provider_inventory: "ForkliftInventory",
 ) -> Conversion:
     """Standalone DeepInspection Conversion CR for the first VM in the plan.
 
@@ -75,34 +117,58 @@ def di_conversion_resource(
     is needed.
 
     Args:
-        class_plan_config (dict[str, Any]): Raw plan config from parametrization.
+        di_resolved_vm (dict[str, str]): Resolved VM dict with 'name' and 'id'.
         di_connection_secret (Secret): Connection secret for vSphere access.
+        di_vddk_image (str): VDDK init container image.
         fixture_store (dict[str, Any]): Resource tracking dictionary.
         ocp_admin_client (DynamicClient): OpenShift admin client.
         target_namespace (str): Namespace for the Conversion CR.
-        source_provider_data (dict[str, Any]): Provider config from providers.json.
-        source_provider_inventory (ForkliftInventory): Source provider inventory.
 
     Returns:
         Conversion: The created Conversion CR.
-
-    Raises:
-        ValueError: If vddk_init_image is missing from provider data.
     """
-    plan_config = deepcopy(class_plan_config)
-    populate_vm_ids(plan_config, source_provider_inventory)
-    vm = plan_config["virtual_machines"][0]
-
-    vddk_image = source_provider_data.get("vddk_init_image")
-    if not vddk_image:
-        raise ValueError("vddk_init_image missing from source_provider_data — required for DeepInspection")
-
     return create_conversion_resource(
         client=ocp_admin_client,
         fixture_store=fixture_store,
         connection_secret=di_connection_secret,
-        vm_id=vm["id"],
-        vm_name=vm["name"],
-        vddk_image=vddk_image,
+        vm_id=di_resolved_vm["id"],
+        vm_name=di_resolved_vm["name"],
+        vddk_image=di_vddk_image,
+        target_namespace=target_namespace,
+    )
+
+
+@pytest.fixture(scope="class")
+def di_invalid_conversion_resource(
+    di_resolved_vm: dict[str, str],
+    di_connection_secret: Secret,
+    fixture_store: dict[str, Any],
+    ocp_admin_client: "DynamicClient",
+    target_namespace: str,
+) -> Conversion:
+    """Conversion CR with missing vddkImage to trigger validation error.
+
+    Creates a DeepInspection Conversion CR without the required vddkImage
+    field. The controller's validateVDDKImage() sets a Critical condition
+    and blocks pipeline execution.
+
+    Args:
+        di_resolved_vm (dict[str, str]): Resolved VM dict with 'name' and 'id'.
+        di_connection_secret (Secret): Connection secret for vSphere access.
+        fixture_store (dict[str, Any]): Resource tracking dictionary.
+        ocp_admin_client (DynamicClient): OpenShift admin client.
+        target_namespace (str): Namespace for the Conversion CR.
+
+    Returns:
+        Conversion: The created Conversion CR (will have Critical conditions).
+    """
+    return create_and_store_resource(
+        client=ocp_admin_client,
+        fixture_store=fixture_store,
+        resource=Conversion,
+        namespace=target_namespace,
+        type=CONVERSION_TYPE_DEEP_INSPECTION,
+        connection={"secret": {"name": di_connection_secret.name, "namespace": di_connection_secret.namespace}},
+        vm={"id": di_resolved_vm["id"], "name": di_resolved_vm["name"], "type": "VirtualMachine"},
         target_namespace=target_namespace,
     )

--- a/tests/deep_inspection/conftest.py
+++ b/tests/deep_inspection/conftest.py
@@ -8,11 +8,9 @@ from ocp_resources.conversion import Conversion
 from ocp_resources.secret import Secret
 
 from utilities.deep_inspection import (
-    CONVERSION_TYPE_DEEP_INSPECTION,
     create_conversion_resource,
     create_di_connection_secret,
 )
-from utilities.resources import create_and_store_resource
 from utilities.utils import populate_vm_ids
 
 if TYPE_CHECKING:
@@ -162,13 +160,11 @@ def di_invalid_conversion_resource(
     Returns:
         Conversion: The created Conversion CR (will have Critical conditions).
     """
-    return create_and_store_resource(
+    return create_conversion_resource(
         client=ocp_admin_client,
         fixture_store=fixture_store,
-        resource=Conversion,
-        namespace=target_namespace,
-        type=CONVERSION_TYPE_DEEP_INSPECTION,
-        connection={"secret": {"name": di_connection_secret.name, "namespace": di_connection_secret.namespace}},
-        vm={"id": di_resolved_vm["id"], "name": di_resolved_vm["name"], "type": "VirtualMachine"},
+        connection_secret=di_connection_secret,
+        vm_id=di_resolved_vm["id"],
+        vm_name=di_resolved_vm["name"],
         target_namespace=target_namespace,
     )

--- a/tests/deep_inspection/conftest.py
+++ b/tests/deep_inspection/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -52,7 +51,7 @@ def di_connection_secret(
 def di_resolved_vm(
     class_plan_config: dict[str, Any],
     source_provider_inventory: "ForkliftInventory",
-) -> dict[str, str]:
+) -> dict[str, Any]:
     """First VM from the plan config with populated inventory ID.
 
     Args:
@@ -60,24 +59,23 @@ def di_resolved_vm(
         source_provider_inventory (ForkliftInventory): Source provider inventory.
 
     Returns:
-        dict[str, str]: VM dict with 'name' and 'id' keys.
+        dict[str, Any]: VM dict with 'name' and 'id' keys.
     """
-    plan_config = deepcopy(class_plan_config)
-    populate_vm_ids(plan_config, source_provider_inventory)
-    return plan_config["virtual_machines"][0]
+    populate_vm_ids(class_plan_config, source_provider_inventory)
+    return class_plan_config["virtual_machines"][0]
 
 
 @pytest.fixture(scope="class")
-def di_vm_name(di_resolved_vm: dict[str, str]) -> str:
-    """First VM name from the resolved plan config.
+def di_vm_name(class_plan_config: dict[str, Any]) -> str:
+    """First VM name from the plan config.
 
     Args:
-        di_resolved_vm (dict[str, str]): Resolved VM dict with 'name' and 'id'.
+        class_plan_config (dict[str, Any]): Raw plan config from parametrization.
 
     Returns:
         str: The VM name.
     """
-    return di_resolved_vm["name"]
+    return class_plan_config["virtual_machines"][0]["name"]
 
 
 @pytest.fixture(scope="class")
@@ -101,7 +99,7 @@ def di_vddk_image(source_provider_data: dict[str, Any]) -> str:
 
 @pytest.fixture(scope="class")
 def di_conversion_resource(
-    di_resolved_vm: dict[str, str],
+    di_resolved_vm: dict[str, Any],
     di_connection_secret: Secret,
     di_vddk_image: str,
     fixture_store: dict[str, Any],
@@ -115,7 +113,7 @@ def di_conversion_resource(
     is needed.
 
     Args:
-        di_resolved_vm (dict[str, str]): Resolved VM dict with 'name' and 'id'.
+        di_resolved_vm (dict[str, Any]): Resolved VM dict with 'name' and 'id'.
         di_connection_secret (Secret): Connection secret for vSphere access.
         di_vddk_image (str): VDDK init container image.
         fixture_store (dict[str, Any]): Resource tracking dictionary.
@@ -138,7 +136,7 @@ def di_conversion_resource(
 
 @pytest.fixture(scope="class")
 def di_invalid_conversion_resource(
-    di_resolved_vm: dict[str, str],
+    di_resolved_vm: dict[str, Any],
     di_connection_secret: Secret,
     fixture_store: dict[str, Any],
     ocp_admin_client: "DynamicClient",
@@ -151,7 +149,7 @@ def di_invalid_conversion_resource(
     and blocks pipeline execution.
 
     Args:
-        di_resolved_vm (dict[str, str]): Resolved VM dict with 'name' and 'id'.
+        di_resolved_vm (dict[str, Any]): Resolved VM dict with 'name' and 'id'.
         di_connection_secret (Secret): Connection secret for vSphere access.
         fixture_store (dict[str, Any]): Resource tracking dictionary.
         ocp_admin_client (DynamicClient): OpenShift admin client.

--- a/tests/deep_inspection/conftest.py
+++ b/tests/deep_inspection/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from ocp_resources.conversion import Conversion
 from ocp_resources.secret import Secret
 
+from libs.providers.vmware import VMWareProvider
 from utilities.deep_inspection import (
     create_conversion_resource,
     create_di_connection_secret,
@@ -48,6 +49,27 @@ def di_connection_secret(
 
 
 @pytest.fixture(scope="class")
+def vmware_source_provider(source_provider: "BaseProvider") -> VMWareProvider:
+    """Source provider validated as VMWare type.
+
+    Snapshot operations (create, list, cleanup) require vSphere-specific
+    APIs only available on VMWareProvider.
+
+    Args:
+        source_provider (BaseProvider): Source provider instance.
+
+    Returns:
+        VMWareProvider: The source provider, type-validated.
+
+    Raises:
+        TypeError: If source provider is not a VMWareProvider.
+    """
+    if not isinstance(source_provider, VMWareProvider):
+        raise TypeError(f"Snapshot operations require VMWareProvider, got {type(source_provider).__name__}")
+    return source_provider
+
+
+@pytest.fixture(scope="class")
 def di_resolved_vm(
     class_plan_config: dict[str, Any],
     source_provider_inventory: "ForkliftInventory",
@@ -59,7 +81,7 @@ def di_resolved_vm(
         source_provider_inventory (ForkliftInventory): Source provider inventory.
 
     Returns:
-        dict[str, Any]: VM dict with 'name' and 'id' keys.
+        dict[str, Any]: VM config dict with populated 'name' and 'id' keys.
     """
     populate_vm_ids(class_plan_config, source_provider_inventory)
     return class_plan_config["virtual_machines"][0]
@@ -106,14 +128,13 @@ def di_conversion_resource(
     ocp_admin_client: "DynamicClient",
     target_namespace: str,
 ) -> Conversion:
-    """Standalone DeepInspection Conversion CR for the first VM in the plan.
+    """Standalone DeepInspection Conversion CR for the first VM.
 
-    Uses class_plan_config directly (not prepared_plan) because Deep Inspection
-    only creates a snapshot, inspects, and removes the snapshot — no VM cloning
-    is needed.
+    Bypasses prepared_plan because Deep Inspection only creates a snapshot,
+    inspects, and removes it — no VM cloning is needed.
 
     Args:
-        di_resolved_vm (dict[str, Any]): Resolved VM dict with 'name' and 'id'.
+        di_resolved_vm (dict[str, Any]): VM config dict with 'name' and 'id'.
         di_connection_secret (Secret): Connection secret for vSphere access.
         di_vddk_image (str): VDDK init container image.
         fixture_store (dict[str, Any]): Resource tracking dictionary.

--- a/tests/deep_inspection/test_standalone_di.py
+++ b/tests/deep_inspection/test_standalone_di.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 from ocp_resources.conversion import Conversion
-from ocp_resources.pod import Pod
 from ocp_resources.secret import Secret
 from pytest_testconfig import config as py_config
 
@@ -16,6 +15,7 @@ from utilities.deep_inspection import (
     verify_di_results,
     wait_for_conversion_complete,
     wait_for_conversion_phase,
+    wait_for_conversion_pods,
     wait_for_conversion_pods_cleanup,
     wait_for_critical_conditions,
     wait_for_di_snapshot,
@@ -111,16 +111,9 @@ class TestStandaloneDICancel:
         )
 
     def test_cancel_conversion(self, di_vm_name: str, vmware_source_provider: "VMWareProvider") -> None:
-        """Wait for DI snapshot on source VM, then cancel the conversion."""
+        """Wait for DI pod to be running on the cluster, then cancel the conversion."""
         wait_for_di_snapshot(source_provider=vmware_source_provider, vm_name=di_vm_name)
-        pods = list(
-            Pod.get(
-                client=self.conversion.client,
-                namespace=self.conversion.namespace,
-                label_selector=f"conversion={self.conversion.name}",
-            )
-        )
-        assert pods, f"No conversion pods found before cancel for '{self.conversion.name}'"
+        wait_for_conversion_pods(conversion=self.conversion)
         cancel_conversion(conversion=self.conversion)
 
     @pytest.mark.usefixtures("class_plan_config")

--- a/tests/deep_inspection/test_standalone_di.py
+++ b/tests/deep_inspection/test_standalone_di.py
@@ -1,10 +1,31 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
 import pytest
 from ocp_resources.conversion import Conversion
+from ocp_resources.pod import Pod
+from ocp_resources.secret import Secret
 from pytest_testconfig import config as py_config
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from utilities.deep_inspection import verify_di_results, wait_for_conversion_complete
+from exceptions.exceptions import ConversionError
+from utilities.deep_inspection import (
+    DI_POD_CLEANUP_TIMEOUT,
+    DI_SNAPSHOT_CLEANUP_TIMEOUT,
+    DI_SNAPSHOT_NAME,
+    VDDK_IMAGE_NOT_SET_CONDITION,
+    cancel_conversion,
+    create_conversion_resource,
+    verify_di_results,
+    wait_for_conversion_complete,
+    wait_for_conversion_phase,
+    wait_for_di_snapshot,
+)
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+    from libs.providers.vmware import VMWareProvider
 
 
 @pytest.mark.parametrize(
@@ -49,3 +70,202 @@ class TestStandaloneDeepInspection:
     def test_verify_di_results(self, di_vm_name: str) -> None:
         """Verify inspection results contain OS info and filesystem data."""
         verify_di_results(conversion=self.conversion, vm_name=di_vm_name)
+
+
+@pytest.mark.parametrize(
+    "class_plan_config",
+    [
+        pytest.param(
+            py_config["tests_params"]["test_standalone_di_vsphere"],
+        ),
+    ],
+    indirect=True,
+    ids=["standalone-di-cancel-vsphere"],
+)
+@pytest.mark.incremental
+@pytest.mark.tier1
+@pytest.mark.deep_inspection
+@pytest.mark.vsphere
+class TestStandaloneDICancel:
+    """Cancel a running standalone Deep Inspection and re-run.
+
+    Verifies the cancel mechanism: patch status.phase to Canceled,
+    controller deletes the pod and cleans up snapshots. Then creates
+    a new DI for the same VM and verifies it succeeds.
+    """
+
+    conversion: Conversion
+    rerun_conversion: Conversion
+
+    def test_create_and_cancel_conversion(
+        self,
+        di_conversion_resource: Conversion,
+        di_vm_name: str,
+        source_provider: "VMWareProvider",
+    ) -> None:
+        """Create DI Conversion, wait for Running and snapshot, then cancel."""
+        self.__class__.conversion = di_conversion_resource
+        wait_for_conversion_phase(
+            conversion=self.conversion,
+            phase=Conversion.Status.RUNNING,
+            timeout=py_config["plan_wait_timeout"],
+        )
+        wait_for_di_snapshot(source_provider=source_provider, vm_name=di_vm_name)
+        cancel_conversion(conversion=self.conversion)
+
+    @pytest.mark.usefixtures("di_vm_name")
+    def test_verify_cancel_cleanup(self) -> None:
+        """Verify canceled conversion reaches Canceled phase and pod is cleaned up."""
+        with pytest.raises(ConversionError, match="Canceled"):
+            wait_for_conversion_complete(
+                conversion=self.conversion,
+                timeout=py_config["plan_wait_timeout"],
+            )
+
+        try:
+            for pods in TimeoutSampler(
+                wait_timeout=DI_POD_CLEANUP_TIMEOUT,
+                sleep=5,
+                func=lambda: list(
+                    Pod.get(
+                        client=self.conversion.client,
+                        namespace=self.conversion.namespace,
+                        label_selector=f"conversion={self.conversion.name}",
+                    )
+                ),
+            ):
+                if not pods:
+                    return
+        except TimeoutExpiredError:
+            remaining = list(
+                Pod.get(
+                    client=self.conversion.client,
+                    namespace=self.conversion.namespace,
+                    label_selector=f"conversion={self.conversion.name}",
+                )
+            )
+            raise AssertionError(
+                f"Conversion pods still present {DI_POD_CLEANUP_TIMEOUT}s after cancel: {[p.name for p in remaining]}"
+            )
+
+    def test_verify_snapshot_cleanup(self, di_vm_name: str, source_provider: "VMWareProvider") -> None:
+        """Verify forklift DI snapshot is removed from the source VM after cancel."""
+        vm = source_provider.get_vm_by_name(query=di_vm_name)
+        assert vm, f"VM '{di_vm_name}' not found in source provider"
+        try:
+            for snapshots in TimeoutSampler(
+                wait_timeout=DI_SNAPSHOT_CLEANUP_TIMEOUT,
+                sleep=10,
+                func=lambda: [s for s in source_provider.list_snapshots(vm) if s.name == DI_SNAPSHOT_NAME],
+            ):
+                if not snapshots:
+                    return
+        except TimeoutExpiredError:
+            remaining = [s.name for s in source_provider.list_snapshots(vm)]
+            raise AssertionError(
+                f"DI snapshot '{DI_SNAPSHOT_NAME}' still present on VM '{di_vm_name}' "
+                f"{DI_SNAPSHOT_CLEANUP_TIMEOUT}s after cancel. All snapshots: {remaining}"
+            )
+
+    def test_rerun_di_after_cancel(
+        self,
+        di_resolved_vm: dict[str, str],
+        di_connection_secret: Secret,
+        di_vddk_image: str,
+        fixture_store: dict[str, Any],
+        ocp_admin_client: "DynamicClient",
+        target_namespace: str,
+    ) -> None:
+        """Create a new DI Conversion for the same VM after cancel."""
+        self.__class__.rerun_conversion = create_conversion_resource(
+            client=ocp_admin_client,
+            fixture_store=fixture_store,
+            connection_secret=di_connection_secret,
+            vm_id=di_resolved_vm["id"],
+            vm_name=di_resolved_vm["name"],
+            vddk_image=di_vddk_image,
+            target_namespace=target_namespace,
+        )
+        assert self.rerun_conversion
+
+    @pytest.mark.usefixtures("di_vm_name")
+    def test_rerun_wait_for_completion(self) -> None:
+        """Wait for the re-run DI to complete successfully."""
+        wait_for_conversion_complete(
+            conversion=self.rerun_conversion,
+            timeout=py_config["plan_wait_timeout"],
+        )
+
+    def test_rerun_verify_results(self, di_vm_name: str) -> None:
+        """Verify the re-run DI produced valid inspection results."""
+        verify_di_results(conversion=self.rerun_conversion, vm_name=di_vm_name)
+
+
+@pytest.mark.parametrize(
+    "class_plan_config",
+    [
+        pytest.param(
+            py_config["tests_params"]["test_standalone_di_vsphere"],
+        ),
+    ],
+    indirect=True,
+    ids=["standalone-di-validation-vsphere"],
+)
+@pytest.mark.incremental
+@pytest.mark.tier1
+@pytest.mark.deep_inspection
+@pytest.mark.vsphere
+class TestStandaloneDIValidation:
+    """Validation errors for standalone Deep Inspection.
+
+    Creates a Conversion CR with missing vddkImage (required for
+    DeepInspection type). The controller sets a Critical condition
+    (VDDKImageNotSet) and blocks the pipeline.
+    """
+
+    conversion: Conversion
+
+    def test_create_invalid_conversion(self, di_invalid_conversion_resource: Conversion) -> None:
+        """Create a DeepInspection Conversion CR without vddkImage."""
+        self.__class__.conversion = di_invalid_conversion_resource
+        assert self.conversion
+
+    @pytest.mark.usefixtures("di_vm_name")
+    def test_verify_validation_error(self) -> None:
+        """Verify controller sets Critical condition for missing vddkImage.
+
+        Polls status until conditions appear (controller may not have
+        reconciled immediately after CR creation).
+        """
+        timeout = py_config["plan_wait_timeout"]
+        critical_conditions: list[Any] = []
+        phase = ""
+
+        try:
+            for sample in TimeoutSampler(
+                wait_timeout=timeout,
+                sleep=3,
+                func=lambda: self.conversion.instance.status,
+            ):
+                if not sample:
+                    continue
+                conditions = sample.get("conditions", [])
+                critical_conditions = [
+                    c for c in conditions if c.get("category") == "Critical" and c.get("status") == "True"
+                ]
+                if critical_conditions:
+                    phase = sample.get("phase", "")
+                    break
+        except TimeoutExpiredError:
+            raise AssertionError(f"Conversion '{self.conversion.name}' expected Critical conditions within {timeout}s")
+
+        condition_types = [c.get("type") for c in critical_conditions]
+        assert VDDK_IMAGE_NOT_SET_CONDITION in condition_types, (
+            f"Conversion '{self.conversion.name}' expected {VDDK_IMAGE_NOT_SET_CONDITION} condition, "
+            f"got: {condition_types}"
+        )
+
+        assert phase not in {Conversion.Status.RUNNING, Conversion.Status.SUCCEEDED}, (
+            f"Conversion '{self.conversion.name}' should not reach Running or Succeeded with validation errors, "
+            f"got phase '{phase}'"
+        )

--- a/tests/deep_inspection/test_standalone_di.py
+++ b/tests/deep_inspection/test_standalone_di.py
@@ -239,6 +239,7 @@ class TestStandaloneDIValidation:
         """
         timeout = py_config["plan_wait_timeout"]
         critical_conditions: list[Any] = []
+        conditions: list[Any] = []
         phase = ""
 
         try:
@@ -257,8 +258,10 @@ class TestStandaloneDIValidation:
                     phase = sample.get("phase", "")
                     break
         except TimeoutExpiredError as err:
+            last_condition_types = [c.get("type") for c in conditions]
             raise AssertionError(
-                f"Conversion '{self.conversion.name}' expected Critical conditions within {timeout}s"
+                f"Conversion '{self.conversion.name}' expected Critical conditions within {timeout}s. "
+                f"Last phase='{phase}', conditions={last_condition_types}"
             ) from err
 
         condition_types = [c.get("type") for c in critical_conditions]

--- a/tests/deep_inspection/test_standalone_di.py
+++ b/tests/deep_inspection/test_standalone_di.py
@@ -10,6 +10,7 @@ from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from exceptions.exceptions import ConversionError
+from libs.providers.vmware import VMWareProvider
 from utilities.deep_inspection import (
     DI_POD_CLEANUP_TIMEOUT,
     DI_SNAPSHOT_CLEANUP_TIMEOUT,
@@ -20,12 +21,13 @@ from utilities.deep_inspection import (
     verify_di_results,
     wait_for_conversion_complete,
     wait_for_conversion_phase,
+    wait_for_critical_conditions,
     wait_for_di_snapshot,
 )
 
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
-    from libs.providers.vmware import VMWareProvider
+    from libs.base_provider import BaseProvider
 
 
 @pytest.mark.parametrize(
@@ -97,19 +99,23 @@ class TestStandaloneDICancel:
     conversion: Conversion
     rerun_conversion: Conversion
 
-    def test_create_and_cancel_conversion(
-        self,
-        di_conversion_resource: Conversion,
-        di_vm_name: str,
-        source_provider: "VMWareProvider",
-    ) -> None:
-        """Create DI Conversion, wait for Running and snapshot, then cancel."""
+    def test_create_conversion(self, di_conversion_resource: Conversion) -> None:
+        """Create a standalone DeepInspection Conversion CR for cancel testing."""
         self.__class__.conversion = di_conversion_resource
+        assert self.conversion
+
+    @pytest.mark.usefixtures("di_vm_name")
+    def test_wait_for_running(self) -> None:
+        """Wait for the Conversion CR to reach Running phase."""
         wait_for_conversion_phase(
             conversion=self.conversion,
             phase=Conversion.Status.RUNNING,
             timeout=py_config["plan_wait_timeout"],
         )
+
+    def test_cancel_conversion(self, di_vm_name: str, source_provider: "BaseProvider") -> None:
+        """Wait for DI snapshot on source VM, then cancel the conversion."""
+        assert isinstance(source_provider, VMWareProvider), "Snapshot verification requires vSphere provider"
         wait_for_di_snapshot(source_provider=source_provider, vm_name=di_vm_name)
         cancel_conversion(conversion=self.conversion)
 
@@ -148,8 +154,9 @@ class TestStandaloneDICancel:
                 f"Conversion pods still present {DI_POD_CLEANUP_TIMEOUT}s after cancel: {[p.name for p in remaining]}"
             ) from err
 
-    def test_verify_snapshot_cleanup(self, di_vm_name: str, source_provider: "VMWareProvider") -> None:
+    def test_verify_snapshot_cleanup(self, di_vm_name: str, source_provider: "BaseProvider") -> None:
         """Verify forklift DI snapshot is removed from the source VM after cancel."""
+        assert isinstance(source_provider, VMWareProvider), "Snapshot verification requires vSphere provider"
         vm = source_provider.get_vm_by_name(query=di_vm_name)
         assert vm, f"VM '{di_vm_name}' not found in source provider"
         try:
@@ -169,7 +176,7 @@ class TestStandaloneDICancel:
 
     def test_rerun_di_after_cancel(
         self,
-        di_resolved_vm: dict[str, str],
+        di_resolved_vm: dict[str, Any],
         di_connection_secret: Secret,
         di_vddk_image: str,
         fixture_store: dict[str, Any],
@@ -232,37 +239,11 @@ class TestStandaloneDIValidation:
 
     @pytest.mark.usefixtures("di_vm_name")
     def test_verify_validation_error(self) -> None:
-        """Verify controller sets Critical condition for missing vddkImage.
-
-        Polls status until conditions appear (controller may not have
-        reconciled immediately after CR creation).
-        """
-        timeout = py_config["plan_wait_timeout"]
-        critical_conditions: list[Any] = []
-        conditions: list[Any] = []
-        phase = ""
-
-        try:
-            for sample in TimeoutSampler(
-                wait_timeout=timeout,
-                sleep=3,
-                func=lambda: self.conversion.instance.status,
-            ):
-                if not sample:
-                    continue
-                conditions = sample.get("conditions", [])
-                phase = sample.get("phase", "")
-                critical_conditions = [
-                    c for c in conditions if c.get("category") == "Critical" and c.get("status") == "True"
-                ]
-                if critical_conditions:
-                    break
-        except TimeoutExpiredError as err:
-            last_condition_types = [c.get("type") for c in conditions]
-            raise AssertionError(
-                f"Conversion '{self.conversion.name}' expected Critical conditions within {timeout}s. "
-                f"Last phase='{phase}', conditions={last_condition_types}"
-            ) from err
+        """Verify controller sets Critical condition for missing vddkImage."""
+        critical_conditions, phase = wait_for_critical_conditions(
+            conversion=self.conversion,
+            timeout=py_config["plan_wait_timeout"],
+        )
 
         condition_types = [c.get("type") for c in critical_conditions]
         assert VDDK_IMAGE_NOT_SET_CONDITION in condition_types, (

--- a/tests/deep_inspection/test_standalone_di.py
+++ b/tests/deep_inspection/test_standalone_di.py
@@ -7,27 +7,24 @@ from ocp_resources.conversion import Conversion
 from ocp_resources.pod import Pod
 from ocp_resources.secret import Secret
 from pytest_testconfig import config as py_config
-from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from exceptions.exceptions import ConversionError
-from libs.providers.vmware import VMWareProvider
 from utilities.deep_inspection import (
-    DI_POD_CLEANUP_TIMEOUT,
-    DI_SNAPSHOT_CLEANUP_TIMEOUT,
-    DI_SNAPSHOT_NAME,
     VDDK_IMAGE_NOT_SET_CONDITION,
     cancel_conversion,
     create_conversion_resource,
     verify_di_results,
     wait_for_conversion_complete,
     wait_for_conversion_phase,
+    wait_for_conversion_pods_cleanup,
     wait_for_critical_conditions,
     wait_for_di_snapshot,
+    wait_for_di_snapshot_cleanup,
 )
 
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
-    from libs.base_provider import BaseProvider
+    from libs.providers.vmware import VMWareProvider
 
 
 @pytest.mark.parametrize(
@@ -61,7 +58,7 @@ class TestStandaloneDeepInspection:
         self.__class__.conversion = di_conversion_resource
         assert self.conversion
 
-    @pytest.mark.usefixtures("di_vm_name")
+    @pytest.mark.usefixtures("class_plan_config")
     def test_wait_for_completion(self) -> None:
         """Wait for the DeepInspection pipeline to complete."""
         wait_for_conversion_complete(
@@ -104,7 +101,7 @@ class TestStandaloneDICancel:
         self.__class__.conversion = di_conversion_resource
         assert self.conversion
 
-    @pytest.mark.usefixtures("di_vm_name")
+    @pytest.mark.usefixtures("class_plan_config")
     def test_wait_for_running(self) -> None:
         """Wait for the Conversion CR to reach Running phase."""
         wait_for_conversion_phase(
@@ -113,13 +110,20 @@ class TestStandaloneDICancel:
             timeout=py_config["plan_wait_timeout"],
         )
 
-    def test_cancel_conversion(self, di_vm_name: str, source_provider: "BaseProvider") -> None:
+    def test_cancel_conversion(self, di_vm_name: str, vmware_source_provider: "VMWareProvider") -> None:
         """Wait for DI snapshot on source VM, then cancel the conversion."""
-        assert isinstance(source_provider, VMWareProvider), "Snapshot verification requires vSphere provider"
-        wait_for_di_snapshot(source_provider=source_provider, vm_name=di_vm_name)
+        wait_for_di_snapshot(source_provider=vmware_source_provider, vm_name=di_vm_name)
+        pods = list(
+            Pod.get(
+                client=self.conversion.client,
+                namespace=self.conversion.namespace,
+                label_selector=f"conversion={self.conversion.name}",
+            )
+        )
+        assert pods, f"No conversion pods found before cancel for '{self.conversion.name}'"
         cancel_conversion(conversion=self.conversion)
 
-    @pytest.mark.usefixtures("di_vm_name")
+    @pytest.mark.usefixtures("class_plan_config")
     def test_verify_cancel_cleanup(self) -> None:
         """Verify canceled conversion reaches Canceled phase and pod is cleaned up."""
         with pytest.raises(ConversionError, match="Canceled"):
@@ -128,51 +132,11 @@ class TestStandaloneDICancel:
                 timeout=py_config["plan_wait_timeout"],
             )
 
-        try:
-            for pods in TimeoutSampler(
-                wait_timeout=DI_POD_CLEANUP_TIMEOUT,
-                sleep=5,
-                func=lambda: list(
-                    Pod.get(
-                        client=self.conversion.client,
-                        namespace=self.conversion.namespace,
-                        label_selector=f"conversion={self.conversion.name}",
-                    )
-                ),
-            ):
-                if not pods:
-                    return
-        except TimeoutExpiredError as err:
-            remaining = list(
-                Pod.get(
-                    client=self.conversion.client,
-                    namespace=self.conversion.namespace,
-                    label_selector=f"conversion={self.conversion.name}",
-                )
-            )
-            raise AssertionError(
-                f"Conversion pods still present {DI_POD_CLEANUP_TIMEOUT}s after cancel: {[p.name for p in remaining]}"
-            ) from err
+        wait_for_conversion_pods_cleanup(conversion=self.conversion)
 
-    def test_verify_snapshot_cleanup(self, di_vm_name: str, source_provider: "BaseProvider") -> None:
+    def test_verify_snapshot_cleanup(self, di_vm_name: str, vmware_source_provider: "VMWareProvider") -> None:
         """Verify forklift DI snapshot is removed from the source VM after cancel."""
-        assert isinstance(source_provider, VMWareProvider), "Snapshot verification requires vSphere provider"
-        vm = source_provider.get_vm_by_name(query=di_vm_name)
-        assert vm, f"VM '{di_vm_name}' not found in source provider"
-        try:
-            for snapshots in TimeoutSampler(
-                wait_timeout=DI_SNAPSHOT_CLEANUP_TIMEOUT,
-                sleep=10,
-                func=lambda: [s for s in source_provider.list_snapshots(vm) if s.name == DI_SNAPSHOT_NAME],
-            ):
-                if not snapshots:
-                    return
-        except TimeoutExpiredError as err:
-            remaining = [s.name for s in source_provider.list_snapshots(vm)]
-            raise AssertionError(
-                f"DI snapshot '{DI_SNAPSHOT_NAME}' still present on VM '{di_vm_name}' "
-                f"{DI_SNAPSHOT_CLEANUP_TIMEOUT}s after cancel. All snapshots: {remaining}"
-            ) from err
+        wait_for_di_snapshot_cleanup(source_provider=vmware_source_provider, vm_name=di_vm_name)
 
     def test_rerun_di_after_cancel(
         self,
@@ -195,7 +159,7 @@ class TestStandaloneDICancel:
         )
         assert self.rerun_conversion
 
-    @pytest.mark.usefixtures("di_vm_name")
+    @pytest.mark.usefixtures("class_plan_config")
     def test_rerun_wait_for_completion(self) -> None:
         """Wait for the re-run DI to complete successfully."""
         wait_for_conversion_complete(
@@ -237,7 +201,7 @@ class TestStandaloneDIValidation:
         self.__class__.conversion = di_invalid_conversion_resource
         assert self.conversion
 
-    @pytest.mark.usefixtures("di_vm_name")
+    @pytest.mark.usefixtures("class_plan_config")
     def test_verify_validation_error(self) -> None:
         """Verify controller sets Critical condition for missing vddkImage."""
         critical_conditions, phase = wait_for_critical_conditions(

--- a/tests/deep_inspection/test_standalone_di.py
+++ b/tests/deep_inspection/test_standalone_di.py
@@ -251,11 +251,11 @@ class TestStandaloneDIValidation:
                 if not sample:
                     continue
                 conditions = sample.get("conditions", [])
+                phase = sample.get("phase", "")
                 critical_conditions = [
                     c for c in conditions if c.get("category") == "Critical" and c.get("status") == "True"
                 ]
                 if critical_conditions:
-                    phase = sample.get("phase", "")
                     break
         except TimeoutExpiredError as err:
             last_condition_types = [c.get("type") for c in conditions]

--- a/tests/deep_inspection/test_standalone_di.py
+++ b/tests/deep_inspection/test_standalone_di.py
@@ -136,7 +136,7 @@ class TestStandaloneDICancel:
             ):
                 if not pods:
                     return
-        except TimeoutExpiredError:
+        except TimeoutExpiredError as err:
             remaining = list(
                 Pod.get(
                     client=self.conversion.client,
@@ -146,7 +146,7 @@ class TestStandaloneDICancel:
             )
             raise AssertionError(
                 f"Conversion pods still present {DI_POD_CLEANUP_TIMEOUT}s after cancel: {[p.name for p in remaining]}"
-            )
+            ) from err
 
     def test_verify_snapshot_cleanup(self, di_vm_name: str, source_provider: "VMWareProvider") -> None:
         """Verify forklift DI snapshot is removed from the source VM after cancel."""
@@ -160,12 +160,12 @@ class TestStandaloneDICancel:
             ):
                 if not snapshots:
                     return
-        except TimeoutExpiredError:
+        except TimeoutExpiredError as err:
             remaining = [s.name for s in source_provider.list_snapshots(vm)]
             raise AssertionError(
                 f"DI snapshot '{DI_SNAPSHOT_NAME}' still present on VM '{di_vm_name}' "
                 f"{DI_SNAPSHOT_CLEANUP_TIMEOUT}s after cancel. All snapshots: {remaining}"
-            )
+            ) from err
 
     def test_rerun_di_after_cancel(
         self,
@@ -256,8 +256,10 @@ class TestStandaloneDIValidation:
                 if critical_conditions:
                     phase = sample.get("phase", "")
                     break
-        except TimeoutExpiredError:
-            raise AssertionError(f"Conversion '{self.conversion.name}' expected Critical conditions within {timeout}s")
+        except TimeoutExpiredError as err:
+            raise AssertionError(
+                f"Conversion '{self.conversion.name}' expected Critical conditions within {timeout}s"
+            ) from err
 
         condition_types = [c.get("type") for c in critical_conditions]
         assert VDDK_IMAGE_NOT_SET_CONDITION in condition_types, (

--- a/tests/tests_config/config.py
+++ b/tests/tests_config/config.py
@@ -776,7 +776,6 @@ tests_params: dict = {
                 "name": "mtv-tests-di-rhel8",
             },
         ],
-        "deep_inspection": True,
     },
 }
 

--- a/utilities/deep_inspection.py
+++ b/utilities/deep_inspection.py
@@ -169,12 +169,12 @@ def wait_for_conversion_phase(conversion: Conversion, phase: str, timeout: int) 
                     message=f"Reached terminal phase '{current_phase}' before target phase '{phase}'",
                 )
 
-    except TimeoutExpiredError:
+    except TimeoutExpiredError as err:
         raise ConversionError(
             conversion_name=conversion.name,
             phase=last_phase or "Unknown",
             message=f"Did not reach phase '{phase}' within {timeout}s",
-        )
+        ) from err
 
 
 def wait_for_di_snapshot(
@@ -198,8 +198,6 @@ def wait_for_di_snapshot(
         TimeoutExpiredError: If snapshot does not appear within timeout.
     """
     vm = source_provider.get_vm_by_name(query=vm_name)
-    if vm is None:
-        raise ValueError(f"VM '{vm_name}' not found in source provider")
     try:
         for snapshots in TimeoutSampler(
             wait_timeout=timeout,
@@ -209,8 +207,10 @@ def wait_for_di_snapshot(
             if snapshots:
                 LOGGER.info(f"DI snapshot '{DI_SNAPSHOT_NAME}' found on VM '{vm_name}'")
                 return
-    except TimeoutExpiredError:
-        raise TimeoutExpiredError(f"DI snapshot '{DI_SNAPSHOT_NAME}' not found on VM '{vm_name}' within {timeout}s")
+    except TimeoutExpiredError as err:
+        raise TimeoutExpiredError(
+            f"DI snapshot '{DI_SNAPSHOT_NAME}' not found on VM '{vm_name}' within {timeout}s"
+        ) from err
 
 
 def create_conversion_resource(
@@ -307,12 +307,12 @@ def wait_for_conversion_complete(conversion: Conversion, timeout: int) -> None:
                     )
                 return
 
-    except TimeoutExpiredError:
+    except TimeoutExpiredError as err:
         raise ConversionError(
             conversion_name=conversion.name,
             phase=last_phase or "Unknown",
             message=f"Timed out after {timeout}s at stage '{last_stage}'",
-        )
+        ) from err
 
 
 def verify_di_results(conversion: Conversion, vm_name: str) -> None:

--- a/utilities/deep_inspection.py
+++ b/utilities/deep_inspection.py
@@ -197,7 +197,7 @@ def wait_for_di_snapshot(
         TimeoutExpiredError: If snapshot does not appear within timeout.
     """
     vm = source_provider.get_vm_by_name(query=vm_name)
-    if not vm:
+    if vm is None:
         raise ValueError(f"VM '{vm_name}' not found in source provider")
     for snapshots in TimeoutSampler(
         wait_timeout=timeout,
@@ -250,7 +250,7 @@ def create_conversion_resource(
         "vm": {"id": vm_id, "name": vm_name, "type": "VirtualMachine"},
         "target_namespace": target_namespace,
     }
-    if vddk_image:
+    if vddk_image is not None:
         kwargs["vddk_image"] = vddk_image
     if settings:
         kwargs["settings"] = settings

--- a/utilities/deep_inspection.py
+++ b/utilities/deep_inspection.py
@@ -27,6 +27,7 @@ CONVERSION_STAGE_FINISHED = "Finished"  # forklift: StageFinished (conversion.go
 VDDK_IMAGE_NOT_SET_CONDITION = "VDDKImageNotSet"  # forklift: validation.go:14
 DI_SNAPSHOT_NAME = "forklift-deep-inspection"  # forklift: snapshotName (client.go:21)
 DI_SNAPSHOT_CREATION_TIMEOUT = 120
+DI_POD_CREATION_TIMEOUT = 120
 DI_POD_CLEANUP_TIMEOUT = 60
 DI_SNAPSHOT_CLEANUP_TIMEOUT = 180
 
@@ -406,9 +407,6 @@ def wait_for_critical_conditions(
     return critical, phase
 
 
-DI_POD_CREATION_TIMEOUT = 120
-
-
 def wait_for_conversion_pods(
     conversion: Conversion,
     timeout: int = DI_POD_CREATION_TIMEOUT,
@@ -419,6 +417,10 @@ def wait_for_conversion_pods(
     one exists. The forklift controller creates the snapshot before the
     pod, so the pod may not exist yet when the snapshot is found.
 
+    Also checks for terminal phases on each iteration — if the conversion
+    fails or is canceled before creating a pod, raises immediately instead
+    of waiting until timeout.
+
     Args:
         conversion (Conversion): The Conversion CR whose pods to wait for.
         timeout (int): Maximum wait time in seconds.
@@ -427,19 +429,32 @@ def wait_for_conversion_pods(
         list[Pod]: The conversion pods found.
 
     Raises:
+        ConversionError: If the conversion reaches a terminal phase before pods appear.
         AssertionError: If no pods appear within timeout.
     """
+
+    def _poll() -> list["Pod"]:
+        status = conversion.instance.status or {}
+        phase = status.get("phase", "")
+        if phase in CONVERSION_TERMINAL_PHASES:
+            raise ConversionError(
+                conversion_name=conversion.name,
+                phase=phase,
+                message=f"Reached terminal phase '{phase}' before pods were created",
+            )
+        return list(
+            Pod.get(
+                client=conversion.client,
+                namespace=conversion.namespace,
+                label_selector=f"conversion={conversion.name}",
+            )
+        )
+
     try:
         for pods in TimeoutSampler(
             wait_timeout=timeout,
             sleep=3,
-            func=lambda: list(
-                Pod.get(
-                    client=conversion.client,
-                    namespace=conversion.namespace,
-                    label_selector=f"conversion={conversion.name}",
-                )
-            ),
+            func=_poll,
         ):
             if pods:
                 LOGGER.info(f"Found {len(pods)} pod(s) for conversion '{conversion.name}'")

--- a/utilities/deep_inspection.py
+++ b/utilities/deep_inspection.py
@@ -189,24 +189,28 @@ def wait_for_di_snapshot(
     performing cancel operations.
 
     Args:
-        source_provider (BaseProvider): Source provider with list_snapshots method.
+        source_provider (VMWareProvider): Source provider with list_snapshots method.
         vm_name (str): Source VM name to check snapshots on.
         timeout (int): Maximum wait time in seconds.
 
     Raises:
+        ValueError: If the source VM is not found in the provider.
         TimeoutExpiredError: If snapshot does not appear within timeout.
     """
     vm = source_provider.get_vm_by_name(query=vm_name)
     if vm is None:
         raise ValueError(f"VM '{vm_name}' not found in source provider")
-    for snapshots in TimeoutSampler(
-        wait_timeout=timeout,
-        sleep=5,
-        func=lambda: [s for s in source_provider.list_snapshots(vm) if s.name == DI_SNAPSHOT_NAME],
-    ):
-        if snapshots:
-            LOGGER.info(f"DI snapshot '{DI_SNAPSHOT_NAME}' found on VM '{vm_name}'")
-            return
+    try:
+        for snapshots in TimeoutSampler(
+            wait_timeout=timeout,
+            sleep=5,
+            func=lambda: [s for s in source_provider.list_snapshots(vm) if s.name == DI_SNAPSHOT_NAME],
+        ):
+            if snapshots:
+                LOGGER.info(f"DI snapshot '{DI_SNAPSHOT_NAME}' found on VM '{vm_name}'")
+                return
+    except TimeoutExpiredError:
+        raise TimeoutExpiredError(f"DI snapshot '{DI_SNAPSHOT_NAME}' not found on VM '{vm_name}' within {timeout}s")
 
 
 def create_conversion_resource(

--- a/utilities/deep_inspection.py
+++ b/utilities/deep_inspection.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
 LOGGER = get_logger(name=__name__)
 
 CONVERSION_TERMINAL_PHASES = {Conversion.Status.SUCCEEDED, Conversion.Status.FAILED, Conversion.Condition.CANCELED}
-CONVERSION_CANCELED_PHASE = Conversion.Condition.CANCELED
 # Not exposed by openshift-python-wrapper — mirrors forklift constants:
 CONVERSION_TYPE_DEEP_INSPECTION = "DeepInspection"  # forklift: DeepInspection (conversion.go:20)
 CONVERSION_STAGE_FINISHED = "Finished"  # forklift: StageFinished (conversion.go:55)
@@ -29,7 +28,6 @@ DI_SNAPSHOT_NAME = "forklift-deep-inspection"  # forklift: snapshotName (client.
 DI_SNAPSHOT_CREATION_TIMEOUT = 120
 DI_POD_CLEANUP_TIMEOUT = 60
 DI_SNAPSHOT_CLEANUP_TIMEOUT = 180
-DI_SNAPSHOT_REMOVAL_TIMEOUT = 120
 
 
 def create_di_connection_secret(
@@ -120,7 +118,7 @@ def cancel_conversion(conversion: Conversion) -> None:
     """
     api_resource = conversion.client.resources.get(api_version=conversion.api_version, kind=conversion.kind)
     api_resource.status.patch(
-        body={"status": {"phase": CONVERSION_CANCELED_PHASE, "stage": CONVERSION_STAGE_FINISHED}},
+        body={"status": {"phase": Conversion.Condition.CANCELED, "stage": CONVERSION_STAGE_FINISHED}},
         name=conversion.name,
         namespace=conversion.namespace,
         content_type="application/merge-patch+json",
@@ -352,3 +350,52 @@ def verify_di_results(conversion: Conversion, vm_name: str) -> None:
         f"os={os_info.get('name')} {os_info.get('version', '')}, "
         f"filesystems={len(filesystems)}"
     )
+
+
+def wait_for_critical_conditions(
+    conversion: Conversion,
+    timeout: int,
+) -> tuple[list[Any], str]:
+    """Wait for Critical conditions to appear on a Conversion CR.
+
+    Polls the Conversion CR status until at least one condition with
+    category=Critical and status=True appears. Returns the critical
+    conditions and the phase at the time they were found.
+
+    Args:
+        conversion (Conversion): The Conversion CR to monitor.
+        timeout (int): Maximum wait time in seconds.
+
+    Returns:
+        tuple[list[Any], str]: (critical_conditions, phase) at the time
+            critical conditions were detected.
+
+    Raises:
+        AssertionError: If no Critical conditions appear within timeout.
+    """
+    conditions: list[Any] = []
+    phase = ""
+    critical: list[Any] = []
+
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=timeout,
+            sleep=3,
+            func=lambda: conversion.instance.status,
+        ):
+            if not sample:
+                continue
+            conditions = sample.get("conditions", [])
+            phase = sample.get("phase", "")
+            critical = [c for c in conditions if c.get("category") == "Critical" and c.get("status") == "True"]
+            if critical:
+                LOGGER.info(f"Conversion '{conversion.name}' has {len(critical)} Critical condition(s)")
+                break
+    except TimeoutExpiredError as err:
+        last_condition_types = [c.get("type") for c in conditions]
+        raise AssertionError(
+            f"Conversion '{conversion.name}' expected Critical conditions within {timeout}s. "
+            f"Last phase='{phase}', conditions={last_condition_types}"
+        ) from err
+
+    return critical, phase

--- a/utilities/deep_inspection.py
+++ b/utilities/deep_inspection.py
@@ -15,10 +15,21 @@ from utilities.resources import create_and_store_resource
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
     from libs.base_provider import BaseProvider
+    from libs.providers.vmware import VMWareProvider
 
 LOGGER = get_logger(name=__name__)
 
 CONVERSION_TERMINAL_PHASES = {Conversion.Status.SUCCEEDED, Conversion.Status.FAILED, Conversion.Condition.CANCELED}
+CONVERSION_CANCELED_PHASE = Conversion.Condition.CANCELED
+# Not exposed by openshift-python-wrapper — mirrors forklift constants:
+CONVERSION_TYPE_DEEP_INSPECTION = "DeepInspection"  # forklift: DeepInspection (conversion.go:20)
+CONVERSION_STAGE_FINISHED = "Finished"  # forklift: StageFinished (conversion.go:55)
+VDDK_IMAGE_NOT_SET_CONDITION = "VDDKImageNotSet"  # forklift: validation.go:14
+DI_SNAPSHOT_NAME = "forklift-deep-inspection"  # forklift: snapshotName (client.go:21)
+DI_SNAPSHOT_CREATION_TIMEOUT = 120
+DI_POD_CLEANUP_TIMEOUT = 60
+DI_SNAPSHOT_CLEANUP_TIMEOUT = 180
+DI_SNAPSHOT_REMOVAL_TIMEOUT = 120
 
 
 def create_di_connection_secret(
@@ -96,6 +107,107 @@ def create_di_connection_secret(
     )
 
 
+def cancel_conversion(conversion: Conversion) -> None:
+    """Cancel a Conversion CR by patching the status subresource.
+
+    Mirrors the forklift controller's CancelConversion() pattern
+    (kubevirt.go:973-975): sets phase=Canceled, stage=Finished via
+    a status subresource merge-patch. The caller is responsible for
+    ensuring the conversion is in a cancelable state (e.g., Running).
+
+    Args:
+        conversion (Conversion): The Conversion CR to cancel.
+    """
+    api_resource = conversion.client.resources.get(api_version=conversion.api_version, kind=conversion.kind)
+    api_resource.status.patch(
+        body={"status": {"phase": CONVERSION_CANCELED_PHASE, "stage": CONVERSION_STAGE_FINISHED}},
+        name=conversion.name,
+        namespace=conversion.namespace,
+        content_type="application/merge-patch+json",
+    )
+    LOGGER.info(f"Canceled conversion '{conversion.name}'")
+
+
+def wait_for_conversion_phase(conversion: Conversion, phase: str, timeout: int) -> None:
+    """Wait for a Conversion CR to reach a specific phase.
+
+    Polls the Conversion CR status until the phase matches the expected
+    value. Useful for timing cancel operations (wait for Running before
+    canceling). Raises ConversionError if the conversion reaches a
+    different terminal phase before the target.
+
+    Args:
+        conversion (Conversion): The Conversion CR to monitor.
+        phase (str): Target phase to wait for (e.g., Conversion.Status.RUNNING).
+        timeout (int): Maximum wait time in seconds.
+
+    Raises:
+        ConversionError: If the conversion reaches a terminal phase other
+            than the target, or if the timeout expires.
+    """
+    last_phase = ""
+    is_target_terminal = phase in CONVERSION_TERMINAL_PHASES
+
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=timeout,
+            sleep=3,
+            func=lambda: conversion.instance.status,
+        ):
+            if not sample:
+                continue
+
+            current_phase = sample.get("phase", "")
+            last_phase = current_phase
+            if current_phase == phase:
+                LOGGER.info(f"Conversion '{conversion.name}' reached phase '{phase}'")
+                return
+
+            if not is_target_terminal and current_phase in CONVERSION_TERMINAL_PHASES:
+                raise ConversionError(
+                    conversion_name=conversion.name,
+                    phase=current_phase,
+                    message=f"Reached terminal phase '{current_phase}' before target phase '{phase}'",
+                )
+
+    except TimeoutExpiredError:
+        raise ConversionError(
+            conversion_name=conversion.name,
+            phase=last_phase or "Unknown",
+            message=f"Did not reach phase '{phase}' within {timeout}s",
+        )
+
+
+def wait_for_di_snapshot(
+    source_provider: "VMWareProvider",
+    vm_name: str,
+    timeout: int = DI_SNAPSHOT_CREATION_TIMEOUT,
+) -> None:
+    """Wait for the DI snapshot to appear on the source VM.
+
+    Polls the source provider until the forklift-deep-inspection snapshot
+    exists. Used to ensure the DI pipeline has fully started before
+    performing cancel operations.
+
+    Args:
+        source_provider (BaseProvider): Source provider with list_snapshots method.
+        vm_name (str): Source VM name to check snapshots on.
+        timeout (int): Maximum wait time in seconds.
+
+    Raises:
+        TimeoutExpiredError: If snapshot does not appear within timeout.
+    """
+    vm = source_provider.get_vm_by_name(query=vm_name)
+    for snapshots in TimeoutSampler(
+        wait_timeout=timeout,
+        sleep=5,
+        func=lambda: [s for s in source_provider.list_snapshots(vm) if s.name == DI_SNAPSHOT_NAME],
+    ):
+        if snapshots:
+            LOGGER.info(f"DI snapshot '{DI_SNAPSHOT_NAME}' found on VM '{vm_name}'")
+            return
+
+
 def create_conversion_resource(
     client: "DynamicClient",
     fixture_store: dict[str, Any],
@@ -131,7 +243,7 @@ def create_conversion_resource(
         fixture_store=fixture_store,
         resource=Conversion,
         namespace=target_namespace,
-        type="DeepInspection",
+        type=CONVERSION_TYPE_DEEP_INSPECTION,
         connection={"secret": {"name": connection_secret.name, "namespace": connection_secret.namespace}},
         vm={"id": vm_id, "name": vm_name, "type": "VirtualMachine"},
         vddk_image=vddk_image,

--- a/utilities/deep_inspection.py
+++ b/utilities/deep_inspection.py
@@ -406,6 +406,50 @@ def wait_for_critical_conditions(
     return critical, phase
 
 
+DI_POD_CREATION_TIMEOUT = 120
+
+
+def wait_for_conversion_pods(
+    conversion: Conversion,
+    timeout: int = DI_POD_CREATION_TIMEOUT,
+) -> list["Pod"]:
+    """Wait for at least one pod associated with a Conversion CR to appear.
+
+    Polls for pods matching the conversion label selector until at least
+    one exists. The forklift controller creates the snapshot before the
+    pod, so the pod may not exist yet when the snapshot is found.
+
+    Args:
+        conversion (Conversion): The Conversion CR whose pods to wait for.
+        timeout (int): Maximum wait time in seconds.
+
+    Returns:
+        list[Pod]: The conversion pods found.
+
+    Raises:
+        AssertionError: If no pods appear within timeout.
+    """
+    try:
+        for pods in TimeoutSampler(
+            wait_timeout=timeout,
+            sleep=3,
+            func=lambda: list(
+                Pod.get(
+                    client=conversion.client,
+                    namespace=conversion.namespace,
+                    label_selector=f"conversion={conversion.name}",
+                )
+            ),
+        ):
+            if pods:
+                LOGGER.info(f"Found {len(pods)} pod(s) for conversion '{conversion.name}'")
+                return pods
+    except TimeoutExpiredError as err:
+        raise AssertionError(f"No conversion pods found for '{conversion.name}' within {timeout}s") from err
+
+    return []
+
+
 def wait_for_conversion_pods_cleanup(
     conversion: Conversion,
     timeout: int = DI_POD_CLEANUP_TIMEOUT,

--- a/utilities/deep_inspection.py
+++ b/utilities/deep_inspection.py
@@ -4,6 +4,7 @@ import base64
 from typing import TYPE_CHECKING, Any
 
 from ocp_resources.conversion import Conversion
+from ocp_resources.pod import Pod
 from ocp_resources.resource import NotFoundError
 from ocp_resources.secret import Secret
 from simple_logger.logger import get_logger
@@ -297,7 +298,11 @@ def wait_for_conversion_complete(conversion: Conversion, timeout: int) -> None:
             if phase in CONVERSION_TERMINAL_PHASES:
                 if phase != Conversion.Status.SUCCEEDED:
                     conditions = sample.get("conditions", [])
-                    messages = [c.get("message", "") for c in conditions if c.get("category") == "Critical"]
+                    messages = [
+                        c.get("message", "")
+                        for c in conditions
+                        if c.get("category") == "Critical" and c.get("status") == "True"
+                    ]
                     raise ConversionError(
                         conversion_name=conversion.name,
                         phase=phase,
@@ -399,3 +404,82 @@ def wait_for_critical_conditions(
         ) from err
 
     return critical, phase
+
+
+def wait_for_conversion_pods_cleanup(
+    conversion: Conversion,
+    timeout: int = DI_POD_CLEANUP_TIMEOUT,
+) -> None:
+    """Wait for all pods associated with a Conversion CR to be cleaned up.
+
+    Polls for pods matching the conversion label selector until none remain.
+
+    Args:
+        conversion (Conversion): The Conversion CR whose pods to monitor.
+        timeout (int): Maximum wait time in seconds.
+
+    Raises:
+        AssertionError: If pods are still present after timeout.
+    """
+    try:
+        for pods in TimeoutSampler(
+            wait_timeout=timeout,
+            sleep=5,
+            func=lambda: list(
+                Pod.get(
+                    client=conversion.client,
+                    namespace=conversion.namespace,
+                    label_selector=f"conversion={conversion.name}",
+                )
+            ),
+        ):
+            if not pods:
+                LOGGER.info(f"All pods cleaned up for conversion '{conversion.name}'")
+                return
+    except TimeoutExpiredError as err:
+        remaining = list(
+            Pod.get(
+                client=conversion.client,
+                namespace=conversion.namespace,
+                label_selector=f"conversion={conversion.name}",
+            )
+        )
+        raise AssertionError(
+            f"Conversion pods still present {timeout}s after cancel: {[p.name for p in remaining]}"
+        ) from err
+
+
+def wait_for_di_snapshot_cleanup(
+    source_provider: "VMWareProvider",
+    vm_name: str,
+    timeout: int = DI_SNAPSHOT_CLEANUP_TIMEOUT,
+) -> None:
+    """Wait for the DI snapshot to be removed from the source VM.
+
+    Polls the source provider until the forklift-deep-inspection snapshot
+    no longer exists on the VM.
+
+    Args:
+        source_provider (VMWareProvider): Source provider with list_snapshots method.
+        vm_name (str): Source VM name to check snapshots on.
+        timeout (int): Maximum wait time in seconds.
+
+    Raises:
+        AssertionError: If DI snapshot is still present after timeout.
+    """
+    vm = source_provider.get_vm_by_name(query=vm_name)
+    try:
+        for snapshots in TimeoutSampler(
+            wait_timeout=timeout,
+            sleep=10,
+            func=lambda: [s for s in source_provider.list_snapshots(vm) if s.name == DI_SNAPSHOT_NAME],
+        ):
+            if not snapshots:
+                LOGGER.info(f"DI snapshot '{DI_SNAPSHOT_NAME}' cleaned up from VM '{vm_name}'")
+                return
+    except TimeoutExpiredError as err:
+        remaining = [s.name for s in source_provider.list_snapshots(vm)]
+        raise AssertionError(
+            f"DI snapshot '{DI_SNAPSHOT_NAME}' still present on VM '{vm_name}' "
+            f"{timeout}s after cancel. All snapshots: {remaining}"
+        ) from err

--- a/utilities/deep_inspection.py
+++ b/utilities/deep_inspection.py
@@ -429,12 +429,20 @@ def wait_for_conversion_pods(
         list[Pod]: The conversion pods found.
 
     Raises:
-        ConversionError: If the conversion reaches a terminal phase before pods appear.
+        ConversionError: If the conversion reaches a terminal phase before pods appear,
+            or if the Conversion CR is deleted during polling.
         AssertionError: If no pods appear within timeout.
     """
 
     def _poll() -> list["Pod"]:
-        status = conversion.instance.status or {}
+        try:
+            status = conversion.instance.status or {}
+        except NotFoundError as err:
+            raise ConversionError(
+                conversion_name=conversion.name,
+                phase="Unknown",
+                message="Conversion not found while waiting for pods",
+            ) from err
         phase = status.get("phase", "")
         if phase in CONVERSION_TERMINAL_PHASES:
             raise ConversionError(

--- a/utilities/deep_inspection.py
+++ b/utilities/deep_inspection.py
@@ -146,7 +146,6 @@ def wait_for_conversion_phase(conversion: Conversion, phase: str, timeout: int) 
             than the target, or if the timeout expires.
     """
     last_phase = ""
-    is_target_terminal = phase in CONVERSION_TERMINAL_PHASES
 
     try:
         for sample in TimeoutSampler(
@@ -163,7 +162,7 @@ def wait_for_conversion_phase(conversion: Conversion, phase: str, timeout: int) 
                 LOGGER.info(f"Conversion '{conversion.name}' reached phase '{phase}'")
                 return
 
-            if not is_target_terminal and current_phase in CONVERSION_TERMINAL_PHASES:
+            if current_phase in CONVERSION_TERMINAL_PHASES:
                 raise ConversionError(
                     conversion_name=conversion.name,
                     phase=current_phase,
@@ -198,6 +197,8 @@ def wait_for_di_snapshot(
         TimeoutExpiredError: If snapshot does not appear within timeout.
     """
     vm = source_provider.get_vm_by_name(query=vm_name)
+    if not vm:
+        raise ValueError(f"VM '{vm_name}' not found in source provider")
     for snapshots in TimeoutSampler(
         wait_timeout=timeout,
         sleep=5,
@@ -214,8 +215,8 @@ def create_conversion_resource(
     connection_secret: Secret,
     vm_id: str,
     vm_name: str,
-    vddk_image: str,
     target_namespace: str,
+    vddk_image: str | None = None,
     snapshot_moref: str | None = None,
 ) -> Conversion:
     """Create a standalone DeepInspection Conversion CR.
@@ -226,8 +227,9 @@ def create_conversion_resource(
         connection_secret (Secret): Connection secret for vSphere access.
         vm_id (str): Source VM ID from inventory.
         vm_name (str): Source VM name.
-        vddk_image (str): VDDK init container image (required for DeepInspection).
         target_namespace (str): Namespace for the Conversion CR and pods.
+        vddk_image (str | None): VDDK init container image. Required for
+            DeepInspection — omit to test validation error (VDDKImageNotSet).
         snapshot_moref (str | None): vSphere snapshot MOREF. If provided, snapshot
             creation stages are skipped.
 
@@ -238,18 +240,22 @@ def create_conversion_resource(
     if snapshot_moref:
         settings["SNAPSHOT_MOREF"] = snapshot_moref
 
-    return create_and_store_resource(
-        client=client,
-        fixture_store=fixture_store,
-        resource=Conversion,
-        namespace=target_namespace,
-        type=CONVERSION_TYPE_DEEP_INSPECTION,
-        connection={"secret": {"name": connection_secret.name, "namespace": connection_secret.namespace}},
-        vm={"id": vm_id, "name": vm_name, "type": "VirtualMachine"},
-        vddk_image=vddk_image,
-        target_namespace=target_namespace,
-        settings=settings or None,
-    )
+    kwargs: dict[str, Any] = {
+        "client": client,
+        "fixture_store": fixture_store,
+        "resource": Conversion,
+        "namespace": target_namespace,
+        "type": CONVERSION_TYPE_DEEP_INSPECTION,
+        "connection": {"secret": {"name": connection_secret.name, "namespace": connection_secret.namespace}},
+        "vm": {"id": vm_id, "name": vm_name, "type": "VirtualMachine"},
+        "target_namespace": target_namespace,
+    }
+    if vddk_image:
+        kwargs["vddk_image"] = vddk_image
+    if settings:
+        kwargs["settings"] = settings
+
+    return create_and_store_resource(**kwargs)
 
 
 def wait_for_conversion_complete(conversion: Conversion, timeout: int) -> None:

--- a/utilities/deep_inspection.py
+++ b/utilities/deep_inspection.py
@@ -299,7 +299,7 @@ def wait_for_conversion_complete(conversion: Conversion, timeout: int) -> None:
             if phase in CONVERSION_TERMINAL_PHASES:
                 if phase != Conversion.Status.SUCCEEDED:
                     conditions = sample.get("conditions", [])
-                    messages = [c.get("message", "") for c in conditions if c.get("type") == "Critical"]
+                    messages = [c.get("message", "") for c in conditions if c.get("category") == "Critical"]
                     raise ConversionError(
                         conversion_name=conversion.name,
                         phase=phase,


### PR DESCRIPTION
## Summary

Adds two new test classes for standalone Deep Inspection (Conversion CR), extending the happy-path coverage from PR #575:

- **TestStandaloneDICancel** (8 tests, scenario 17): Creates a DI Conversion CR, waits for Running phase, verifies pods exist, cancels via status subresource patch (mirroring forklift's `CancelConversion()` pattern), verifies cleanup (pod deleted, `forklift-deep-inspection` snapshot removed by controller), then re-runs DI on the same VM and verifies success.

- **TestStandaloneDIValidation** (2 tests, scenario 18): Creates a Conversion CR without `vddkImage` to trigger controller validation. Verifies the CR reaches a non-running phase with a Critical `VDDKImageNotSet` condition.

### New utilities (`utilities/deep_inspection.py`)
- `cancel_conversion()` — patches status subresource to set `phase=Canceled, stage=Finished`
- `wait_for_conversion_phase()` — polls until a specific phase is reached, with terminal phase guard
- `wait_for_di_snapshot()` — polls vSphere for `forklift-deep-inspection` snapshot creation
- `wait_for_conversion_pods_cleanup()` — polls until conversion pods are cleaned up after cancel
- `wait_for_di_snapshot_cleanup()` — polls until DI snapshot is removed from source VM
- `wait_for_critical_conditions()` — polls for Critical conditions on a Conversion CR

### New fixtures (`tests/deep_inspection/conftest.py`)
- `vmware_source_provider` — type-validated VMWareProvider for snapshot API access
- `di_invalid_conversion_resource` — creates a Conversion CR without `vddkImage` for validation testing

## Jira
[MTV-6046](https://redhat.atlassian.net/browse/MTV-6046)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced standalone vSphere Deep Inspection workflows with lifecycle helpers for phase polling, conversion cancellation, DI snapshot discovery, and pod/snapshot cleanup waiting.
  * Deep Inspection conversion creation now supports omitting `vddkImage` to intentionally exercise validation behavior with standardized timeouts.
* **Tests**
  * Added standalone coverage for canceling an in-progress conversion and verifying cleanup/result re-run.
  * Added validation tests ensuring missing `vddkImage` triggers the expected critical condition.
  * Improved Deep Inspection test fixtures by pre-resolving the target VM and required inputs.
* **Bug Fixes**
  * Improved conversion completion/critical-condition detection for more accurate terminal outcomes and clearer failure details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->