### PR TITLE
fix: revert multus_network_name to use class_plan_config for VM lookups

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -42,6 +42,7 @@ from exceptions.exceptions import (
     RemoteClusterAndLocalCluterNamesError,
 )
 from utilities.copyoffload_constants import FORKLIFT_CONTROLLER_NAME
+from utilities.copyoffload_migration import apply_copyoffload_vm_name_override
 from libs.base_provider import BaseProvider
 from libs.forklift_inventory import (
     ForkliftInventory,
@@ -861,8 +862,11 @@ def multus_network_name(
     else:
         nad_namespace = target_namespace
 
-    vms = [vm["name"] for vm in class_plan_config["virtual_machines"]]
-    LOGGER.info(f"Found VMs from class plan config: {vms}")
+    virtual_machines = [dict(vm) for vm in class_plan_config["virtual_machines"]]
+    # Copy-offload configs use a placeholder VM name; the real name comes from .providers.json
+    apply_copyoffload_vm_name_override(virtual_machines=virtual_machines, source_provider=source_provider)
+    vms = [vm["name"] for vm in virtual_machines]
+    LOGGER.info(f"Found VMs for network lookup: {vms}")
 
     # Query networks using provider abstraction (handles templates vs VMs internally)
     networks = source_provider.get_vm_or_template_networks(names=vms, inventory=source_provider_inventory)
@@ -1035,13 +1039,7 @@ def prepared_plan(
         plan["_vm_target_namespace"] = target_namespace
 
     # Override VM names from provider config if specified
-    if hasattr(source_provider, "copyoffload_config") and source_provider.copyoffload_config:
-        default_vm_override = source_provider.copyoffload_config.get("default_vm_name")
-        if default_vm_override:
-            for vm in virtual_machines:
-                if vm.get("clone", False):  # Only override for cloned VMs
-                    LOGGER.info(f"Overriding VM name '{vm['name']}' with '{default_vm_override}' from provider config")
-                    vm["name"] = default_vm_override
+    apply_copyoffload_vm_name_override(virtual_machines=virtual_machines, source_provider=source_provider)
 
     if source_provider.type != Provider.ProviderType.OVA:
         openshift_source_provider: bool = source_provider.type == Provider.ProviderType.OPENSHIFT

--- a/conftest.py
+++ b/conftest.py
@@ -819,7 +819,6 @@ def multus_network_name(
     source_provider: BaseProvider,
     source_provider_inventory: ForkliftInventory,
     class_plan_config: dict[str, Any],
-    prepared_plan: dict[str, Any],
     request: pytest.FixtureRequest,
 ) -> dict[str, str]:
     """Create NADs based on network requirements with unique names per test class.
@@ -839,7 +838,6 @@ def multus_network_name(
         source_provider (BaseProvider): Source provider instance
         source_provider_inventory (ForkliftInventory): Source provider inventory
         class_plan_config (dict[str, Any]): Plan configuration from class parametrization
-        prepared_plan (dict[str, Any]): Prepared plan with cloned VM names
         request (pytest.FixtureRequest): Pytest fixture request
 
     Returns:
@@ -863,10 +861,8 @@ def multus_network_name(
     else:
         nad_namespace = target_namespace
 
-    # Get cloned VM names from prepared_plan (not original template names from class_plan_config)
-    # After cloning, prepared_plan has the actual VM names (e.g., auto-zzsx-xcopy-template-test-...)
-    vms = [vm["name"] for vm in prepared_plan["virtual_machines"]]
-    LOGGER.info(f"Found VMs from prepared plan: {vms}")
+    vms = [vm["name"] for vm in class_plan_config["virtual_machines"]]
+    LOGGER.info(f"Found VMs from class plan config: {vms}")
 
     # Query networks using provider abstraction (handles templates vs VMs internally)
     networks = source_provider.get_vm_or_template_networks(names=vms, inventory=source_provider_inventory)

--- a/utilities/copyoffload_migration.py
+++ b/utilities/copyoffload_migration.py
@@ -36,9 +36,11 @@ from utilities.mtv_migration import get_migration_for_plan, wait_for_migration_c
 from utilities.post_migration import get_ssh_credentials_from_provider_config
 from utilities.resources import create_and_store_resource
 
+from libs.base_provider import BaseProvider
+from libs.providers.vmware import VMWareProvider
+
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
-    from libs.providers.vmware import VMWareProvider
 
 LOGGER = get_logger(__name__)
 
@@ -51,6 +53,30 @@ PVC_NAME_LABEL = "pvcName"
 # Populate pod log caching constants
 _POPULATE_POD_LOGS_CACHE_KEY = "populate_pod_logs"
 _POPULATE_POD_NAME_PREFIX = "populate-"
+
+
+def apply_copyoffload_vm_name_override(
+    virtual_machines: list[dict[str, Any]],
+    source_provider: BaseProvider,
+) -> None:
+    """Override placeholder VM names with the real VM name from copy-offload config.
+
+    Copy-offload test configs use placeholder names (e.g., "xcopy-template-test") that
+    must be resolved to the real template name from the provider's copyoffload_config.
+
+    Args:
+        virtual_machines (list[dict[str, Any]]): List of VM config dicts to update in place.
+        source_provider (BaseProvider): Source provider that may have copyoffload_config.
+    """
+    if not isinstance(source_provider, VMWareProvider) or not source_provider.copyoffload_config:
+        return
+    default_vm_override = source_provider.copyoffload_config.get("default_vm_name")
+    if not default_vm_override:
+        return
+    for vm in virtual_machines:
+        if vm.get("clone", False):
+            LOGGER.info(f"Overriding VM name '{vm['name']}' with '{default_vm_override}' from provider config")
+            vm["name"] = default_vm_override
 
 
 class PopulatePodLogData(TypedDict):

--- a/utilities/copyoffload_migration.py
+++ b/utilities/copyoffload_migration.py
@@ -56,7 +56,7 @@ _POPULATE_POD_NAME_PREFIX = "populate-"
 
 
 def apply_copyoffload_vm_name_override(
-    virtual_machines: list[dict[str, Any]],
+    virtual_machines: list[dict[str, str | bool]],
     source_provider: BaseProvider,
 ) -> None:
     """Override placeholder VM names with the real VM name from copy-offload config.
@@ -65,7 +65,7 @@ def apply_copyoffload_vm_name_override(
     must be resolved to the real template name from the provider's copyoffload_config.
 
     Args:
-        virtual_machines (list[dict[str, Any]]): List of VM config dicts to update in place.
+        virtual_machines (list[dict[str, str | bool]]): List of VM config dicts to update in place.
         source_provider (BaseProvider): Source provider that may have copyoffload_config.
     """
     if not isinstance(source_provider, VMWareProvider) or not source_provider.copyoffload_config:


### PR DESCRIPTION
PR #583 changed the multus_network_name fixture to use prepared_plan
(cloned VM names) instead of class_plan_config (original template names)
for network lookups. This broke all RHV tests because RHV clones VMs
FROM templates — cloned VMs are VMs, not templates. The provider's
get_vm_or_template_networks() calls get_template_by_name(), which
searches the oVirt templates service and raises NotFoundError for
cloned VM names.

Reverting to class_plan_config is safe because cloned VMs always
inherit the source VM/template networks — no code path in the
codebase adds or modifies network assignments after cloning.

For copy-offload tests, the config uses a placeholder VM name
("xcopy-template-test") that gets overridden from .providers.json
at runtime. This override is now also applied in multus_network_name
via a shared helper to ensure the network lookup uses the real
VM name.

Also extracts the copy-offload VM name override logic into
apply_copyoffload_vm_name_override() to eliminate duplication
between multus_network_name and prepared_plan fixtures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network detection for VM-based test setups by deriving network lookup targets from the original class plan configuration rather than cloned VM names.
  * VM and template discovery now consistently respects copy-offload default naming, improving reliability for subsequent network lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->